### PR TITLE
Add language to code fencing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Installation
 
-```
+```bash
 npm install @xmtp/xmtp-js
 ```
 


### PR DESCRIPTION
I'm working on a way to single-source this repo's `README.md` and display it in the XMTP docs. 

The doc build process includes a markdown linter that requires a language for code fencing. 

The doc build is failing because the README.md is missing the language for one instance of code fencing.

I've added the language to resolve the doc build error so that I can proceed with my single-sourcing task.