### PR TITLE
Restart filter on disconnects

### DIFF
--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -77,11 +77,12 @@ export default class Stream<T> {
       this.callback,
       [this.topic]
     )
-    await this.startDisconnectWatcher()
+    await this.listenForDisconnect()
   }
 
-  private async startDisconnectWatcher() {
+  private async listenForDisconnect() {
     const peer = await this.client.waku.filter.randomPeer
+    // Save the callback function on the class so we can clean up later
     this._disconnectCallback = async (connection: Connection) => {
       if (connection.remotePeer.toB58String() === peer?.id?.toB58String()) {
         console.log(`Connection to peer ${connection.remoteAddr} lost`)

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -1,6 +1,10 @@
 import { WakuMessage } from 'js-waku'
+import { Connection } from 'libp2p'
 import Message from './Message'
 import Client from './Client'
+import { sleep } from './utils'
+
+const DISCONNECT_LOOP_INTERVAL = 1000
 
 export type MessageTransformer<T> = (msg: Message) => T
 
@@ -20,6 +24,8 @@ export default class Stream<T> {
   // cache the callback so that it can be properly deregistered in Waku
   // if callback is undefined the stream is closed
   callback: ((wakuMsg: WakuMessage) => Promise<void>) | undefined
+
+  private _disconnectCallback?: (connection: Connection) => Promise<void>
 
   unsubscribeFn?: () => Promise<void>
 
@@ -66,9 +72,41 @@ export default class Stream<T> {
     if (!this.callback) {
       throw new Error('Missing callback for stream')
     }
+
     this.unsubscribeFn = await this.client.waku.filter.subscribe(
       this.callback,
       [this.topic]
+    )
+    await this.startDisconnectWatcher()
+  }
+
+  private async startDisconnectWatcher() {
+    const peer = await this.client.waku.filter.randomPeer
+    this._disconnectCallback = async (connection: Connection) => {
+      if (connection.remotePeer.toB58String() === peer?.id?.toB58String()) {
+        console.log(`Connection to peer ${connection.remoteAddr} lost`)
+        while (true) {
+          try {
+            if (!this.callback) {
+              return
+            }
+            this.unsubscribeFn = await this.client.waku.filter.subscribe(
+              this.callback,
+              [this.topic]
+            )
+            console.log(`Connection to peer ${connection.remoteAddr} restored`)
+            return
+          } catch (e) {
+            console.warn(`Error reconnecting to ${connection.remoteAddr}`)
+            await sleep(DISCONNECT_LOOP_INTERVAL)
+          }
+        }
+      }
+    }
+
+    this.client.waku.libp2p.connectionManager.on(
+      'peer:disconnect',
+      this._disconnectCallback
     )
   }
 
@@ -93,6 +131,12 @@ export default class Stream<T> {
   // https://tc39.es/ecma262/#table-iterator-interface-optional-properties
   // Note that this means the Stream will be closed after it was used in a for-await-of or yield* or similar.
   async return(): Promise<IteratorResult<T>> {
+    if (this._disconnectCallback) {
+      this.client.waku.libp2p.connectionManager.off(
+        'peer:disconnect',
+        this._disconnectCallback
+      )
+    }
     if (!this.callback) {
       return { value: undefined, done: true }
     }


### PR DESCRIPTION
## Summary
- Fixes an issue with `js-libp2p` where no events are emitted when connections close, because some streams are hanging open. This is borrowed from status web's implementation of js-waku. https://github.com/status-im/status-web/pull/288/files#
- When a disconnect event is fired, attempts to recreate the filter stream in a loop. Currently only supports connecting to the same peer, which is fine in our case where we can reasonably expect that the same peer will eventually come back. 

## Notes
It's unclear whether this will actually catch our deploys, since the load balancer should be handling them in a 0-downtime way. Unless we are very lucky with the timing of the loop, I am not sure this event will trigger. It might, but I haven't been able to find a good way to test that locally, since it is dependent on the AWS LB behavior. If not, we will have to wait for the underlying connection monitoring issue in LibP2P to be fixed upstream before we have a solution to that case. But this will definitely help with any case of temporary downtime of our nodes.