### PR TITLE
Update date and domain in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 XMTP Labs (xmtp.org)
+Copyright (c) 2022 XMTP Labs (xmtp.com)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates the date to 2022 in the LICENSE and change domain from xmtp.org to xmtp.com (is that right?).

Also just wanted to get some 👀  on the LICENSE in general.