### PR TITLE
Client startup steps and contact management

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,10 @@ export const buildUserContactTopic = (walletAddr: string): string => {
   return buildContentTopic(`contact-${walletAddr}`)
 }
 
+export const buildUserIntroTopic = (walletAddr: string): string => {
+  return buildContentTopic(`intro-${walletAddr}`)
+}
+
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
 


### PR DESCRIPTION
This PR makes the Client the central piece to use for sending/receiving messages and hides most of the details (including contact management) behind it. The creation now requires a wallet and automatically attempts to load keys from storage or creates and stores new ones. It currently always publishes the keys on startup.

The send and receive APIs now deal with wallet addresses not key bundles. The client keeps track of known contacts and key bundles discovered in the process of sending messages (not persisted so starts empty currently).