### PR TITLE
Wrap utils.getRandomValues in a function to be exported

### DIFF
--- a/src/crypto/utils.ts
+++ b/src/crypto/utils.ts
@@ -1,7 +1,9 @@
 import * as secp from '@noble/secp256k1'
 import { crypto } from './encryption'
 
-export const getRandomValues = crypto.getRandomValues
+export function getRandomValues<T extends ArrayBufferView | null>(array: T): T {
+  return crypto.getRandomValues(array)
+}
 
 export const bytesToHex = secp.utils.bytesToHex
 


### PR DESCRIPTION
I ran into a couple issues getting the chat app working with the latest xmtp-js; this is one of them, it's a weird one. I'm hitting this exception in the browser console consistently when the app calls `Client.create` (from `getRandomValues` in `PrivateKeyBundle.ts`):
```
Uncaught (in promise) TypeError: Illegal invocation
    at PrivateKeyBundle.eval (PrivateKeyBundle.js?0dec:165:50)
    at step (PrivateKeyBundle.js?0dec:32:1)
    at Object.eval [as next] (PrivateKeyBundle.js?0dec:13:46)
    at eval (PrivateKeyBundle.js?0dec:7:1)
    at new Promise (<anonymous>)
    at __awaiter (PrivateKeyBundle.js?0dec:3:1)
    at PrivateKeyBundle.encode (PrivateKeyBundle.js?0dec:149:1)
    at EncryptedStore.eval (EncryptedStore.js?14cc:93:1)
    at step (EncryptedStore.js?14cc:32:1)
    at Object.eval [as next] (EncryptedStore.js?14cc:13:46)
    at fulfilled (EncryptedStore.js?14cc:4:43)
```

I was poking around and thought that maybe it's the reference to `crypto` that was doing something illegal/misreferenced, and so tried having that line of code access `crypto.getRandomValues` directly, and it worked. ~I don't have a great explanation for why yet, curious if anybody else has any ideas.~ See comments for why.