### PR TITLE
Lint commit messages in GH job

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint Code
 on:
   push:
     branches:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,0 +1,11 @@
+name: Lint Commits
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4


### PR DESCRIPTION
Add a CI check for linting commit messages, similar to the check in the husky pre-commit hook.