### PR TITLE
Use pinst to disable postinstall on published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "husky": "^7.0.4",
         "jest": "^27.2.0",
         "node-localstorage": "^2.2.1",
+        "pinst": "^2.1.6",
         "prettier": "^2.4.0",
         "semantic-release": "^19.0.2",
         "ts-jest": "^27.0.5",
@@ -12435,6 +12436,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/pinst": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
+      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
+      "dev": true,
+      "dependencies": {
+        "fromentries": "^1.3.2"
+      },
+      "bin": {
+        "pinst": "bin.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -24524,6 +24540,15 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
+    },
+    "pinst": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
+      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.3.2"
+      }
     },
     "pirates": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
   "types": "dist/types/src/index.d.js",
   "scripts": {
     "postinstall": "husky install",
+    "prepublishOnly": "pinst --disable",
+    "postpublish": "pinst --enable",
     "build": "npm run build:proto && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:types",
     "build:proto": "npm run clean:proto && buf generate",
     "build:cjs": "node tools/cleanup cjs && tsc -p config/tsconfig.cjs.json",
@@ -77,6 +79,7 @@
     "husky": "^7.0.4",
     "jest": "^27.2.0",
     "node-localstorage": "^2.2.1",
+    "pinst": "^2.1.6",
     "prettier": "^2.4.0",
     "semantic-release": "^19.0.2",
     "ts-jest": "^27.0.5",


### PR DESCRIPTION
Currently if you try to `npm install @xmtp/xmtp-js@1.0.0` you run into this error:
```
sh: husky: command not found
```

Which is from the `"postinstall": "husky install"` in `package.json`, but was missing the `pinst` configuration to disable this for published packages. This issue didn't surface when testing via `npm install file:../xmtp-js`.

So this PR fixes that.

Follow-up on https://github.com/xmtp/xmtp-js/pull/53 addressing https://github.com/xmtp-labs/core/issues/148.