### PR TITLE
Add lint and autolint commands to messaging/package

### DIFF
--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -15,6 +15,8 @@
     "build:esm": "BABEL_ENV=esm babel src --out-dir lib --out-file-extension .esm.js --extensions \".ts,.js\" --source-maps inline",
     "build:proto": "buf generate",
     "test": "mocha -r ts-node/register test/*.ts test/**/*.ts",
+    "lint": "prettier --check . && eslint .",
+    "autolint": "prettier --write . && eslint --fix .",
     "coverage": "nyc npm run test"
   },
   "keywords": [


### PR DESCRIPTION
So we can run `pnpm lint` and `pnpm lint` from `packages/messaging`: https://xmtp-inc.slack.com/archives/C02BABHFZG9/p1643063573050200