### PR TITLE
Version bump to 0.0.1-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xmtp/xmtp-js",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xmtp/xmtp-js",
-      "version": "0.0.1-alpha.3",
+      "version": "0.0.1-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/xmtp-js",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "description": "XMTP client SDK for interacting with XMTP networks.",
   "main": "dist/cjs/src/index.js",
   "module": "dist/esm/src/index.js",


### PR DESCRIPTION
And publish to npm when merged - for work on the chat app.

Currently rebased on top of https://github.com/xmtp/xmtp-js/pull/37, so this will wait until after it's merged.