### PR TITLE
Jazzz/bundle version prep

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -25,6 +25,7 @@ import {
 import { decompress, compress } from './Compression'
 import { Compression } from './proto/messaging'
 import * as proto from './proto/messaging'
+import ContactBundle from './ContactBundle'
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -195,10 +196,12 @@ export default class Client {
       callback: (msgs: WakuMessage[]) => {
         for (const msg of msgs) {
           if (!msg.payload) continue
-          const bundle = PublicKeyBundle.fromBytes(msg.payload as Uint8Array)
-          const address = bundle.walletSignatureAddress()
+          const bundle = ContactBundle.fromBytes(msg.payload as Uint8Array)
+          const keyBundle = bundle.keyBundle
+
+          const address = keyBundle?.walletSignatureAddress()
           if (address === peerAddress) {
-            recipientKey = bundle
+            recipientKey = keyBundle
             break
           }
         }

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -1,0 +1,39 @@
+import * as proto from '../src/proto/messaging'
+import { PublicKeyBundle } from './crypto'
+import PublicKey from './crypto/PublicKey'
+
+// ContactBundle packages all the infromation which a client uses to advertise on the network.
+export default class ContactBundle implements proto.ContactBundleV1 {
+  keyBundle: PublicKeyBundle
+
+  constructor(publicKeyBundle: PublicKeyBundle) {
+    if (!publicKeyBundle) {
+      throw new Error('missing keyBundle')
+    }
+    this.keyBundle = publicKeyBundle
+  }
+
+  toBytes(): Uint8Array {
+    return proto.ContactBundle.encode({
+      v1: {
+        keyBundle: this.keyBundle,
+      },
+    }).finish()
+  }
+
+  static fromBytes(bytes: Uint8Array): ContactBundle {
+    const decoded = proto.ContactBundle.decode(bytes)
+    if (!decoded.v1?.keyBundle?.identityKey) {
+      throw new Error('missing keyBundle')
+    }
+    if (!decoded.v1?.keyBundle?.preKey) {
+      throw new Error('missing pre-key')
+    }
+    return new ContactBundle(
+      new PublicKeyBundle(
+        new PublicKey(decoded.v1?.keyBundle?.identityKey),
+        new PublicKey(decoded.v1?.keyBundle?.preKey)
+      )
+    )
+  }
+}

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -14,10 +14,8 @@ export default class ContactBundle implements proto.ContactBundleV1 {
   }
 
   toBytes(): Uint8Array {
-    return proto.ContactBundle.encode({
-      v1: {
-        keyBundle: this.keyBundle,
-      },
+    return proto.ContactBundleV1.encode({
+      keyBundle: this.keyBundle,
     }).finish()
   }
 
@@ -47,7 +45,10 @@ export default class ContactBundle implements proto.ContactBundleV1 {
       const b = proto.ContactBundle.decode(bytes)
       return b.v1?.keyBundle
     } catch (e) {
-      if (e instanceof Error && e.message.startsWith('invalid wire type')) {
+      if (
+        e instanceof RangeError ||
+        (e instanceof Error && e.message.startsWith('invalid wire type'))
+      ) {
         // Adds a default fallback for older versions of the proto
         const legacyBundle = proto.ContactBundleV1.decode(bytes)
         return legacyBundle.keyBundle

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -22,18 +22,37 @@ export default class ContactBundle implements proto.ContactBundleV1 {
   }
 
   static fromBytes(bytes: Uint8Array): ContactBundle {
-    const decoded = proto.ContactBundle.decode(bytes)
-    if (!decoded.v1?.keyBundle?.identityKey) {
+    const bundle = this.decodeV1(bytes)
+
+    if (!bundle) {
+      throw new Error('could not parse bundle')
+    }
+
+    if (!bundle.identityKey) {
       throw new Error('missing keyBundle')
     }
-    if (!decoded.v1?.keyBundle?.preKey) {
+    if (!bundle.preKey) {
       throw new Error('missing pre-key')
     }
     return new ContactBundle(
       new PublicKeyBundle(
-        new PublicKey(decoded.v1?.keyBundle?.identityKey),
-        new PublicKey(decoded.v1?.keyBundle?.preKey)
+        new PublicKey(bundle.identityKey),
+        new PublicKey(bundle.preKey)
       )
     )
+  }
+
+  static decodeV1(bytes: Uint8Array): proto.PublicKeyBundle | undefined {
+    try {
+      const b = proto.ContactBundle.decode(bytes)
+      return b.v1?.keyBundle
+    } catch (e) {
+      if (e instanceof Error && e.message.startsWith('invalid wire type')) {
+        // Adds a default fallback for older versions of the proto
+        const legacyBundle = proto.ContactBundleV1.decode(bytes)
+        return legacyBundle.keyBundle
+      }
+      throw new Error("Couldn't decode contact bundle:" + e)
+    }
   }
 }

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -11,7 +11,7 @@ import { NoMatchingPreKeyError } from './errors'
 // PrivateKeyBundle bundles the private keys corresponding to a PublicKeyBundle for convenience.
 // This bundle must not be shared with anyone, although will have to be persisted
 // somehow so that older messages can be decrypted again.
-export default class PrivateKeyBundle implements proto.PrivateKeyBundle {
+export default class PrivateKeyBundle implements proto.PrivateKeyBundleV1 {
   identityKey: PrivateKey
   preKeys: PrivateKey[]
 
@@ -121,8 +121,10 @@ export default class PrivateKeyBundle implements proto.PrivateKeyBundle {
       throw new Error('missing identity key')
     }
     const bytes = proto.PrivateKeyBundle.encode({
-      identityKey: this.identityKey,
-      preKeys: this.preKeys,
+      v1: {
+        identityKey: this.identityKey,
+        preKeys: this.preKeys,
+      },
     }).finish()
     const wPreKey = getRandomValues(new Uint8Array(32))
     const secret = hexToBytes(
@@ -130,8 +132,10 @@ export default class PrivateKeyBundle implements proto.PrivateKeyBundle {
     )
     const ciphertext = await encrypt(bytes, secret)
     return proto.EncryptedPrivateKeyBundle.encode({
-      walletPreKey: wPreKey,
-      ciphertext,
+      v1: {
+        walletPreKey: wPreKey,
+        ciphertext,
+      },
     }).finish()
   }
 
@@ -141,29 +145,29 @@ export default class PrivateKeyBundle implements proto.PrivateKeyBundle {
     bytes: Uint8Array
   ): Promise<PrivateKeyBundle> {
     const encrypted = proto.EncryptedPrivateKeyBundle.decode(bytes)
-    if (!encrypted.walletPreKey) {
+    if (!encrypted.v1?.walletPreKey) {
       throw new Error('missing wallet pre-key')
     }
     const secret = hexToBytes(
       await wallet.signMessage(
-        PrivateKeyBundle.storageSigRequestText(encrypted.walletPreKey)
+        PrivateKeyBundle.storageSigRequestText(encrypted.v1.walletPreKey)
       )
     )
-    if (!encrypted.ciphertext?.aes256GcmHkdfSha256) {
+    if (!encrypted.v1?.ciphertext?.aes256GcmHkdfSha256) {
       throw new Error('missing bundle ciphertext')
     }
-    const ciphertext = new Ciphertext(encrypted.ciphertext)
+    const ciphertext = new Ciphertext(encrypted.v1.ciphertext)
     const decrypted = await decrypt(ciphertext, secret)
     const bundle = proto.PrivateKeyBundle.decode(decrypted)
-    if (!bundle.identityKey) {
+    if (!bundle.v1?.identityKey) {
       throw new Error('missing identity key')
     }
-    if (bundle.preKeys.length === 0) {
+    if (bundle.v1?.preKeys.length === 0) {
       throw new Error('missing pre-keys')
     }
     return new PrivateKeyBundle(
-      new PrivateKey(bundle.identityKey),
-      bundle.preKeys.map((protoKey) => new PrivateKey(protoKey))
+      new PrivateKey(bundle.v1.identityKey),
+      bundle.v1.preKeys.map((protoKey) => new PrivateKey(protoKey))
     )
   }
 }

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -1,4 +1,4 @@
-import * as proto from '../../src/proto/private_key'
+import * as proto from '../proto/private_key'
 import PrivateKey from './PrivateKey'
 import PublicKey from './PublicKey'
 import PublicKeyBundle from './PublicKeyBundle'
@@ -144,30 +144,74 @@ export default class PrivateKeyBundle implements proto.PrivateKeyBundleV1 {
     wallet: ethers.Signer,
     bytes: Uint8Array
   ): Promise<PrivateKeyBundle> {
-    const encrypted = proto.EncryptedPrivateKeyBundle.decode(bytes)
-    if (!encrypted.v1?.walletPreKey) {
+    const eBundle = getEncryptedV1Bundle(bytes)
+
+    if (!eBundle) {
+      throw new Error('invalid bundle version')
+    }
+
+    if (!eBundle.walletPreKey) {
       throw new Error('missing wallet pre-key')
     }
     const secret = hexToBytes(
       await wallet.signMessage(
-        PrivateKeyBundle.storageSigRequestText(encrypted.v1.walletPreKey)
+        PrivateKeyBundle.storageSigRequestText(eBundle.walletPreKey)
       )
     )
-    if (!encrypted.v1?.ciphertext?.aes256GcmHkdfSha256) {
+    if (!eBundle?.ciphertext?.aes256GcmHkdfSha256) {
       throw new Error('missing bundle ciphertext')
     }
-    const ciphertext = new Ciphertext(encrypted.v1.ciphertext)
+    const ciphertext = new Ciphertext(eBundle.ciphertext)
     const decrypted = await decrypt(ciphertext, secret)
-    const bundle = proto.PrivateKeyBundle.decode(decrypted)
-    if (!bundle.v1?.identityKey) {
+    const bundle = getPrivateV1Bundle(decrypted)
+
+    if (!bundle) {
+      throw new Error('could not decode bundle')
+    }
+
+    if (!bundle.identityKey) {
       throw new Error('missing identity key')
     }
-    if (bundle.v1?.preKeys.length === 0) {
+    if (bundle.preKeys.length === 0) {
       throw new Error('missing pre-keys')
     }
     return new PrivateKeyBundle(
-      new PrivateKey(bundle.v1.identityKey),
-      bundle.v1.preKeys.map((protoKey) => new PrivateKey(protoKey))
+      new PrivateKey(bundle.identityKey),
+      bundle.preKeys.map((protoKey) => new PrivateKey(protoKey))
     )
+  }
+}
+
+// getEncryptedV1Bundle returns the decoded bundle from the provided bytes. If there is an error decoding the bundle it attempts
+// to decode the bundle as a legacy bundle.
+function getEncryptedV1Bundle(
+  bytes: Uint8Array
+): proto.EncryptedPrivateKeyBundleV1 | undefined {
+  try {
+    const b = proto.EncryptedPrivateKeyBundle.decode(bytes)
+    return b.v1
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('invalid wire type')) {
+      // Adds a default fallback for older versions of the KeyBundles
+      return proto.EncryptedPrivateKeyBundleV1.decode(bytes)
+    }
+    throw new Error("Couldn't decode encrypted bundle:" + e)
+  }
+}
+
+// getPrivateV1Bundle returns the decoded bundle from the provided bytes. If there is an error decoding the bundle it attempts
+// to decode the bundle as a legacy bundle.
+function getPrivateV1Bundle(
+  bytes: Uint8Array
+): proto.PrivateKeyBundleV1 | undefined {
+  try {
+    const b = proto.PrivateKeyBundle.decode(bytes)
+    return b.v1
+  } catch (e) {
+    if (e instanceof Error && e.message.startsWith('invalid wire type')) {
+      // Adds a default fallback for older versions of the proto
+      return proto.PrivateKeyBundleV1.decode(bytes)
+    }
+    throw new Error("Couldn't decode private bundle:" + e)
   }
 }

--- a/src/proto/messaging.proto
+++ b/src/proto/messaging.proto
@@ -32,6 +32,16 @@ message PublicKeyBundle {
   PublicKey preKey = 2;
 }
 
+message ContactBundleV1 {
+  PublicKeyBundle keyBundle = 1;
+}
+
+message ContactBundle {
+  oneof version {
+    ContactBundleV1 v1 = 1;
+  }
+}
+
 // ContentTypeId is used to identify the type of content stored in a Message.
 message ContentTypeId {
   string authorityId = 1;  // authority governing this content type

--- a/src/proto/messaging.ts
+++ b/src/proto/messaging.ts
@@ -76,6 +76,14 @@ export interface PublicKeyBundle {
   preKey: PublicKey | undefined
 }
 
+export interface ContactBundleV1 {
+  keyBundle: PublicKeyBundle | undefined
+}
+
+export interface ContactBundle {
+  v1: ContactBundleV1 | undefined
+}
+
 /** ContentTypeId is used to identify the type of content stored in a Message. */
 export interface ContentTypeId {
   /** authority governing this content type */
@@ -526,6 +534,129 @@ export const PublicKeyBundle = {
     message.preKey =
       object.preKey !== undefined && object.preKey !== null
         ? PublicKey.fromPartial(object.preKey)
+        : undefined
+    return message
+  },
+}
+
+function createBaseContactBundleV1(): ContactBundleV1 {
+  return { keyBundle: undefined }
+}
+
+export const ContactBundleV1 = {
+  encode(
+    message: ContactBundleV1,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.keyBundle !== undefined) {
+      PublicKeyBundle.encode(
+        message.keyBundle,
+        writer.uint32(10).fork()
+      ).ldelim()
+    }
+    return writer
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ContactBundleV1 {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBaseContactBundleV1()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.keyBundle = PublicKeyBundle.decode(reader, reader.uint32())
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): ContactBundleV1 {
+    return {
+      keyBundle: isSet(object.keyBundle)
+        ? PublicKeyBundle.fromJSON(object.keyBundle)
+        : undefined,
+    }
+  },
+
+  toJSON(message: ContactBundleV1): unknown {
+    const obj: any = {}
+    message.keyBundle !== undefined &&
+      (obj.keyBundle = message.keyBundle
+        ? PublicKeyBundle.toJSON(message.keyBundle)
+        : undefined)
+    return obj
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ContactBundleV1>, I>>(
+    object: I
+  ): ContactBundleV1 {
+    const message = createBaseContactBundleV1()
+    message.keyBundle =
+      object.keyBundle !== undefined && object.keyBundle !== null
+        ? PublicKeyBundle.fromPartial(object.keyBundle)
+        : undefined
+    return message
+  },
+}
+
+function createBaseContactBundle(): ContactBundle {
+  return { v1: undefined }
+}
+
+export const ContactBundle = {
+  encode(
+    message: ContactBundle,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.v1 !== undefined) {
+      ContactBundleV1.encode(message.v1, writer.uint32(10).fork()).ldelim()
+    }
+    return writer
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ContactBundle {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBaseContactBundle()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.v1 = ContactBundleV1.decode(reader, reader.uint32())
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): ContactBundle {
+    return {
+      v1: isSet(object.v1) ? ContactBundleV1.fromJSON(object.v1) : undefined,
+    }
+  },
+
+  toJSON(message: ContactBundle): unknown {
+    const obj: any = {}
+    message.v1 !== undefined &&
+      (obj.v1 = message.v1 ? ContactBundleV1.toJSON(message.v1) : undefined)
+    return obj
+  },
+
+  fromPartial<I extends Exact<DeepPartial<ContactBundle>, I>>(
+    object: I
+  ): ContactBundle {
+    const message = createBaseContactBundle()
+    message.v1 =
+      object.v1 !== undefined && object.v1 !== null
+        ? ContactBundleV1.fromPartial(object.v1)
         : undefined
     return message
   },

--- a/src/proto/private_key.proto
+++ b/src/proto/private_key.proto
@@ -18,12 +18,24 @@ message PrivateKey {
   PublicKey publicKey = 3;
 }
 
-message PrivateKeyBundle {
+message PrivateKeyBundleV1 {
   PrivateKey identityKey = 1;
   repeated PrivateKey preKeys = 2;
 }
 
-message EncryptedPrivateKeyBundle {
+message PrivateKeyBundle {
+   oneof version {
+      PrivateKeyBundleV1 v1 = 1;
+  }
+}
+
+message EncryptedPrivateKeyBundleV1 {
   bytes walletPreKey = 1;
   Ciphertext ciphertext = 2;
+}
+
+message EncryptedPrivateKeyBundle {
+   oneof version {
+      EncryptedPrivateKeyBundleV1 v1 = 1;
+  }
 }

--- a/src/proto/private_key.ts
+++ b/src/proto/private_key.ts
@@ -16,14 +16,22 @@ export interface PrivateKey_Secp256k1 {
   bytes: Uint8Array
 }
 
-export interface PrivateKeyBundle {
+export interface PrivateKeyBundleV1 {
   identityKey: PrivateKey | undefined
   preKeys: PrivateKey[]
 }
 
-export interface EncryptedPrivateKeyBundle {
+export interface PrivateKeyBundle {
+  v1: PrivateKeyBundleV1 | undefined
+}
+
+export interface EncryptedPrivateKeyBundleV1 {
   walletPreKey: Uint8Array
   ciphertext: Ciphertext | undefined
+}
+
+export interface EncryptedPrivateKeyBundle {
+  v1: EncryptedPrivateKeyBundleV1 | undefined
 }
 
 function createBasePrivateKey(): PrivateKey {
@@ -183,13 +191,13 @@ export const PrivateKey_Secp256k1 = {
   },
 }
 
-function createBasePrivateKeyBundle(): PrivateKeyBundle {
+function createBasePrivateKeyBundleV1(): PrivateKeyBundleV1 {
   return { identityKey: undefined, preKeys: [] }
 }
 
-export const PrivateKeyBundle = {
+export const PrivateKeyBundleV1 = {
   encode(
-    message: PrivateKeyBundle,
+    message: PrivateKeyBundleV1,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
     if (message.identityKey !== undefined) {
@@ -201,10 +209,10 @@ export const PrivateKeyBundle = {
     return writer
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): PrivateKeyBundle {
+  decode(input: _m0.Reader | Uint8Array, length?: number): PrivateKeyBundleV1 {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
     let end = length === undefined ? reader.len : reader.pos + length
-    const message = createBasePrivateKeyBundle()
+    const message = createBasePrivateKeyBundleV1()
     while (reader.pos < end) {
       const tag = reader.uint32()
       switch (tag >>> 3) {
@@ -222,7 +230,7 @@ export const PrivateKeyBundle = {
     return message
   },
 
-  fromJSON(object: any): PrivateKeyBundle {
+  fromJSON(object: any): PrivateKeyBundleV1 {
     return {
       identityKey: isSet(object.identityKey)
         ? PrivateKey.fromJSON(object.identityKey)
@@ -233,7 +241,7 @@ export const PrivateKeyBundle = {
     }
   },
 
-  toJSON(message: PrivateKeyBundle): unknown {
+  toJSON(message: PrivateKeyBundleV1): unknown {
     const obj: any = {}
     message.identityKey !== undefined &&
       (obj.identityKey = message.identityKey
@@ -249,10 +257,10 @@ export const PrivateKeyBundle = {
     return obj
   },
 
-  fromPartial<I extends Exact<DeepPartial<PrivateKeyBundle>, I>>(
+  fromPartial<I extends Exact<DeepPartial<PrivateKeyBundleV1>, I>>(
     object: I
-  ): PrivateKeyBundle {
-    const message = createBasePrivateKeyBundle()
+  ): PrivateKeyBundleV1 {
+    const message = createBasePrivateKeyBundleV1()
     message.identityKey =
       object.identityKey !== undefined && object.identityKey !== null
         ? PrivateKey.fromPartial(object.identityKey)
@@ -263,13 +271,71 @@ export const PrivateKeyBundle = {
   },
 }
 
-function createBaseEncryptedPrivateKeyBundle(): EncryptedPrivateKeyBundle {
+function createBasePrivateKeyBundle(): PrivateKeyBundle {
+  return { v1: undefined }
+}
+
+export const PrivateKeyBundle = {
+  encode(
+    message: PrivateKeyBundle,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.v1 !== undefined) {
+      PrivateKeyBundleV1.encode(message.v1, writer.uint32(10).fork()).ldelim()
+    }
+    return writer
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PrivateKeyBundle {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBasePrivateKeyBundle()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.v1 = PrivateKeyBundleV1.decode(reader, reader.uint32())
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): PrivateKeyBundle {
+    return {
+      v1: isSet(object.v1) ? PrivateKeyBundleV1.fromJSON(object.v1) : undefined,
+    }
+  },
+
+  toJSON(message: PrivateKeyBundle): unknown {
+    const obj: any = {}
+    message.v1 !== undefined &&
+      (obj.v1 = message.v1 ? PrivateKeyBundleV1.toJSON(message.v1) : undefined)
+    return obj
+  },
+
+  fromPartial<I extends Exact<DeepPartial<PrivateKeyBundle>, I>>(
+    object: I
+  ): PrivateKeyBundle {
+    const message = createBasePrivateKeyBundle()
+    message.v1 =
+      object.v1 !== undefined && object.v1 !== null
+        ? PrivateKeyBundleV1.fromPartial(object.v1)
+        : undefined
+    return message
+  },
+}
+
+function createBaseEncryptedPrivateKeyBundleV1(): EncryptedPrivateKeyBundleV1 {
   return { walletPreKey: new Uint8Array(), ciphertext: undefined }
 }
 
-export const EncryptedPrivateKeyBundle = {
+export const EncryptedPrivateKeyBundleV1 = {
   encode(
-    message: EncryptedPrivateKeyBundle,
+    message: EncryptedPrivateKeyBundleV1,
     writer: _m0.Writer = _m0.Writer.create()
   ): _m0.Writer {
     if (message.walletPreKey.length !== 0) {
@@ -284,10 +350,10 @@ export const EncryptedPrivateKeyBundle = {
   decode(
     input: _m0.Reader | Uint8Array,
     length?: number
-  ): EncryptedPrivateKeyBundle {
+  ): EncryptedPrivateKeyBundleV1 {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
     let end = length === undefined ? reader.len : reader.pos + length
-    const message = createBaseEncryptedPrivateKeyBundle()
+    const message = createBaseEncryptedPrivateKeyBundleV1()
     while (reader.pos < end) {
       const tag = reader.uint32()
       switch (tag >>> 3) {
@@ -305,7 +371,7 @@ export const EncryptedPrivateKeyBundle = {
     return message
   },
 
-  fromJSON(object: any): EncryptedPrivateKeyBundle {
+  fromJSON(object: any): EncryptedPrivateKeyBundleV1 {
     return {
       walletPreKey: isSet(object.walletPreKey)
         ? bytesFromBase64(object.walletPreKey)
@@ -316,7 +382,7 @@ export const EncryptedPrivateKeyBundle = {
     }
   },
 
-  toJSON(message: EncryptedPrivateKeyBundle): unknown {
+  toJSON(message: EncryptedPrivateKeyBundleV1): unknown {
     const obj: any = {}
     message.walletPreKey !== undefined &&
       (obj.walletPreKey = base64FromBytes(
@@ -331,14 +397,85 @@ export const EncryptedPrivateKeyBundle = {
     return obj
   },
 
-  fromPartial<I extends Exact<DeepPartial<EncryptedPrivateKeyBundle>, I>>(
+  fromPartial<I extends Exact<DeepPartial<EncryptedPrivateKeyBundleV1>, I>>(
     object: I
-  ): EncryptedPrivateKeyBundle {
-    const message = createBaseEncryptedPrivateKeyBundle()
+  ): EncryptedPrivateKeyBundleV1 {
+    const message = createBaseEncryptedPrivateKeyBundleV1()
     message.walletPreKey = object.walletPreKey ?? new Uint8Array()
     message.ciphertext =
       object.ciphertext !== undefined && object.ciphertext !== null
         ? Ciphertext.fromPartial(object.ciphertext)
+        : undefined
+    return message
+  },
+}
+
+function createBaseEncryptedPrivateKeyBundle(): EncryptedPrivateKeyBundle {
+  return { v1: undefined }
+}
+
+export const EncryptedPrivateKeyBundle = {
+  encode(
+    message: EncryptedPrivateKeyBundle,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.v1 !== undefined) {
+      EncryptedPrivateKeyBundleV1.encode(
+        message.v1,
+        writer.uint32(10).fork()
+      ).ldelim()
+    }
+    return writer
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number
+  ): EncryptedPrivateKeyBundle {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input)
+    let end = length === undefined ? reader.len : reader.pos + length
+    const message = createBaseEncryptedPrivateKeyBundle()
+    while (reader.pos < end) {
+      const tag = reader.uint32()
+      switch (tag >>> 3) {
+        case 1:
+          message.v1 = EncryptedPrivateKeyBundleV1.decode(
+            reader,
+            reader.uint32()
+          )
+          break
+        default:
+          reader.skipType(tag & 7)
+          break
+      }
+    }
+    return message
+  },
+
+  fromJSON(object: any): EncryptedPrivateKeyBundle {
+    return {
+      v1: isSet(object.v1)
+        ? EncryptedPrivateKeyBundleV1.fromJSON(object.v1)
+        : undefined,
+    }
+  },
+
+  toJSON(message: EncryptedPrivateKeyBundle): unknown {
+    const obj: any = {}
+    message.v1 !== undefined &&
+      (obj.v1 = message.v1
+        ? EncryptedPrivateKeyBundleV1.toJSON(message.v1)
+        : undefined)
+    return obj
+  },
+
+  fromPartial<I extends Exact<DeepPartial<EncryptedPrivateKeyBundle>, I>>(
+    object: I
+  ): EncryptedPrivateKeyBundle {
+    const message = createBaseEncryptedPrivateKeyBundle()
+    message.v1 =
+      object.v1 !== undefined && object.v1 !== null
+        ? EncryptedPrivateKeyBundleV1.fromPartial(object.v1)
         : undefined
     return message
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { Waku, WakuMessage } from 'js-waku'
 import { PublicKeyBundle } from './crypto'
+import ContactBundle from './ContactBundle'
 
 export const buildContentTopic = (name: string): string =>
   `/xmtp/0/${name}/proto`
@@ -52,7 +53,11 @@ export async function publishUserContact(
   keys: PublicKeyBundle,
   address: string
 ): Promise<void> {
+  const contactBundle = new ContactBundle(keys)
   await waku.lightPush.push(
-    await WakuMessage.fromBytes(keys.toBytes(), buildUserContactTopic(address))
+    await WakuMessage.fromBytes(
+      contactBundle.toBytes(),
+      buildUserContactTopic(address)
+    )
   )
 }

--- a/test/ContactBundle.test.ts
+++ b/test/ContactBundle.test.ts
@@ -1,0 +1,18 @@
+import * as assert from 'assert'
+import ContactBundle from '../src/ContactBundle'
+import * as ethers from 'ethers'
+import { PrivateKeyBundle } from '../src'
+
+describe('ContactBundles', function () {
+  it('roundtrip', async function () {
+    const priv = PrivateKeyBundle.generate()
+
+    const cb1 = new ContactBundle((await priv).getPublicKeyBundle())
+    const bytes1 = cb1.toBytes()
+
+    const cb2 = ContactBundle.fromBytes(bytes1)
+    const bytes2 = cb2.toBytes()
+
+    assert.deepEqual(bytes1, bytes2)
+  })
+})


### PR DESCRIPTION
This PR adds decoding for versioned bundles. If a versioned bundle cannot be decoded it attempts to parse it as a 'LegacyBundle' as a fallback. 

Once majority of clients have had a change to update, versioned bundles will be enabled by default.