### PR TITLE
Send message to 2 topics; 1 for sender to consume and 1 for recipient to consume

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,13 +2,9 @@ export const buildContentTopic = (name: string): string =>
   `/xmtp/0/${name}/proto`
 
 export const buildDirectMessageTopic = (
-  sender: string,
-  recipient: string
-): string => {
-  const members = [sender, recipient]
-  members.sort()
-  return buildContentTopic(`dm-${members.join('-')}`)
-}
+  decoderWalletAddr: string,
+  encoderWalletAddr: string
+): string => buildContentTopic(`dm-${decoderWalletAddr}-${encoderWalletAddr}`)
 
 export const buildUserContactTopic = (walletAddr: string): string => {
   return buildContentTopic(`contact-${walletAddr}`)

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -17,8 +17,12 @@ describe('Messaging', function () {
     const msg1 = await Message.encode(
       alice,
       bob.getPublicKeyBundle(),
-      'Yo!',
-      new Date()
+      {
+        sender: alice.getPublicKeyBundle(),
+        recipient: bob.getPublicKeyBundle(),
+        timestamp: new Date().getTime(),
+      },
+      'Yo!'
     )
     assert.equal(msg1.senderAddress(), aliceWallet.address)
     assert.equal(msg1.decrypted, 'Yo!')

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,8 +1,23 @@
+import assert from 'assert'
 import { Wallet } from 'ethers'
 import { PrivateKey } from '../src'
+import { promiseWithTimeout } from '../src/utils'
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
+
+export const assertTimeout = async (
+  callback: () => Promise<void>,
+  timeoutMs: number
+): Promise<void> => {
+  let timeout = false
+  try {
+    await promiseWithTimeout<void>(timeoutMs, callback, 'timeout')
+  } catch (err) {
+    timeout = err instanceof Error && (err as Error).message === 'timeout'
+  }
+  assert.ok(timeout)
+}
 
 export async function waitFor<T>(
   callback: () => Promise<T>,


### PR DESCRIPTION
This surfaced as an issue while working on the example app. If we only send messages to 1 topic for both the sender and recipient to consume and present, then the sender will fail to decode/decrypt the messages that were encoded/encrypted for the recipient, by design, but this means that the sender isn't able to show their own sent messages in a DM/conversation. So this PR updates the strategy to send to 2 topics, 1 for the sender to consume from, encoded/encrypted for them, and 1 for the recipient to consume from, encoded/encrypted for them.

The client interface is definitely getting more complex with this change; any suggestions to help simplify it is appreciated 🙏 