### PR TITLE
Add buf-setup-action to GH release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
+      - name: Setup buf build
+        uses: bufbuild/buf-setup-action@v0.6.0
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
Another follow-up on https://github.com/xmtp/xmtp-js/pull/53 for https://github.com/xmtp-labs/core/issues/148 - this PR makes `buf` available in the GH release job for the build.