### PR TITLE
Pin xmtp node go to a version that doesn't use postgres

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   waku-node:
-    image: xmtp/node-go:latest
+    image: xmtp/node-go@sha256:489f72a4049272989b42032f6fe23aac91cfaf13c93605017d4dce93d21f4993
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
     command:


### PR DESCRIPTION
## Summary
The `latest` tag of `xmtp-node-go` has diverged from what we are running on testnet. This locks to an older version which matches testnet. Once we move everything over to AWS, we will update the local dev setup to include a Postgres instance and can go back to pointing to latest.

This issue was causing our tests to fail, since the tests automatically pull down the `latest` docker image which was failing to start.