### PR TITLE
docs: npm token install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ The XMTP protocol is in the early stages of development. This pre-stable alpha l
 
 ## Installation
 
-This library is not yet public on npm. It can be installed from this repo using `npm install xmtp/xmtp-js` or from npm using a private access token:
+This library is not yet public on npm. It can be installed from this repo to your project directory using `npm install xmtp/xmtp-js`, or from npm using a private access token:
 
 ```bash
+# In your project directory
+
 export NPM_TOKEN=$YOUR_NPM_TOKEN
 echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
 npm install @xmtp/xmtp-js


### PR DESCRIPTION
## Contents
- Updates README.md with instructions for `npm` private access token install method.