### PR TITLE
Fix flakey Client.listMessages test

### DIFF
--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -141,13 +141,12 @@ describe('Client', () => {
                 const messages = address
                   ? await client.listConversationMessages(address)
                   : await client.listIntroductionMessages()
-                if (!messages.length) throw new Error('no messages')
+                assert.equal(messages.length, expected.length, name)
                 return messages
               },
               5000,
               500
             )
-            assert.equal(messages.length, expected.length, name)
             for (let i = 0; i < expected.length; i++) {
               assert.equal(
                 messages[i].decrypted,


### PR DESCRIPTION
This test started failing more often when it went from testing a single message to many, because the `waitFor` condition was to pass if `messages.length > 0` rather than when the expected number of messages have been persisted. So this PR updates it to wait for all of the messages.