### PR TITLE
fix: update to use postgres for test

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,12 +1,22 @@
 services:
   waku-node:
-    image: xmtp/node-go@sha256:489f72a4049272989b42032f6fe23aac91cfaf13c93605017d4dce93d21f4993
+    image: xmtp/node-go:latest
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
     command:
       - --ws
       - --store
+      - --message-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --lightpush
       - --ws-port=9001
+      - --wait-for-db=30s
     ports:
       - 9001:9001
+    depends_on:
+      - db
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: xmtp
+    ports:
+      - 5432:5432

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -18,4 +18,3 @@ services:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: xmtp
-

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -18,5 +18,4 @@ services:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: xmtp
-    ports:
-      - 5432:5432
+

--- a/src/store/PrivateTopicStore.ts
+++ b/src/store/PrivateTopicStore.ts
@@ -28,7 +28,7 @@ export default class NetworkStore implements Store {
 
   async set(key: string, value: Buffer): Promise<void> {
     const keys = Uint8Array.from(value)
-    await this.waku.relay.send(
+    await this.waku.lightPush.push(
       await WakuMessage.fromBytes(keys, this.buildTopic(key))
     )
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,7 @@ export async function publishUserContact(
   keys: PublicKeyBundle,
   address: string
 ): Promise<void> {
-  return waku.relay.send(
+  await waku.lightPush.push(
     await WakuMessage.fromBytes(keys.toBytes(), buildUserContactTopic(address))
   )
 }

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -17,6 +17,7 @@ describe('conversations', () => {
   beforeEach(async () => {
     alice = await Client.create(Wallet.createRandom(), opts)
     bob = await Client.create(Wallet.createRandom(), opts)
+    await sleep(100)
   })
 
   afterEach(async () => {

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -56,6 +56,7 @@ describe('PrivateTopicStore', () => {
         expect(empty).toBeNull()
 
         await store.set(key, Buffer.from(value))
+        await sleep(100)
         const full = await store.get(key)
 
         expect(full).toBeDefined()


### PR DESCRIPTION
Switch to use latest node-go and consequently the postgres message store.

The change highlighted some flakiness in our tests, presumably due to higher latencies to the now external DB. Switching to lightpush from relay for sending contacts and private keys to the network improved it, although I still see some flakiness locally. Presumably because the lightpush confirmation doesn't necessarily mean that the message has actually reached the store.

# Questions

1. Do we want to use lightpush instead of relay for these?
2. If yes, do we want to check the lightpush response and throw in some cases?
3. Do we want to further fortify the tests against flakiness? I've seen mostly the Conversations tests flaking out [with "Address X is not on the network"](https://github.com/xmtp/xmtp-js/blob/main/src/conversations/Conversations.ts#L89) presumably because they were too fast grabbing the contact info 