### PR TITLE
fix: add production env support

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -34,8 +34,8 @@ const NODES_LIST_URL = 'https://nodes.xmtp.com/'
 type Nodes = { [k: string]: string }
 
 type NodesList = {
-  testnet: Nodes
   dev: Nodes
+  production: Nodes
 }
 
 // Default maximum allowed content size

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -15,7 +15,7 @@ const newLocalDockerWaku = (): Promise<Waku> =>
   )
 
 const newTestnetWaku = (): Promise<Waku> =>
-  createWaku(defaultOptions({ env: 'testnet' }))
+  createWaku(defaultOptions({ env: 'dev' }))
 
 describe('PrivateTopicStore', () => {
   jest.setTimeout(10000)
@@ -27,7 +27,7 @@ describe('PrivateTopicStore', () => {
   ]
   if (process.env.CI || process.env.TESTNET) {
     tests.push({
-      name: 'testnet',
+      name: 'dev',
       newWaku: newTestnetWaku,
     })
   }


### PR DESCRIPTION
## Summary
- Adds support for the `production` env in the fleets file
- Removes support for the `testnet` environment, which has been shut down

## Will handle separately
- Update documentation explaining the difference between the two envs