### PR TITLE
fix: setup for tests against node running on localhost

### DIFF
--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -4,6 +4,7 @@ import {
   newWallet,
   dumpStream,
   newLocalDockerClient,
+  newLocalHostClient,
   newDevClient,
 } from './helpers'
 import { publishUserContact, sleep } from '../src/utils'
@@ -20,12 +21,19 @@ import {
 } from '../src'
 
 describe('Client', () => {
-  const tests = [
-    {
+  const tests = []
+  if (process.env.LOCAL_NODE) {
+    tests.push({
+      name: 'local host node',
+      newClient: newLocalHostClient,
+    })
+  } else {
+    tests.push({
       name: 'local docker node',
       newClient: newLocalDockerClient,
-    },
-  ]
+    })
+  }
+
   if (process.env.CI || process.env.TESTNET) {
     tests.push({
       name: 'dev',

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -13,6 +13,9 @@ import { promiseWithTimeout } from '../src/utils'
 const LOCAL_DOCKER_MULTIADDR =
   '/ip4/127.0.0.1/tcp/9001/ws/p2p/16Uiu2HAmNCxLZCkXNbpVPBpSSnHj9iq4HZQj7fxRzw2kj1kKSHHA'
 
+const LOCAL_HOST_MULTIADDR =
+  '/ip4/127.0.0.1/tcp/9002/ws/p2p/16Uiu2HAmNCxLZCkXNbpVPBpSSnHj9iq4HZQj7fxRzw2kj1kKSHHA'
+
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -94,10 +97,20 @@ export class CodecRegistry {
   }
 }
 
+// client running against local docker node,
+// see dev/docker-compose
 export const newLocalDockerClient = (): Promise<Client> =>
   Client.create(newWallet(), {
     bootstrapAddrs: [LOCAL_DOCKER_MULTIADDR],
   })
 
+// client running against local node running on the host,
+// see github.com/xmtp/xmtp-node-go/xmtp-js.sh
+export const newLocalHostClient = (): Promise<Client> =>
+  Client.create(newWallet(), {
+    bootstrapAddrs: [LOCAL_HOST_MULTIADDR],
+  })
+
+// client running against the dev cluster in AWS
 export const newDevClient = (): Promise<Client> =>
   Client.create(newWallet(), { env: 'dev' })


### PR DESCRIPTION
This is a companion change to https://github.com/xmtp/xmtp-node-go/pull/28. This allows me to run the xmtp-js tests against a node running on localhost directly.

This made it easier to iterate on my metrics changes, I don't have to build a docker image to push to the local docker setup (and I didn't have to add prometheus to the docker-compose setup we have here).