### PR TITLE
Run tests against testnet in CI, but not in dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,3 @@ jobs:
           node-version-file: '.nvmrc'
       - run: npm install
       - run: npm test
-        env:
-          CI: 'true'


### PR DESCRIPTION
Only run tests against testnet if `CI` or `TESTNET` envs are set.