### PR TITLE
Add ability to check addresses prior to sending a message

### DIFF
--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -47,9 +47,9 @@ describe('Client', () => {
 
       it('user contacts published', async () => {
         await sleep(10)
-        const alicePublic = await alice.getUserContact(alice.address)
+        const alicePublic = await alice.getUserContactFromNetwork(alice.address)
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
-        const bobPublic = await bob.getUserContact(bob.address)
+        const bobPublic = await bob.getUserContactFromNetwork(bob.address)
         assert.deepEqual(bob.keys.getPublicKeyBundle(), bobPublic)
       })
 


### PR DESCRIPTION

## Which problem does this solve?
Clients have no ability to check if an address is on the network without sending a message and catching an error. 

## Changes
This PR adds a method `canMessage` to `Client` which checks for the existence of a `PublicKeyBundle` on the network.  


[xmtp-labs/208](https://github.com/xmtp-labs/hq/issues/208)