### PR TITLE
Version Message Proto

### DIFF
--- a/src/proto/messaging.proto
+++ b/src/proto/messaging.proto
@@ -54,9 +54,15 @@ message MessageHeader {
   uint64 timestamp = 3;
 }
 
-message Message {
+message V1Message {
     bytes headerBytes = 1; // encapsulates the encoded MessageHeader
     Ciphertext ciphertext = 2;
+}
+
+message Message {
+  oneof version {
+    V1Message v1 = 1;
+  }
 }
 
 // Private Key Storage


### PR DESCRIPTION
## Summary
Versions the message body to allow for future backwards-incompatible changes. For more info, see here: https://github.com/xmtp-labs/hq/pull/327

I took the "path-of-least-resistance" approach here, and just made the existing messaging class only compatible with V1 messages. Once we have multiple versions we need to support, we will probably want to refactor this a bit to have a wrapper class that supports multiple versions.

## Note
This will make all messages sent by previous versions of the SDK unreadable, and will make messages sent with this version of the SDK unreadable to previous versions.

