### PR TITLE
private key encryption/serialization using a wallet

### DIFF
--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -104,30 +104,27 @@ export class Ciphertext {
   }
 
   // build Ciphertext from proto.Message
-  static fromDecoded(message: proto.Message): Ciphertext {
-    if (!message.payload) {
+  static fromDecoded(payload: proto.Payload): Ciphertext {
+    if (!payload) {
       throw new Error('missing message payload');
     }
-    if (!message.payload.aes256GcmHkdfSha256) {
+    if (!payload.aes256GcmHkdfSha256) {
       throw new Error('unrecognized message payload');
     }
-    const payload = message.payload.aes256GcmHkdfSha256;
-    return new Ciphertext(payload.payload, payload.hkdfSalt, payload.gcmNonce);
+    return new Ciphertext(
+      payload.aes256GcmHkdfSha256.payload,
+      payload.aes256GcmHkdfSha256.hkdfSalt,
+      payload.aes256GcmHkdfSha256.gcmNonce
+    );
   }
 
   // build proto.Message from Ciphertext and the parties' KeyBundles.
-  toBeEncoded(sender: KeyBundle, recipient: KeyBundle): proto.Message {
+  toBeEncoded(): proto.Payload {
     return {
-      header: {
-        sender: sender.toBeEncoded(),
-        recipient: recipient.toBeEncoded()
-      },
-      payload: {
-        aes256GcmHkdfSha256: {
-          payload: this.payload,
-          hkdfSalt: this.salt,
-          gcmNonce: this.nonce
-        }
+      aes256GcmHkdfSha256: {
+        payload: this.payload,
+        hkdfSalt: this.salt,
+        gcmNonce: this.nonce
       }
     };
   }
@@ -330,6 +327,21 @@ export class PrivateKey {
   matches(key: PublicKey): boolean {
     return this.getPublicKey().equals(key);
   }
+
+  toBeEncoded(): proto.PrivateKey {
+    return {
+      secp256k1: {
+        bytes: this.bytes
+      }
+    };
+  }
+
+  static fromDecoded(key: proto.PrivateKey): PrivateKey {
+    if (!key.secp256k1) {
+      throw new Error('unrecognized private key');
+    }
+    return new PrivateKey(key.secp256k1.bytes);
+  }
 }
 
 // Generates a new secp256k1 key pair.
@@ -447,8 +459,13 @@ export class PrivateKeyBundle {
   ): Promise<Uint8Array> {
     const bytes = new TextEncoder().encode(message);
     const ciphertext = await this.encrypt(bytes, recipient);
-    const toBeEncoded = ciphertext.toBeEncoded(this.getKeyBundle(), recipient);
-    return proto.Message.encode(toBeEncoded).finish();
+    return proto.Message.encode({
+      header: {
+        sender: this.getKeyBundle().toBeEncoded(),
+        recipient: recipient.toBeEncoded()
+      },
+      payload: ciphertext.toBeEncoded()
+    }).finish();
   }
 
   // deserialize and decrypt the message;
@@ -464,14 +481,59 @@ export class PrivateKeyBundle {
     if (!message.header.recipient) {
       throw new Error('missing message recipient');
     }
-    const ciphertext = Ciphertext.fromDecoded(message);
     const sender = KeyBundle.fromDecoded(message.header.sender);
     const recipient = KeyBundle.fromDecoded(message.header.recipient);
     if (!this.preKey.matches(recipient.preKey)) {
       throw new Error('recipient pre-key mismatch');
     }
+    if (!message.payload) {
+      throw new Error('missing message payload');
+    }
+    const ciphertext = Ciphertext.fromDecoded(message.payload);
     bytes = await this.decrypt(ciphertext, sender);
     return new TextDecoder().decode(bytes);
+  }
+
+  async encode(wallet: ethers.Signer): Promise<Uint8Array> {
+    // serialize the contents
+    const bytes = proto.PrivateKeyBundle.encode({
+      identityKey: this.identityKey.toBeEncoded(),
+      preKeys: [this.preKey.toBeEncoded()]
+    }).finish();
+    const wPreKey = getRandomValues(new Uint8Array(32));
+    const secret = hexToBytes(await wallet.signMessage(wPreKey));
+    const encrypted = await encrypt(bytes, secret);
+    return proto.EncryptedPrivateKeyBundle.encode({
+      walletPreKey: wPreKey,
+      payload: encrypted.toBeEncoded()
+    }).finish();
+  }
+
+  static async decode(
+    wallet: ethers.Signer,
+    bytes: Uint8Array
+  ): Promise<PrivateKeyBundle> {
+    const encrypted = proto.EncryptedPrivateKeyBundle.decode(bytes);
+    if (!encrypted.walletPreKey) {
+      throw new Error('missing wallet pre-key');
+    }
+    const secret = hexToBytes(await wallet.signMessage(encrypted.walletPreKey));
+    if (!encrypted.payload) {
+      throw new Error('missing bundle payload');
+    }
+    const ciphertext = Ciphertext.fromDecoded(encrypted.payload);
+    const decrypted = await decrypt(ciphertext, secret);
+    const bundle = proto.PrivateKeyBundle.decode(decrypted);
+    if (!bundle.identityKey) {
+      throw new Error('missing identity key');
+    }
+    if (bundle.preKeys.length === 0) {
+      throw new Error('missing pre-keys');
+    }
+    return new PrivateKeyBundle(
+      PrivateKey.fromDecoded(bundle.identityKey),
+      PrivateKey.fromDecoded(bundle.preKeys[0])
+    );
   }
 }
 
@@ -576,4 +638,15 @@ export function hexToBytes(s: string): Uint8Array {
     bytes[i] = Number.parseInt(s.slice(j, j + 2), 16);
   }
   return bytes;
+}
+export function equalBytes(b1: Uint8Array, b2: Uint8Array): boolean {
+  if (b1.length !== b2.length) {
+    return false;
+  }
+  for (let i = 0; i < b1.length; i++) {
+    if (b1[i] !== b2[i]) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/crypto/src/proto/message.proto
+++ b/packages/crypto/src/proto/message.proto
@@ -29,26 +29,39 @@ message PrivateKey {
     }
 }
 
-message Message {
-    message Participant {
-        PublicKey identityKey = 1;
-        PublicKey preKey = 2;
-    }
+message Payload {
     message AES256GCM_HKDFSHA256 {
         bytes hkdfSalt = 1;
         bytes gcmNonce = 2;
         bytes payload = 3;
     }
+    oneof union {
+        AES256GCM_HKDFSHA256 aes256GcmHkdfSha256 = 1;
+    }
+}
+
+message Message {
+    message Participant {
+        PublicKey identityKey = 1;
+        PublicKey preKey = 2;
+    }
     message Header {
         Participant sender = 1;
         Participant recipient = 2;
     }
-    message Payload {
-        oneof union {
-            AES256GCM_HKDFSHA256 aes256GcmHkdfSha256 = 2;
-        }
-    }
 
     Header header = 1;
+    Payload payload = 2;
+}
+
+// Private Key Storage
+
+message PrivateKeyBundle {
+    PrivateKey identityKey = 1;
+    repeated PrivateKey preKeys = 2;
+}
+
+message EncryptedPrivateKeyBundle {
+    bytes walletPreKey = 1;
     Payload payload = 2;
 }

--- a/packages/crypto/src/proto/message.ts
+++ b/packages/crypto/src/proto/message.ts
@@ -34,9 +34,19 @@ export interface PrivateKey_Secp256k1 {
   bytes: Uint8Array;
 }
 
+export interface Payload {
+  aes256GcmHkdfSha256: Payload_Aes256gcmHkdfsha256 | undefined;
+}
+
+export interface Payload_Aes256gcmHkdfsha256 {
+  hkdfSalt: Uint8Array;
+  gcmNonce: Uint8Array;
+  payload: Uint8Array;
+}
+
 export interface Message {
   header: Message_Header | undefined;
-  payload: Message_Payload | undefined;
+  payload: Payload | undefined;
 }
 
 export interface Message_Participant {
@@ -44,19 +54,19 @@ export interface Message_Participant {
   preKey: PublicKey | undefined;
 }
 
-export interface Message_Aes256gcmHkdfsha256 {
-  hkdfSalt: Uint8Array;
-  gcmNonce: Uint8Array;
-  payload: Uint8Array;
-}
-
 export interface Message_Header {
   sender: Message_Participant | undefined;
   recipient: Message_Participant | undefined;
 }
 
-export interface Message_Payload {
-  aes256GcmHkdfSha256: Message_Aes256gcmHkdfsha256 | undefined;
+export interface PrivateKeyBundle {
+  identityKey: PrivateKey | undefined;
+  preKeys: PrivateKey[];
+}
+
+export interface EncryptedPrivateKeyBundle {
+  walletPreKey: Uint8Array;
+  payload: Payload | undefined;
 }
 
 function createBaseSignature(): Signature {
@@ -479,6 +489,167 @@ export const PrivateKey_Secp256k1 = {
   }
 };
 
+function createBasePayload(): Payload {
+  return { aes256GcmHkdfSha256: undefined };
+}
+
+export const Payload = {
+  encode(
+    message: Payload,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.aes256GcmHkdfSha256 !== undefined) {
+      Payload_Aes256gcmHkdfsha256.encode(
+        message.aes256GcmHkdfSha256,
+        writer.uint32(10).fork()
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Payload {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePayload();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.aes256GcmHkdfSha256 = Payload_Aes256gcmHkdfsha256.decode(
+            reader,
+            reader.uint32()
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Payload {
+    return {
+      aes256GcmHkdfSha256: isSet(object.aes256GcmHkdfSha256)
+        ? Payload_Aes256gcmHkdfsha256.fromJSON(object.aes256GcmHkdfSha256)
+        : undefined
+    };
+  },
+
+  toJSON(message: Payload): unknown {
+    const obj: any = {};
+    message.aes256GcmHkdfSha256 !== undefined &&
+      (obj.aes256GcmHkdfSha256 = message.aes256GcmHkdfSha256
+        ? Payload_Aes256gcmHkdfsha256.toJSON(message.aes256GcmHkdfSha256)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Payload>, I>>(object: I): Payload {
+    const message = createBasePayload();
+    message.aes256GcmHkdfSha256 =
+      object.aes256GcmHkdfSha256 !== undefined &&
+      object.aes256GcmHkdfSha256 !== null
+        ? Payload_Aes256gcmHkdfsha256.fromPartial(object.aes256GcmHkdfSha256)
+        : undefined;
+    return message;
+  }
+};
+
+function createBasePayload_Aes256gcmHkdfsha256(): Payload_Aes256gcmHkdfsha256 {
+  return {
+    hkdfSalt: new Uint8Array(),
+    gcmNonce: new Uint8Array(),
+    payload: new Uint8Array()
+  };
+}
+
+export const Payload_Aes256gcmHkdfsha256 = {
+  encode(
+    message: Payload_Aes256gcmHkdfsha256,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.hkdfSalt.length !== 0) {
+      writer.uint32(10).bytes(message.hkdfSalt);
+    }
+    if (message.gcmNonce.length !== 0) {
+      writer.uint32(18).bytes(message.gcmNonce);
+    }
+    if (message.payload.length !== 0) {
+      writer.uint32(26).bytes(message.payload);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): Payload_Aes256gcmHkdfsha256 {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePayload_Aes256gcmHkdfsha256();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.hkdfSalt = reader.bytes();
+          break;
+        case 2:
+          message.gcmNonce = reader.bytes();
+          break;
+        case 3:
+          message.payload = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Payload_Aes256gcmHkdfsha256 {
+    return {
+      hkdfSalt: isSet(object.hkdfSalt)
+        ? bytesFromBase64(object.hkdfSalt)
+        : new Uint8Array(),
+      gcmNonce: isSet(object.gcmNonce)
+        ? bytesFromBase64(object.gcmNonce)
+        : new Uint8Array(),
+      payload: isSet(object.payload)
+        ? bytesFromBase64(object.payload)
+        : new Uint8Array()
+    };
+  },
+
+  toJSON(message: Payload_Aes256gcmHkdfsha256): unknown {
+    const obj: any = {};
+    message.hkdfSalt !== undefined &&
+      (obj.hkdfSalt = base64FromBytes(
+        message.hkdfSalt !== undefined ? message.hkdfSalt : new Uint8Array()
+      ));
+    message.gcmNonce !== undefined &&
+      (obj.gcmNonce = base64FromBytes(
+        message.gcmNonce !== undefined ? message.gcmNonce : new Uint8Array()
+      ));
+    message.payload !== undefined &&
+      (obj.payload = base64FromBytes(
+        message.payload !== undefined ? message.payload : new Uint8Array()
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Payload_Aes256gcmHkdfsha256>, I>>(
+    object: I
+  ): Payload_Aes256gcmHkdfsha256 {
+    const message = createBasePayload_Aes256gcmHkdfsha256();
+    message.hkdfSalt = object.hkdfSalt ?? new Uint8Array();
+    message.gcmNonce = object.gcmNonce ?? new Uint8Array();
+    message.payload = object.payload ?? new Uint8Array();
+    return message;
+  }
+};
+
 function createBaseMessage(): Message {
   return { header: undefined, payload: undefined };
 }
@@ -492,10 +663,7 @@ export const Message = {
       Message_Header.encode(message.header, writer.uint32(10).fork()).ldelim();
     }
     if (message.payload !== undefined) {
-      Message_Payload.encode(
-        message.payload,
-        writer.uint32(18).fork()
-      ).ldelim();
+      Payload.encode(message.payload, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
@@ -511,7 +679,7 @@ export const Message = {
           message.header = Message_Header.decode(reader, reader.uint32());
           break;
         case 2:
-          message.payload = Message_Payload.decode(reader, reader.uint32());
+          message.payload = Payload.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -527,7 +695,7 @@ export const Message = {
         ? Message_Header.fromJSON(object.header)
         : undefined,
       payload: isSet(object.payload)
-        ? Message_Payload.fromJSON(object.payload)
+        ? Payload.fromJSON(object.payload)
         : undefined
     };
   },
@@ -540,7 +708,7 @@ export const Message = {
         : undefined);
     message.payload !== undefined &&
       (obj.payload = message.payload
-        ? Message_Payload.toJSON(message.payload)
+        ? Payload.toJSON(message.payload)
         : undefined);
     return obj;
   },
@@ -553,7 +721,7 @@ export const Message = {
         : undefined;
     message.payload =
       object.payload !== undefined && object.payload !== null
-        ? Message_Payload.fromPartial(object.payload)
+        ? Payload.fromPartial(object.payload)
         : undefined;
     return message;
   }
@@ -634,100 +802,6 @@ export const Message_Participant = {
       object.preKey !== undefined && object.preKey !== null
         ? PublicKey.fromPartial(object.preKey)
         : undefined;
-    return message;
-  }
-};
-
-function createBaseMessage_Aes256gcmHkdfsha256(): Message_Aes256gcmHkdfsha256 {
-  return {
-    hkdfSalt: new Uint8Array(),
-    gcmNonce: new Uint8Array(),
-    payload: new Uint8Array()
-  };
-}
-
-export const Message_Aes256gcmHkdfsha256 = {
-  encode(
-    message: Message_Aes256gcmHkdfsha256,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.hkdfSalt.length !== 0) {
-      writer.uint32(10).bytes(message.hkdfSalt);
-    }
-    if (message.gcmNonce.length !== 0) {
-      writer.uint32(18).bytes(message.gcmNonce);
-    }
-    if (message.payload.length !== 0) {
-      writer.uint32(26).bytes(message.payload);
-    }
-    return writer;
-  },
-
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number
-  ): Message_Aes256gcmHkdfsha256 {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseMessage_Aes256gcmHkdfsha256();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.hkdfSalt = reader.bytes();
-          break;
-        case 2:
-          message.gcmNonce = reader.bytes();
-          break;
-        case 3:
-          message.payload = reader.bytes();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): Message_Aes256gcmHkdfsha256 {
-    return {
-      hkdfSalt: isSet(object.hkdfSalt)
-        ? bytesFromBase64(object.hkdfSalt)
-        : new Uint8Array(),
-      gcmNonce: isSet(object.gcmNonce)
-        ? bytesFromBase64(object.gcmNonce)
-        : new Uint8Array(),
-      payload: isSet(object.payload)
-        ? bytesFromBase64(object.payload)
-        : new Uint8Array()
-    };
-  },
-
-  toJSON(message: Message_Aes256gcmHkdfsha256): unknown {
-    const obj: any = {};
-    message.hkdfSalt !== undefined &&
-      (obj.hkdfSalt = base64FromBytes(
-        message.hkdfSalt !== undefined ? message.hkdfSalt : new Uint8Array()
-      ));
-    message.gcmNonce !== undefined &&
-      (obj.gcmNonce = base64FromBytes(
-        message.gcmNonce !== undefined ? message.gcmNonce : new Uint8Array()
-      ));
-    message.payload !== undefined &&
-      (obj.payload = base64FromBytes(
-        message.payload !== undefined ? message.payload : new Uint8Array()
-      ));
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<Message_Aes256gcmHkdfsha256>, I>>(
-    object: I
-  ): Message_Aes256gcmHkdfsha256 {
-    const message = createBaseMessage_Aes256gcmHkdfsha256();
-    message.hkdfSalt = object.hkdfSalt ?? new Uint8Array();
-    message.gcmNonce = object.gcmNonce ?? new Uint8Array();
-    message.payload = object.payload ?? new Uint8Array();
     return message;
   }
 };
@@ -820,36 +894,36 @@ export const Message_Header = {
   }
 };
 
-function createBaseMessage_Payload(): Message_Payload {
-  return { aes256GcmHkdfSha256: undefined };
+function createBasePrivateKeyBundle(): PrivateKeyBundle {
+  return { identityKey: undefined, preKeys: [] };
 }
 
-export const Message_Payload = {
+export const PrivateKeyBundle = {
   encode(
-    message: Message_Payload,
+    message: PrivateKeyBundle,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
-    if (message.aes256GcmHkdfSha256 !== undefined) {
-      Message_Aes256gcmHkdfsha256.encode(
-        message.aes256GcmHkdfSha256,
-        writer.uint32(18).fork()
-      ).ldelim();
+    if (message.identityKey !== undefined) {
+      PrivateKey.encode(message.identityKey, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.preKeys) {
+      PrivateKey.encode(v!, writer.uint32(18).fork()).ldelim();
     }
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): Message_Payload {
+  decode(input: _m0.Reader | Uint8Array, length?: number): PrivateKeyBundle {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseMessage_Payload();
+    const message = createBasePrivateKeyBundle();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
+        case 1:
+          message.identityKey = PrivateKey.decode(reader, reader.uint32());
+          break;
         case 2:
-          message.aes256GcmHkdfSha256 = Message_Aes256gcmHkdfsha256.decode(
-            reader,
-            reader.uint32()
-          );
+          message.preKeys.push(PrivateKey.decode(reader, reader.uint32()));
           break;
         default:
           reader.skipType(tag & 7);
@@ -859,31 +933,122 @@ export const Message_Payload = {
     return message;
   },
 
-  fromJSON(object: any): Message_Payload {
+  fromJSON(object: any): PrivateKeyBundle {
     return {
-      aes256GcmHkdfSha256: isSet(object.aes256GcmHkdfSha256)
-        ? Message_Aes256gcmHkdfsha256.fromJSON(object.aes256GcmHkdfSha256)
+      identityKey: isSet(object.identityKey)
+        ? PrivateKey.fromJSON(object.identityKey)
+        : undefined,
+      preKeys: Array.isArray(object?.preKeys)
+        ? object.preKeys.map((e: any) => PrivateKey.fromJSON(e))
+        : []
+    };
+  },
+
+  toJSON(message: PrivateKeyBundle): unknown {
+    const obj: any = {};
+    message.identityKey !== undefined &&
+      (obj.identityKey = message.identityKey
+        ? PrivateKey.toJSON(message.identityKey)
+        : undefined);
+    if (message.preKeys) {
+      obj.preKeys = message.preKeys.map(e =>
+        e ? PrivateKey.toJSON(e) : undefined
+      );
+    } else {
+      obj.preKeys = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PrivateKeyBundle>, I>>(
+    object: I
+  ): PrivateKeyBundle {
+    const message = createBasePrivateKeyBundle();
+    message.identityKey =
+      object.identityKey !== undefined && object.identityKey !== null
+        ? PrivateKey.fromPartial(object.identityKey)
+        : undefined;
+    message.preKeys = object.preKeys?.map(e => PrivateKey.fromPartial(e)) || [];
+    return message;
+  }
+};
+
+function createBaseEncryptedPrivateKeyBundle(): EncryptedPrivateKeyBundle {
+  return { walletPreKey: new Uint8Array(), payload: undefined };
+}
+
+export const EncryptedPrivateKeyBundle = {
+  encode(
+    message: EncryptedPrivateKeyBundle,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.walletPreKey.length !== 0) {
+      writer.uint32(10).bytes(message.walletPreKey);
+    }
+    if (message.payload !== undefined) {
+      Payload.encode(message.payload, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): EncryptedPrivateKeyBundle {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEncryptedPrivateKeyBundle();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.walletPreKey = reader.bytes();
+          break;
+        case 2:
+          message.payload = Payload.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): EncryptedPrivateKeyBundle {
+    return {
+      walletPreKey: isSet(object.walletPreKey)
+        ? bytesFromBase64(object.walletPreKey)
+        : new Uint8Array(),
+      payload: isSet(object.payload)
+        ? Payload.fromJSON(object.payload)
         : undefined
     };
   },
 
-  toJSON(message: Message_Payload): unknown {
+  toJSON(message: EncryptedPrivateKeyBundle): unknown {
     const obj: any = {};
-    message.aes256GcmHkdfSha256 !== undefined &&
-      (obj.aes256GcmHkdfSha256 = message.aes256GcmHkdfSha256
-        ? Message_Aes256gcmHkdfsha256.toJSON(message.aes256GcmHkdfSha256)
+    message.walletPreKey !== undefined &&
+      (obj.walletPreKey = base64FromBytes(
+        message.walletPreKey !== undefined
+          ? message.walletPreKey
+          : new Uint8Array()
+      ));
+    message.payload !== undefined &&
+      (obj.payload = message.payload
+        ? Payload.toJSON(message.payload)
         : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<Message_Payload>, I>>(
+  fromPartial<I extends Exact<DeepPartial<EncryptedPrivateKeyBundle>, I>>(
     object: I
-  ): Message_Payload {
-    const message = createBaseMessage_Payload();
-    message.aes256GcmHkdfSha256 =
-      object.aes256GcmHkdfSha256 !== undefined &&
-      object.aes256GcmHkdfSha256 !== null
-        ? Message_Aes256gcmHkdfsha256.fromPartial(object.aes256GcmHkdfSha256)
+  ): EncryptedPrivateKeyBundle {
+    const message = createBaseEncryptedPrivateKeyBundle();
+    message.walletPreKey = object.walletPreKey ?? new Uint8Array();
+    message.payload =
+      object.payload !== undefined && object.payload !== null
+        ? Payload.fromPartial(object.payload)
         : undefined;
     return message;
   }

--- a/packages/crypto/test/index.ts
+++ b/packages/crypto/test/index.ts
@@ -109,4 +109,17 @@ describe('Crypto', function () {
     const address = wPub.walletSignatureAddress();
     assert.equal(address, wallet.address);
   });
+  it('encrypts private key bundle for storage using a wallet', async function () {
+    // create a wallet using a generated key
+    const [wPri] = crypto.generateKeys();
+    const wallet = new ethers.Wallet(wPri.bytes);
+    // generate key bundle
+    const [pri] = await crypto.generateBundles();
+    // encrypt and serialize the bundle for storage
+    const bytes = await pri.encode(wallet);
+    // decrypt and decode the bundle from storage
+    const pri2 = await crypto.PrivateKeyBundle.decode(wallet, bytes);
+    assert.ok(crypto.equalBytes(pri.identityKey.bytes, pri2.identityKey.bytes));
+    assert.ok(crypto.equalBytes(pri.preKey.bytes, pri2.preKey.bytes));
+  });
 });


### PR DESCRIPTION
This is the other half of wallet interactions where we encrypt a private key bundle using a wallet in preparation for storage (and of course decryption for retrieval). I tried to boil it down to
* `aPrivateKeyBundle.encode(aWallet): Uint8Array` and
* `PrivateKeyBundle.decode(aWallet, aUint8Array): aPrivateKeyBundle`

The implementation uses the approach I outlined earlier:
* generate a random byte sequence of roughly a digest size, these should be random but don't need to be secret
* sign the random bytes with the wallet
* use the signature bytes as a secret for symmetric encryption key derivation
* run it through the same symmetric encryption scheme as we use for messages
* package up the random bytes from the first step with the encrypted bytes, this is what goes into the storage

The decryption/decoding goes as follows
* separate the random bytes from the encrypted bytes
* sign the random bytes using a wallet
* use the signature bytes as  a secret for symmetric encryption key derivation
* decrypt the bytes and decode the key bundle from the output 

The implementation made me disentangle the Ciphertext and Message, I promoted Payload to top level message and made it the counterpart of Ciphertext, that allows me to reuse Ciphertext/Payload for both message and key encryption.