### PR TITLE
fix: import node-localstorage in tests only

### DIFF
--- a/src/store/LocalStorageStore.ts
+++ b/src/store/LocalStorageStore.ts
@@ -1,6 +1,3 @@
-// This will create a global localStorage object on Node.js for use in tests
-// If we want to save some bytes from the bundle, we can have Webpack replace this with an empty module for the browser
-import 'node-localstorage/register'
 import { Store } from './Store'
 
 const KEY_PREFIX = '/xmtp/'

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -1,3 +1,7 @@
+// This will create a global localStorage object on Node.js for use in tests
+// If we want to save some bytes from the bundle, we can have Webpack replace
+// this with an empty module for the browser
+import 'node-localstorage/register'
 import assert from 'assert'
 import {
   pollFor,

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -1,3 +1,7 @@
+// This will create a global localStorage object on Node.js for use in tests
+// If we want to save some bytes from the bundle, we can have Webpack replace
+// this with an empty module for the browser
+import 'node-localstorage/register'
 import { EncryptedStore, LocalStorageStore } from '../../src/store'
 import assert from 'assert'
 import { WakuMessage } from 'js-waku'


### PR DESCRIPTION
*Context/Motivation behind change*:

* Deployed a Next.js app to Vercel
* Every API call threw a weird runtime error: 
![image](https://user-images.githubusercontent.com/100799178/180296284-f939fcf9-1bff-4658-b009-51a39c1d875b.png)
* Ultimately I tracked down the error to the `import 'node-localstorage/register` in `LocalStorageStore.ts`
* Admittedly I didn't investigate much further, mostly because of the "this line is for tests" comment in `LocalStorageStore.ts` that suggested a potentially straightforward solution. My guess is that something about the serverless runtime Vercel uses breaks `node-localstorage`, but I'm not sure.

I wasn't sure whether to create an issue or open a conversation on Discord, figured I'd throw up this PR in case the solution I implemented makes sense. I ran tests locally before and after making these changes, all tests pass.
