### PR TITLE
Add Message.recipientAddress

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -37,6 +37,15 @@ export default class Message implements proto.Message {
     ).walletSignatureAddress()
   }
 
+  recipientAddress(): string | undefined {
+    if (!this.header?.recipient?.identityKey) {
+      return undefined
+    }
+    return new PublicKey(
+      this.header.recipient.identityKey
+    ).walletSignatureAddress()
+  }
+
   // encrypt and serialize the message
   static async encode(
     sender: PrivateKeyBundle,

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -11,7 +11,10 @@ describe('Messaging', function () {
     assert.ok(alice.identityKey)
     assert.deepEqual(alice.identityKey.publicKey, alicePub.identityKey)
     // Bob's key bundle
-    const bob = await PrivateKeyBundle.generate()
+    const bob = await PrivateKeyBundle.generate(newWallet())
+    const bobWalletAddress = bob
+      .getPublicKeyBundle()
+      .identityKey.walletSignatureAddress()
 
     // Alice encodes message for Bob
     const msg1 = await Message.encode(
@@ -21,11 +24,29 @@ describe('Messaging', function () {
       new Date()
     )
     assert.equal(msg1.senderAddress(), aliceWallet.address)
+    assert.equal(msg1.recipientAddress(), bobWalletAddress)
     assert.equal(msg1.decrypted, 'Yo!')
 
     // Bob decodes message from Alice
     const msg2 = await Message.decode(bob, msg1.toBytes())
     assert.equal(msg1.decrypted, msg2.decrypted)
     assert.equal(msg2.senderAddress(), aliceWallet.address)
+    assert.equal(msg2.recipientAddress(), bobWalletAddress)
+  })
+
+  it('senderAddress and recipientAddress throw errors without wallet', async () => {
+    const alice = await PrivateKeyBundle.generate()
+    const msg = await Message.encode(
+      alice,
+      alice.getPublicKeyBundle(),
+      'hi',
+      new Date()
+    )
+    expect(() => {
+      msg.senderAddress()
+    }).toThrow('key is not signed')
+    expect(() => {
+      msg.recipientAddress()
+    }).toThrow('key is not signed')
   })
 })


### PR DESCRIPTION
This allows for users of the client to determine the conversation peer address from introduction messages:
```ts
  const recipientAddress = msg.recipientAddress();
  const senderAddress = msg.senderAddress();
  if (!recipientAddress || !senderAddress) return;
  if (recipientAddress === walletAddress) {
    dispatchConversations([{ peerAddress: senderAddress }]);
  } else if (senderAddress == walletAddress) {
    dispatchConversations([{ peerAddress: recipientAddress }]);
  }
```

Helps fix 🐛 s https://github.com/xmtp-labs/eng/issues/33 and https://github.com/xmtp-labs/eng/issues/34 in the chat app.