### PR TITLE
Human friendly signature requests

### DIFF
--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert'
+import { PrivateKey, PrivateKeyBundle } from '../../src/crypto'
+import * as ethers from 'ethers'
+import { bytesToHex, getRandomValues, hexToBytes } from '../../src/crypto/utils'
+
+describe('Crypto', function () {
+  describe('PrivateKeyBundle', function () {
+    it('encrypts private key bundle for storage using a wallet', async function () {
+      // create a wallet using a generated key
+      const bobPri = PrivateKey.generate()
+      assert.ok(bobPri.secp256k1)
+      const wallet = new ethers.Wallet(bobPri.secp256k1.bytes)
+      // generate key bundle
+      const bob = await PrivateKeyBundle.generate(wallet)
+      // encrypt and serialize the bundle for storage
+      const bytes = await bob.encode(wallet)
+      // decrypt and decode the bundle from storage
+      const bobDecoded = await PrivateKeyBundle.decode(wallet, bytes)
+      assert.ok(bob.identityKey)
+      assert.ok(bobDecoded.identityKey)
+      assert.ok(bob.identityKey.publicKey.signature)
+      assert.ok(bobDecoded.identityKey.publicKey.signature)
+      assert.deepEqual(
+        bob.identityKey.publicKey.signature?.ecdsaCompact?.bytes,
+        bobDecoded.identityKey.publicKey.signature?.ecdsaCompact?.bytes
+      )
+      assert.ok(bob.identityKey.secp256k1)
+      assert.ok(bobDecoded.identityKey.secp256k1)
+      assert.deepEqual(
+        bob.identityKey.secp256k1.bytes,
+        bobDecoded.identityKey.secp256k1.bytes
+      )
+      assert.ok(bob.preKeys[0].secp256k1)
+      assert.ok(bobDecoded.preKeys[0].secp256k1)
+      assert.deepEqual(
+        bob.preKeys[0].secp256k1.bytes,
+        bobDecoded.preKeys[0].secp256k1.bytes
+      )
+    })
+
+    it('human-friendly storage signature request text', async function () {
+      const pri = PrivateKey.fromBytes(
+        hexToBytes(
+          '08aaa9dad3ed2f12220a206fd789a6ee2376bb6595b4ebace57c7a79e6e4f1f12c8416d611399eda6c74cb1a4c08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a'
+        )
+      )
+      assert.ok(pri.secp256k1)
+      const wallet = new ethers.Wallet(pri.secp256k1.bytes)
+      const bundle = await PrivateKeyBundle.generate(wallet)
+      const preKey = hexToBytes(
+        'f51bd1da9ec2239723ae2cf6a9f8d0ac37546b27e634002c653d23bacfcc67ad'
+      )
+      const actual = PrivateKeyBundle.storageSigRequestText(preKey)
+      const expected =
+        'XMTP : Enable Identity\nf51bd1da9ec2239723ae2cf6a9f8d0ac37546b27e634002c653d23bacfcc67ad\n\nFor more info: https://xmtp.org/signatures/'
+      assert.equal(actual, expected)
+      assert.ok(true)
+    })
+  })
+})

--- a/test/crypto/PublicKey.test.ts
+++ b/test/crypto/PublicKey.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert'
 import { PrivateKey, PublicKey, utils } from '../../src/crypto'
 import * as ethers from 'ethers'
+import { bytesToHex, hexToBytes } from '../../src/crypto/utils'
 
 describe('Crypto', function () {
   describe('PublicKey', function () {
@@ -17,6 +18,18 @@ describe('Crypto', function () {
       assert.equal(address, '0x0BED7ABd61247635c1973eB38474A2516eD1D884')
     })
 
+    it('human-friendly identity key signature request', async function () {
+      const alice = PrivateKey.fromBytes(
+        hexToBytes(
+          '08aaa9dad3ed2f12220a206fd789a6ee2376bb6595b4ebace57c7a79e6e4f1f12c8416d611399eda6c74cb1a4c08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a'
+        )
+      )
+      const actual = alice.publicKey.identitySigRequestText()
+      const expected =
+        'XMTP : Create Identity\n08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a\n\nFor more info: https://xmtp.org/signatures/'
+      assert.equal(actual, expected)
+    })
+
     it('signs keys using a wallet', async function () {
       // create a wallet using a generated key
       const alice = PrivateKey.generate()
@@ -26,6 +39,7 @@ describe('Crypto', function () {
       assert.ok(wallet.address, alice.publicKey.getEthereumAddress())
       // sign the public key using the wallet
       await alice.publicKey.signWithWallet(wallet)
+      assert.ok(alice.publicKey.signature)
       // validate the key signature and return wallet address
       const address = alice.publicKey.walletSignatureAddress()
       assert.equal(address, wallet.address)

--- a/test/crypto/index.test.ts
+++ b/test/crypto/index.test.ts
@@ -87,36 +87,4 @@ describe('Crypto', function () {
     assert.ok(pub2.preKey)
     assert.ok(pub2.identityKey.verifyKey(pub2.preKey))
   })
-  it('encrypts private key bundle for storage using a wallet', async function () {
-    // create a wallet using a generated key
-    const alice = PrivateKey.generate()
-    assert.ok(alice.secp256k1)
-    const wallet = new ethers.Wallet(alice.secp256k1.bytes)
-    // generate key bundle
-    const bob = await PrivateKeyBundle.generate(wallet)
-    // encrypt and serialize the bundle for storage
-    const bytes = await bob.encode(wallet)
-    // decrypt and decode the bundle from storage
-    const bobDecoded = await PrivateKeyBundle.decode(wallet, bytes)
-    assert.ok(bob.identityKey)
-    assert.ok(bobDecoded.identityKey)
-    assert.ok(bob.identityKey.publicKey.signature)
-    assert.ok(bobDecoded.identityKey.publicKey.signature)
-    assert.deepEqual(
-      bob.identityKey.publicKey.signature?.ecdsaCompact?.bytes,
-      bobDecoded.identityKey.publicKey.signature?.ecdsaCompact?.bytes
-    )
-    assert.ok(bob.identityKey.secp256k1)
-    assert.ok(bobDecoded.identityKey.secp256k1)
-    assert.deepEqual(
-      bob.identityKey.secp256k1.bytes,
-      bobDecoded.identityKey.secp256k1.bytes
-    )
-    assert.ok(bob.preKeys[0].secp256k1)
-    assert.ok(bobDecoded.preKeys[0].secp256k1)
-    assert.deepEqual(
-      bob.preKeys[0].secp256k1.bytes,
-      bobDecoded.preKeys[0].secp256k1.bytes
-    )
-  })
 })


### PR DESCRIPTION
This PR updates the signature request text to be more human-friendly for (1) signing new identity keys and (2) deriving key bundle encryption signature key for encoding/decoding.

xmtp-labs/core#144

![Screen Shot 2022-02-08 at 1 46 06 PM](https://user-images.githubusercontent.com/182290/153055022-c79a7652-b43a-4b35-9580-d0bb6740269f.png)
![Screen Shot 2022-02-08 at 1 46 15 PM](https://user-images.githubusercontent.com/182290/153055030-4ff61b62-3cca-4d13-9b79-c08d5b0f7749.png)

