### PR TITLE
Disable relay listener by default with option to enable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
         "js-waku": "^0.24.0",
-        "protobufjs": ">=6.11.3"
+        "protobufjs": "^6.11.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -75,6 +75,9 @@ type NetworkOptions = {
    * to declare the startup as successful or failed
    */
   waitForPeersTimeoutMs: number
+
+  // Enable the relay listener. Defaults to disabled.
+  enableRelayListener?: boolean
 }
 
 type ContentOptions = {
@@ -109,6 +112,7 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
     waitForPeersTimeoutMs: 10000,
     codecs: [new TextCodec()],
     maxContentSize: MaxContentSize,
+    enableRelayListener: false,
   }
   if (opts?.codecs) {
     opts.codecs = _defaultOptions.codecs.concat(opts.codecs)
@@ -475,6 +479,7 @@ export async function createWaku({
   bootstrapAddrs,
   env,
   waitForPeersTimeoutMs,
+  enableRelayListener,
 }: NetworkOptions): Promise<Waku> {
   const bootstrap: BootstrapOptions = bootstrapAddrs?.length
     ? {
@@ -494,6 +499,9 @@ export async function createWaku({
     },
     bootstrap,
   })
+  if (!enableRelayListener) {
+    waku.relay.removeAllListeners()
+  }
 
   // Wait for peer connection.
   try {


### PR DESCRIPTION
This PR adds support for a flag that disables/removes the waku relay listeners, specifically [this one](https://github.com/status-im/js-waku/blob/master/src/lib/waku_relay/index.ts#L216 ). In our case we want the flag to disable by default, so it's an enable/opt-in flag - since our use at this level is exclusively the filter interface.