### PR TITLE
Update js-waku

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@stardazed/streams-polyfill": "^2.4.0",
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
-        "js-waku": "^0.18",
+        "js-waku": "^0.22.0",
         "protobufjs": "^6.11.2"
       },
       "devDependencies": {
@@ -4701,15 +4701,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "node_modules/ecies-geth": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ecies-geth/-/ecies-geth-1.6.3.tgz",
-      "integrity": "sha512-RAZs5p0MZLGWXt3weAHjefnWzJwTDvMw8GizSHhPNM8HkGDkRnOjbJtN613BD+/EOPaTP5j7bwwd83WhJq+5Ew==",
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "secp256k1": "^4.0.3"
-      }
-    },
     "node_modules/electron-fetch": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
@@ -8012,28 +8003,27 @@
       "dev": true
     },
     "node_modules/js-waku": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.18.0.tgz",
-      "integrity": "sha512-ooqSnDTZqodWFS6RKtqwTKD5pGZ3VG5AWBTD2Gt7iLdTJxTRE1JHUKm3IQmU8lXq6QEBtdisN76Vl9syDir9wg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.22.0.tgz",
+      "integrity": "sha512-4aMOJI6HKSaJ4eLfanbD1CDifwUgCPfcIDnIrt96SJA5A3nf9VXFZUmR1huwv07JithmkP9orXNGb6u8KdGcrg==",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^5.0.0",
         "@ethersproject/rlp": "^5.5.0",
+        "@noble/secp256k1": "^1.3.4",
         "debug": "^4.3.1",
         "dns-query": "^0.8.0",
-        "ecies-geth": "^1.5.2",
         "hi-base32": "^0.5.1",
         "it-concat": "^2.0.0",
         "it-length-prefixed": "^5.0.2",
         "js-sha3": "^0.8.0",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
-        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-gossipsub": "0.13.0",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
         "multiaddr": "^10.0.1",
         "multihashes": "^4.0.3",
         "protobufjs": "^6.8.8",
-        "secp256k1": "^4.0.2",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -9082,11 +9072,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -9112,16 +9097,6 @@
       "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
       "engines": {
         "node": ">= 6.13.0"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -12979,20 +12954,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
-    "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/semantic-release": {
       "version": "19.0.2",
@@ -18508,15 +18469,6 @@
         }
       }
     },
-    "ecies-geth": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ecies-geth/-/ecies-geth-1.6.3.tgz",
-      "integrity": "sha512-RAZs5p0MZLGWXt3weAHjefnWzJwTDvMw8GizSHhPNM8HkGDkRnOjbJtN613BD+/EOPaTP5j7bwwd83WhJq+5Ew==",
-      "requires": {
-        "elliptic": "^6.5.4",
-        "secp256k1": "^4.0.3"
-      }
-    },
     "electron-fetch": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.4.tgz",
@@ -21048,28 +21000,27 @@
       "dev": true
     },
     "js-waku": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.18.0.tgz",
-      "integrity": "sha512-ooqSnDTZqodWFS6RKtqwTKD5pGZ3VG5AWBTD2Gt7iLdTJxTRE1JHUKm3IQmU8lXq6QEBtdisN76Vl9syDir9wg==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.22.0.tgz",
+      "integrity": "sha512-4aMOJI6HKSaJ4eLfanbD1CDifwUgCPfcIDnIrt96SJA5A3nf9VXFZUmR1huwv07JithmkP9orXNGb6u8KdGcrg==",
       "requires": {
         "@chainsafe/libp2p-noise": "^5.0.0",
         "@ethersproject/rlp": "^5.5.0",
+        "@noble/secp256k1": "^1.3.4",
         "debug": "^4.3.1",
         "dns-query": "^0.8.0",
-        "ecies-geth": "^1.5.2",
         "hi-base32": "^0.5.1",
         "it-concat": "^2.0.0",
         "it-length-prefixed": "^5.0.2",
         "js-sha3": "^0.8.0",
         "libp2p": "^0.36.2",
         "libp2p-bootstrap": "^0.14.0",
-        "libp2p-gossipsub": "^0.13.0",
+        "libp2p-gossipsub": "0.13.0",
         "libp2p-mplex": "^0.10.4",
         "libp2p-websockets": "^0.16.1",
         "multiaddr": "^10.0.1",
         "multihashes": "^4.0.3",
         "protobufjs": "^6.8.8",
-        "secp256k1": "^4.0.2",
         "uuid": "^8.3.2"
       }
     },
@@ -21918,11 +21869,6 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
     },
-    "node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
     "node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -21941,11 +21887,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
       "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
-    },
-    "node-gyp-build": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
-      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -24699,16 +24640,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
-    "secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
-      "requires": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
     },
     "semantic-release": {
       "version": "19.0.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@stardazed/streams-polyfill": "^2.4.0",
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
-    "js-waku": "^0.18",
+    "js-waku": "^0.22.0",
     "protobufjs": "^6.11.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
`js-waku` has fixed the issue that was breaking Webpack support that was introduced in version 0.19, making it safe for us to upgrade.