### PR TITLE
Make node-localstorage a full dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
         "js-waku": "^0.24.0",
+        "node-localstorage": "^2.2.1",
         "protobufjs": "^6.11.3"
       },
       "devDependencies": {
@@ -31,7 +32,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^7.0.4",
         "jest": "^27.2.0",
-        "node-localstorage": "^2.2.1",
         "prettier": "^2.4.0",
         "semantic-release": "^19.0.2",
         "ts-jest": "^27.0.5",
@@ -6242,8 +6242,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -6587,7 +6586,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -9079,7 +9077,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
       "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
-      "dev": true,
       "dependencies": {
         "write-file-atomic": "^1.1.4"
       },
@@ -9091,7 +9088,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -13224,7 +13220,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -19614,8 +19609,7 @@
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -19846,8 +19840,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "4.0.0",
@@ -21845,7 +21838,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-2.2.1.tgz",
       "integrity": "sha512-vv8fJuOUCCvSPjDjBLlMqYMHob4aGjkmrkaE42/mZr0VT+ZAU10jRF8oTnX9+pgU9/vYJ8P7YT3Vd6ajkmzSCw==",
-      "dev": true,
       "requires": {
         "write-file-atomic": "^1.1.4"
       },
@@ -21854,7 +21846,6 @@
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -24824,8 +24815,7 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
     "js-waku": "^0.24.0",
+    "node-localstorage": "^2.2.1",
     "protobufjs": "^6.11.3"
   },
   "devDependencies": {
@@ -82,7 +83,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.4",
     "jest": "^27.2.0",
-    "node-localstorage": "^2.2.1",
     "prettier": "^2.4.0",
     "semantic-release": "^19.0.2",
     "ts-jest": "^27.0.5",


### PR DESCRIPTION
## Summary
Developers have been running into issues with a missing dependency for `node-localstorage`. We speculate this is happening due to next.js apps using the ESM build of the SDK instead of the UMD/Webpack version.

This adds `node-localstorage` as a full dependency