### PR TITLE
fix: npm run build in prepublishOnly hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/types/src/index.d.js",
   "scripts": {
     "postinstall": "husky install",
-    "prepublishOnly": "pinst --disable",
+    "prepublishOnly": "pinst --disable && npm run build",
     "postpublish": "pinst --enable",
     "build": "npm run build:proto && npm run build:cjs && npm run build:esm && npm run build:umd && npm run build:types",
     "build:proto": "npm run clean:proto && buf generate",


### PR DESCRIPTION
Another follow-up on https://github.com/xmtp/xmtp-js/pull/53 for https://github.com/xmtp-labs/core/issues/148 - the build output wasn't being included in the published package.