### PR TITLE
docs: workaround for polyfill removal in webpack5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The XMTP protocol is in the early stages of development. This pre-stable alpha l
 
 This library is not yet published as an NPM module. It can be installed from this repo using `npm install xmtp/xmtp-js`.
 
-Additional configuration is required in React environments due to the removal of polyfills from Webpack 5. 
+Additional configuration is required in React environments due to the removal of polyfills from Webpack 5.
 
 ### Create React App
 


### PR DESCRIPTION
Changes:
- README.md: adds context and workaround for the webpack error encountered in #77 