### PR TITLE
Support decoding messages by the sender as well

### DIFF
--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -5,13 +5,10 @@ import PublicKey from './PublicKey'
 // The PreKey must be signed by the IdentityKey.
 // The IdentityKey can be signed by the wallet to authenticate it.
 export default class PublicKeyBundle implements proto.PublicKeyBundle {
-  identityKey: PublicKey | undefined
-  preKey: PublicKey | undefined
+  identityKey: PublicKey
+  preKey: PublicKey
 
-  constructor(
-    identityKey: PublicKey | undefined,
-    preKey: PublicKey | undefined
-  ) {
+  constructor(identityKey: PublicKey, preKey: PublicKey) {
     if (!identityKey) {
       throw new Error('missing identity key')
     }

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -35,7 +35,12 @@ recipientPublic = PublicKeyBundle.fromBytes(bytes)
 
 // encrypting binary `payload` for submission to the network
 // @sender is sender's PrivateKeyBundle
-let secret = await sender.sharedSecret(recipientPublic)
+// @senderPublic is sender's PublicKeyBundle
+let secret = await sender.sharedSecret(
+  recipientPublic,
+  senderPublic.preKey,
+  false
+)
 let bytes = await encrypt(payload, secret)
 ```
 
@@ -50,12 +55,24 @@ If the message was tampered with or the key signatures don't check out, the deco
 // @recipientPublic is the key bundle used to encrypt the message (normally attached to the message)
 // @bytes is the encrypted message
 // @recipient is the recipient's PrivateKeyBundle
-// @sender is the sender's PublicKeyBundle (normally attached to the message)
-let secret = await recipient.sharedSecret(sender, recipientPublic.preKey)
+// @senderPublic is the sender's PublicKeyBundle (normally attached to the message)
+let secret = await recipient.sharedSecret(
+  senderPublic,
+  recipientPublic.preKey,
+  true
+)
 let payload = await decrypt(bytes, secret)
 
-// senders address can be derived from the key bundle
-let address = sender.walletSignatureAddress()
+// sender's address can be derived from the key bundle
+let address = senderPublic.walletSignatureAddress()
+
+// the sender can also decrypt the payload deriving the secret the same way as for encryption.
+let secret = await sender.sharedSecret(
+  recipientPublic,
+  senderPublic.preKey,
+  false
+)
+let payload = await decrypt(bytes, secret)
 ```
 
 ## Implementation Notes
@@ -74,8 +91,6 @@ Protobuf is used for serialization throughout. The protobuf message structure is
 
 # TODO
 
-- distinguish wallet signatures from direct signatures
-- add key timestamp
 - sanity checking to avoid common mistakes
 - wiping of sensitive material
 - decoded keys/messages have Buffers instead of Uint8Arrays; problem?

--- a/test/crypto/index.test.ts
+++ b/test/crypto/index.test.ts
@@ -80,14 +80,12 @@ describe('Crypto', function () {
     const msg1 = 'Yo!'
     const decrypted = new TextEncoder().encode(msg1)
     // Alice encrypts msg for Bob.
+    const alicePublic = alice.getPublicKeyBundle()
     const bobPublic = bob.getPublicKeyBundle()
-    let secret = await alice.sharedSecret(bobPublic)
+    let secret = await alice.sharedSecret(bobPublic, alicePublic.preKey, false)
     const encrypted = await encrypt(decrypted, secret)
     // Bob decrypts msg from Alice.
-    secret = await bob.sharedSecret(
-      alice.getPublicKeyBundle(),
-      bobPublic.preKey
-    )
+    secret = await bob.sharedSecret(alicePublic, bobPublic.preKey, true)
     const decrypted2 = await decrypt(encrypted, secret)
     const msg2 = new TextDecoder().decode(decrypted2)
     assert.equal(msg2, msg1)


### PR DESCRIPTION
This PR extends the Message.decode() logic to allow the sender to decode the message as well by looking at the attached sender and receiver bundles and figuring out which side is trying to decode. This required tweaking the PrivateKeyBundle.sharedSecret() function to add back the boolean indicator for the side and making the preKey non-optional because now both sides may need to use an older preKey. 