### PR TITLE
[WIP] Add stream for all messages

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -500,9 +500,8 @@ export default class Client {
       for (const connections of this.waku.libp2p.connectionManager.connections.values()) {
         for (const connection of connections) {
           if (!connection.streams.length) {
-            console.log('### Shut it down in the client')
             console.log(`Closing connection to ${connection.remoteAddr}`)
-            // connectionsToClose.push(connection.close())
+            connectionsToClose.push(connection.close())
           }
         }
       }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -416,7 +416,7 @@ export default class Client {
   streamIntroductionMessages(): Promise<Stream<Message>> {
     return Stream.create<Message>(
       this,
-      buildUserIntroTopic(this.address),
+      [buildUserIntroTopic(this.address)],
       noTransformation
     )
   }
@@ -425,10 +425,19 @@ export default class Client {
     const topic = buildDirectMessageTopic(peerAddress, this.address)
     return Stream.create<Message>(
       this,
-      topic,
+      [topic],
       noTransformation,
       filterForTopic(topic)
     )
+  }
+
+  streamAllConversationMessages(
+    peerAddresses: string[]
+  ): Promise<Stream<Message>> {
+    const messageTopics = peerAddresses.map((peerAddress) =>
+      buildDirectMessageTopic(peerAddress, this.address)
+    )
+    return Stream.create<Message>(this, messageTopics, noTransformation)
   }
 
   // list stored messages from this wallet's introduction topic
@@ -491,8 +500,9 @@ export default class Client {
       for (const connections of this.waku.libp2p.connectionManager.connections.values()) {
         for (const connection of connections) {
           if (!connection.streams.length) {
+            console.log('### Shut it down in the client')
             console.log(`Closing connection to ${connection.remoteAddr}`)
-            connectionsToClose.push(connection.close())
+            // connectionsToClose.push(connection.close())
           }
         }
       }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -51,6 +51,7 @@ export default class Stream<T> {
       if (!wakuMsg.payload) {
         return
       }
+      console.log('New message: ' + wakuMsg.payload)
       const msg = await this.client.decodeMessage(wakuMsg.payload)
       // If there is a filter on the stream, and the filter returns false, ignore the message
       if (filter && !filter(msg)) {
@@ -168,11 +169,21 @@ export default class Stream<T> {
     return new Promise((resolve) => this.resolvers.unshift(resolve))
   }
 
-  // Update the list of topics and unsubscribe to trigger a disconnect & new subscription.
-  async resetTopics(topics: string[]): Promise<void> {
-    this.topics = topics
+  // Unsubscribe from the existing content topics and resubscribe to the given topics.
+  async resubscribeToTopics(topics: string[]): Promise<void> {
+    if (!this.callback) {
+      throw new Error('Missing callback for stream')
+    }
     if (this.unsubscribeFn) {
       await this.unsubscribeFn()
+      console.log('### Unsubscribed from topics: ' + this.topics)
     }
+    // TODO(elise): Commented out to test unsub/sub with the same topics.
+    // this.topics = topics
+    console.log('### Resubscribed to topics: ' + this.topics)
+    this.unsubscribeFn = await this.client.waku.filter.subscribe(
+      this.callback,
+      this.topics
+    )
   }
 }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -77,7 +77,6 @@ export default class Stream<T> {
       this.callback,
       this.topics
     )
-    console.log('Subscribe to topics in start!')
     await this.listenForDisconnect()
   }
 
@@ -86,14 +85,12 @@ export default class Stream<T> {
     // Save the callback function on the class so we can clean up later
     this._disconnectCallback = async (connection: Connection) => {
       if (connection.remotePeer.toB58String() === peer?.id?.toB58String()) {
-        console.log('### Disconnect callback called!')
         console.log(`Connection to peer ${connection.remoteAddr} lost`)
         while (true) {
           try {
             if (!this.callback) {
               return
             }
-            console.log('Subscribe to topics in disconnect callback!')
             this.unsubscribeFn = await this.client.waku.filter.subscribe(
               this.callback,
               this.topics
@@ -108,7 +105,6 @@ export default class Stream<T> {
       }
     }
 
-    console.log('### Init disconnect callback!')
     this.client.waku.libp2p.connectionManager.on(
       'peer:disconnect',
       this._disconnectCallback
@@ -172,12 +168,10 @@ export default class Stream<T> {
     return new Promise((resolve) => this.resolvers.unshift(resolve))
   }
 
-  // Unsubscribe and resubscribe with new topics.
+  // Update the list of topics and unsubscribe to trigger a disconnect & new subscription.
   async resetTopics(topics: string[]): Promise<void> {
-    console.log(`New topics: ${topics}`)
     this.topics = topics
     if (this.unsubscribeFn) {
-      console.log('### Unsubscribe!')
       await this.unsubscribeFn()
     }
   }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -15,7 +15,7 @@ export type MessageFilter = (msg: Message) => boolean
  * As such can be used with constructs like for-await-of, yield*, array destructing, etc.
  */
 export default class Stream<T> {
-  topic: string
+  topics: string[]
   client: Client
   // queue of incoming Waku messages
   messages: T[]
@@ -31,13 +31,13 @@ export default class Stream<T> {
 
   constructor(
     client: Client,
-    topic: string,
+    topics: string[],
     messageTransformer: MessageTransformer<T>,
     messageFilter?: MessageFilter
   ) {
     this.messages = []
     this.resolvers = []
-    this.topic = topic
+    this.topics = topics
     this.client = client
     this.callback = this.newMessageCallback(messageTransformer, messageFilter)
   }
@@ -75,7 +75,7 @@ export default class Stream<T> {
 
     this.unsubscribeFn = await this.client.waku.filter.subscribe(
       this.callback,
-      [this.topic]
+      this.topics
     )
     await this.listenForDisconnect()
   }
@@ -93,7 +93,7 @@ export default class Stream<T> {
             }
             this.unsubscribeFn = await this.client.waku.filter.subscribe(
               this.callback,
-              [this.topic]
+              this.topics
             )
             console.log(`Connection to peer ${connection.remoteAddr} restored`)
             return

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -80,6 +80,17 @@ export default class Conversations {
     )
   }
 
+  async streamAllMessages(): Promise<Stream<Message>> {
+    const peerAddresses = (await this.list()).map(
+      (conversation) => conversation.peerAddress
+    )
+    const stream = Stream.create<Message>(this.client, ...) // Need to generate the topics from the peer addresses, and specify a message transformer + filter
+    for await (const conversation of await this.stream()) {
+      // Somehow modify the stream above to include the right topics
+    }
+    return stream
+  }
+
   /**
    * Creates a new conversation for the given address. Will throw an error if the peer is not found in the XMTP network
    */

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -87,16 +87,21 @@ export default class Conversations {
     const messagesStream =
       this.client.streamAllConversationMessages(peerAddresses)
 
-    // TODO(elise): de-dupe conversations before triggering the unsubscribe.
     for await (const conversation of await this.stream()) {
-      console.log('New conversation: ' + conversation.peerAddress)
-      const newAddresses = (await this.list()).map(
-        (conversation) => conversation.peerAddress
-      )
-      const newTopics = newAddresses.map((peerAddress) =>
+      // TODO(elise): append the new conversation once unsubscribing is confirmed.
+      // Right now this should just trigger a resubscribe with the same addresses.
+
+      // if (!peerAddresses.includes(conversation.peerAddress)) {
+      // peerAddresses.push(conversation.peerAddress)
+      // }
+      // console.log('New conversation: ' + conversation.peerAddress)
+      // const newAddresses = (await this.list()).map(
+      //   (conversation) => conversation.peerAddress
+      // )
+      const newTopics = peerAddresses.map((peerAddress) =>
         buildDirectMessageTopic(peerAddress, this.client.address)
       )
-      ;(await messagesStream).resetTopics(newTopics)
+      ;(await messagesStream).resubscribeToTopics(newTopics)
     }
 
     return messagesStream

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -87,17 +87,16 @@ export default class Conversations {
     const messagesStream =
       this.client.streamAllConversationMessages(peerAddresses)
 
-    // TODO(elise): unsubscribe message stream and resubscribe with new topics. use concat?
+    // TODO(elise): de-dupe conversations before triggering the unsubscribe.
     for await (const conversation of await this.stream()) {
       console.log('New conversation: ' + conversation.peerAddress)
       const newAddresses = (await this.list()).map(
         (conversation) => conversation.peerAddress
       )
-      // TODO(elise): Strip this out to match above?
-      const topics = newAddresses.map((peerAddress) =>
+      const newTopics = newAddresses.map((peerAddress) =>
         buildDirectMessageTopic(peerAddress, this.client.address)
       )
-      ;(await messagesStream).resetTopics(topics)
+      ;(await messagesStream).resetTopics(newTopics)
     }
 
     return messagesStream


### PR DESCRIPTION
This PR is a work in progress for adding a stream for all messages across all conversations and should not be merged as-is.

Currently this is blocked on unsubscribing from a list of content topics and then subscribing with a new list of content topics. To keep it simple, I set up the content topics list to stay the same between the unsubscribe and the second subscribe for the time being. The unsubscribe appears to work ok, but subscribing again with the same list of content topics causes malformed messages to return.

To reproduce:
1. Check out `ea/test-all-messages` branch in the example react app which [integrates with the new `streamAllMessages()`](https://github.com/xmtp/example-chat-react/compare/ea/test-all-messages) method: https://github.com/xmtp/example-chat-react/tree/ea/test-all-messages
2. Rebuild this library with `npm run build` and then run it
3. Open 2 chat windows with separate wallets and send send a message from one wallet to the other.
4. You should see a new conversation trigger the `resubscribeToTopics` method which is causing the error below for me currently:

<img width="516" alt="Screen Shot 2022-07-27 at 3 27 49 PM" src="https://user-images.githubusercontent.com/556051/181359677-b8d1c1f4-e464-467e-8a84-5f8b526436c0.png">

