### PR TITLE
Add new API Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
+        "@xmtp/proto": "^1.0.0",
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
         "js-waku": "^0.24.0",
@@ -3207,6 +3208,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@xmtp/proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-1.0.0.tgz",
+      "integrity": "sha512-HIkS2KegLL2aX4zQNNyGenntuyr6Pe5wW8poq1j/0ZBR3mqZrXcpkQBNsmOE9zeul79oHns7gLeoPYD10OtInQ=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -17274,6 +17280,11 @@
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
       "dev": true,
       "requires": {}
+    },
+    "@xmtp/proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-1.0.0.tgz",
+      "integrity": "sha512-HIkS2KegLL2aX4zQNNyGenntuyr6Pe5wW8poq1j/0ZBR3mqZrXcpkQBNsmOE9zeul79oHns7gLeoPYD10OtInQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
+    "@xmtp/proto": "^1.0.0",
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
     "js-waku": "^0.24.0",

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -1,0 +1,204 @@
+import {
+  Cursor,
+  Envelope,
+  MessageApi,
+  PagingInfo,
+  PublishRequest,
+  QueryRequest,
+  SortDirection,
+  SubscribeRequest,
+} from '@xmtp/proto'
+import { retry } from './utils'
+import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
+
+const RETRY_SLEEP_TIME = 100
+
+export type QueryParams = {
+  startTime?: Date
+  endTime?: Date
+  contentTopics: string[]
+}
+
+export type QueryAllOptions = {
+  direction?: SortDirection
+  limit?: number
+}
+
+export type QueryStreamOptions = Omit<QueryAllOptions, 'limit'> & {
+  pageSize?: number
+}
+
+export type PublishParams = {
+  contentTopic: string
+  message: Uint8Array
+  timestamp?: Date
+}
+
+export type SubscribeParams = {
+  contentTopics: string[]
+}
+
+export type ApiClientOptions = {
+  maxRetries?: number
+}
+
+export type SubscribeCallback = NotifyStreamEntityArrival<Envelope>
+
+const toNanoString = (d: Date | undefined): undefined | string => {
+  return d && (d.valueOf() * 1_000_000).toFixed(0)
+}
+
+export default class ApiClient {
+  pathPrefix: string
+  maxRetries: number
+
+  constructor(pathPrefix: string, opts?: ApiClientOptions) {
+    this.pathPrefix = pathPrefix
+    this.maxRetries = opts?.maxRetries || 5
+  }
+
+  // Raw method for querying the API
+  private _query(req: QueryRequest): ReturnType<typeof MessageApi.Query> {
+    return retry(
+      MessageApi.Query,
+      [req, { pathPrefix: this.pathPrefix }],
+      this.maxRetries,
+      RETRY_SLEEP_TIME
+    )
+  }
+
+  // Raw method for publishing to the API
+  private _publish(req: PublishRequest): ReturnType<typeof MessageApi.Publish> {
+    return retry(
+      MessageApi.Publish,
+      [req, { pathPrefix: this.pathPrefix }],
+      this.maxRetries,
+      RETRY_SLEEP_TIME
+    )
+  }
+
+  // Raw method for subscribing
+  private _subscribe(
+    req: SubscribeRequest,
+    cb: NotifyStreamEntityArrival<Envelope>
+  ): ReturnType<typeof MessageApi.Subscribe> {
+    return retry(
+      MessageApi.Subscribe,
+      [req, cb, { pathPrefix: this.pathPrefix }],
+      this.maxRetries,
+      RETRY_SLEEP_TIME
+    )
+  }
+
+  async queryAll(
+    params: QueryParams,
+    {
+      direction = SortDirection.SORT_DIRECTION_ASCENDING,
+      limit,
+    }: QueryAllOptions
+  ): Promise<Envelope[]> {
+    const out: Envelope[] = []
+    // Use queryStreamPages for better performance. 1/100th the number of Promises to resolve compared to queryStream
+    for await (const page of this.queryStreamPages(params, {
+      direction,
+      // If there is a limit of < 100, use that as the page size. Otherwise use 100 and stop if/when limit reached.
+      pageSize: limit && limit < 100 ? limit : 100,
+    })) {
+      for (const envelope of page) {
+        out.push(envelope)
+        if (limit && out.length === limit) {
+          break
+        }
+      }
+    }
+    return out
+  }
+
+  // Will produce an AsyncGenerator of Envelopes
+  // Uses queryStreamPages under the hood
+  async *queryStream(
+    params: QueryParams,
+    options: QueryStreamOptions
+  ): AsyncGenerator<Envelope> {
+    for await (const page of this.queryStreamPages(params, options)) {
+      for (const envelope of page) {
+        yield envelope
+      }
+    }
+  }
+
+  // Creates an async generator that will paginate through the Query API until it reaches the end
+  // Will yield each page of results as needed
+  private async *queryStreamPages(
+    { contentTopics, startTime, endTime }: QueryParams,
+    { direction, pageSize = 10 }: QueryStreamOptions
+  ): AsyncGenerator<Envelope[]> {
+    if (!contentTopics || !contentTopics.length) {
+      throw new Error('Must specify content topics')
+    }
+
+    const startTimeNs = toNanoString(startTime)
+    const endTimeNs = toNanoString(endTime)
+    let cursor: Cursor | undefined
+
+    while (true) {
+      const pagingInfo: PagingInfo = {
+        limit: pageSize,
+        direction,
+        cursor,
+      }
+
+      const result = await this._query({
+        contentTopics,
+        startTimeNs,
+        endTimeNs,
+        pagingInfo,
+      })
+
+      if (result.envelopes?.length) {
+        yield result.envelopes
+      } else {
+        return
+      }
+
+      if (result.pagingInfo?.cursor) {
+        cursor = result.pagingInfo?.cursor
+      } else {
+        return
+      }
+    }
+  }
+
+  async publish({
+    contentTopic,
+    timestamp,
+    message,
+  }: PublishParams): ReturnType<typeof MessageApi.Publish> {
+    if (!contentTopic.length) {
+      throw new Error('Content topic cannot be empty string')
+    }
+
+    if (!message.length) {
+      throw new Error('0 length messages not allowed')
+    }
+
+    const dt = timestamp || new Date()
+
+    return this._publish({
+      contentTopic,
+      timestampNs: toNanoString(dt),
+      message,
+    })
+  }
+
+  async subscribe(
+    params: SubscribeParams,
+    callback: SubscribeCallback
+  ): ReturnType<typeof MessageApi.Subscribe> {
+    if (!params.contentTopics.length) {
+      throw new Error('Must provide list of contentTopics to subscribe to')
+    }
+
+    return this._subscribe(params, callback)
+  }
+}

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -90,7 +90,7 @@ export default class ApiClient {
     )
   }
 
-  async queryAll(
+  async query(
     params: QueryParams,
     {
       direction = SortDirection.SORT_DIRECTION_ASCENDING,
@@ -116,7 +116,7 @@ export default class ApiClient {
 
   // Will produce an AsyncGenerator of Envelopes
   // Uses queryStreamPages under the hood
-  async *queryStream(
+  async *queryIterator(
     params: QueryParams,
     options: QueryStreamOptions
   ): AsyncGenerator<Envelope> {

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -99,7 +99,7 @@ export default class ApiClient {
   ): Promise<Envelope[]> {
     const out: Envelope[] = []
     // Use queryStreamPages for better performance. 1/100th the number of Promises to resolve compared to queryStream
-    for await (const page of this.queryStreamPages(params, {
+    for await (const page of this.queryIteratePages(params, {
       direction,
       // If there is a limit of < 100, use that as the page size. Otherwise use 100 and stop if/when limit reached.
       pageSize: limit && limit < 100 ? limit : 100,
@@ -120,7 +120,7 @@ export default class ApiClient {
     params: QueryParams,
     options: QueryStreamOptions
   ): AsyncGenerator<Envelope> {
-    for await (const page of this.queryStreamPages(params, options)) {
+    for await (const page of this.queryIteratePages(params, options)) {
       for (const envelope of page) {
         yield envelope
       }
@@ -129,7 +129,7 @@ export default class ApiClient {
 
   // Creates an async generator that will paginate through the Query API until it reaches the end
   // Will yield each page of results as needed
-  private async *queryStreamPages(
+  private async *queryIteratePages(
     { contentTopics, startTime, endTime }: QueryParams,
     { direction, pageSize = 10 }: QueryStreamOptions
   ): AsyncGenerator<Envelope[]> {

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -90,6 +90,7 @@ export default class ApiClient {
     )
   }
 
+  // Use the Query API to return the full contents of any specified topics
   async query(
     params: QueryParams,
     {
@@ -98,7 +99,7 @@ export default class ApiClient {
     }: QueryAllOptions
   ): Promise<Envelope[]> {
     const out: Envelope[] = []
-    // Use queryStreamPages for better performance. 1/100th the number of Promises to resolve compared to queryStream
+    // Use queryIteratePages for better performance. 1/100th the number of Promises to resolve compared to queryStream
     for await (const page of this.queryIteratePages(params, {
       direction,
       // If there is a limit of < 100, use that as the page size. Otherwise use 100 and stop if/when limit reached.
@@ -169,6 +170,8 @@ export default class ApiClient {
     }
   }
 
+  // Publish a message to the network
+  // Will convert timestamps to the appropriate format expected by the network
   async publish({
     contentTopic,
     timestamp,
@@ -191,6 +194,8 @@ export default class ApiClient {
     })
   }
 
+  // Subscribe to a list of topics.
+  // Provided callback function will be called on each new message
   async subscribe(
     params: SubscribeParams,
     callback: SubscribeCallback

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,7 @@ export async function retry<T extends (...arg0: any[]) => any>(
     const result = await fn(...args)
     return result
   } catch (e) {
-    console.error(e)
+    console.log(e)
     if (currRetry > maxRetries) {
       throw e
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,6 +48,29 @@ export const promiseWithTimeout = <T>(
   })
 }
 
+// Implements type safe retries of arbitrary async functions
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function retry<T extends (...arg0: any[]) => any>(
+  fn: T,
+  args: Parameters<T>,
+  maxRetries: number,
+  sleepTime: number,
+  retryCount = 1
+): Promise<Awaited<ReturnType<T>>> {
+  const currRetry = typeof retryCount === 'number' ? retryCount : 1
+  try {
+    const result = await fn(...args)
+    return result
+  } catch (e) {
+    console.error(e)
+    if (currRetry > maxRetries) {
+      throw e
+    }
+    await sleep(sleepTime)
+    return retry(fn, args, maxRetries, sleepTime, currRetry + 1)
+  }
+}
+
 export async function publishUserContact(
   waku: Waku,
   keys: PublicKeyBundle,

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -30,7 +30,7 @@ describe('Query', () => {
 
   it('stops when receiving empty results', async () => {
     const apiMock = createQueryMock([], 1)
-    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
     expect(result).toHaveLength(0)
     expect(apiMock).toHaveBeenCalledTimes(1)
     const expectedReq: QueryRequest = {
@@ -47,14 +47,14 @@ describe('Query', () => {
 
   it('stops when receiving some results and a null cursor', async () => {
     const apiMock = createQueryMock([createEnvelope()], 1)
-    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
     expect(result).toHaveLength(1)
     expect(apiMock).toHaveBeenCalledTimes(1)
   })
 
   it('gets multiple pages of results', async () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
-    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
     expect(result).toHaveLength(4)
     expect(apiMock).toHaveBeenCalledTimes(2)
   })
@@ -62,7 +62,7 @@ describe('Query', () => {
   it('streams a single page of results', async () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 1)
     let count = 0
-    for await (const _envelope of client.queryStream(
+    for await (const _envelope of client.queryIterator(
       { contentTopics: ['foo'] },
       { pageSize: 5 }
     )) {
@@ -85,7 +85,7 @@ describe('Query', () => {
   it('streams multiple pages of results', async () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
     let count = 0
-    for await (const _envelope of client.queryStream(
+    for await (const _envelope of client.queryIterator(
       { contentTopics: [CONTENT_TOPIC] },
       { pageSize: 5 }
     )) {

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -1,0 +1,221 @@
+import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
+import ApiClient, { PublishParams } from '../src/ApiClient'
+import {
+  Cursor,
+  Envelope,
+  MessageApi,
+  SortDirection,
+  QueryRequest,
+  QueryResponse,
+  PublishResponse,
+  PublishRequest,
+  SubscribeRequest,
+} from '@xmtp/proto'
+
+const PATH_PREFIX = 'http://fake:5050'
+const CURSOR: Cursor = {
+  index: {
+    digest: Uint8Array.from([1, 2, 3]),
+    senderTimeNs: '3',
+  },
+}
+const CONTENT_TOPIC = 'foo'
+
+const client = new ApiClient(PATH_PREFIX)
+
+describe('Query', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('stops when receiving empty results', async () => {
+    const apiMock = createQueryMock([], 1)
+    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    expect(result).toHaveLength(0)
+    expect(apiMock).toHaveBeenCalledTimes(1)
+    const expectedReq: QueryRequest = {
+      contentTopics: ['foo'],
+      pagingInfo: {
+        direction: SortDirection.SORT_DIRECTION_ASCENDING,
+        limit: 100,
+      },
+    }
+    expect(apiMock).toHaveBeenCalledWith(expectedReq, {
+      pathPrefix: PATH_PREFIX,
+    })
+  })
+
+  it('stops when receiving some results and a null cursor', async () => {
+    const apiMock = createQueryMock([createEnvelope()], 1)
+    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    expect(result).toHaveLength(1)
+    expect(apiMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('gets multiple pages of results', async () => {
+    const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
+    const result = await client.queryAll({ contentTopics: [CONTENT_TOPIC] }, {})
+    expect(result).toHaveLength(4)
+    expect(apiMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('streams a single page of results', async () => {
+    const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 1)
+    let count = 0
+    for await (const _envelope of client.queryStream(
+      { contentTopics: ['foo'] },
+      { pageSize: 5 }
+    )) {
+      count++
+    }
+    expect(count).toBe(2)
+    expect(apiMock).toHaveBeenCalledTimes(1)
+
+    const expectedReq: QueryRequest = {
+      contentTopics: ['foo'],
+      pagingInfo: {
+        limit: 5,
+      },
+    }
+    expect(apiMock).toHaveBeenCalledWith(expectedReq, {
+      pathPrefix: PATH_PREFIX,
+    })
+  })
+
+  it('streams multiple pages of results', async () => {
+    const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
+    let count = 0
+    for await (const _envelope of client.queryStream(
+      { contentTopics: [CONTENT_TOPIC] },
+      { pageSize: 5 }
+    )) {
+      count++
+    }
+    expect(count).toBe(4)
+    expect(apiMock).toHaveBeenCalledTimes(2)
+
+    const expectedReq: QueryRequest = {
+      contentTopics: [CONTENT_TOPIC],
+      pagingInfo: {
+        limit: 5,
+        cursor: CURSOR,
+      },
+    }
+    expect(apiMock).toHaveBeenLastCalledWith(expectedReq, {
+      pathPrefix: PATH_PREFIX,
+    })
+  })
+})
+
+describe('Publish', () => {
+  const publishMock = createPublishMock()
+  beforeEach(() => {
+    publishMock.mockClear()
+  })
+
+  it('publishes valid messages', async () => {
+    const now = new Date()
+    const msg: PublishParams = {
+      timestamp: now,
+      message: Uint8Array.from([1, 2, 3]),
+      contentTopic: CONTENT_TOPIC,
+    }
+
+    await client.publish(msg)
+    expect(publishMock).toHaveBeenCalledTimes(1)
+    const expectedRequest: PublishRequest = {
+      message: msg.message,
+      contentTopic: msg.contentTopic,
+      timestampNs: (now.valueOf() * 1_000_000).toFixed(0),
+    }
+    expect(publishMock).toHaveBeenCalledWith(expectedRequest, {
+      pathPrefix: PATH_PREFIX,
+    })
+  })
+
+  it('throws on invalid message', () => {
+    const promise = client.publish({
+      contentTopic: '',
+      message: Uint8Array.from([]),
+    })
+    expect(promise).rejects.toBeInstanceOf(Error)
+  })
+})
+
+describe('Subscribe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('can subscribe', async () => {
+    const subscribeMock = createSubscribeMock(2)
+    let numEnvelopes = 0
+    const cb = (env: Envelope) => {
+      numEnvelopes++
+    }
+    const req = { contentTopics: [CONTENT_TOPIC] }
+    await client.subscribe(req, cb)
+    expect(numEnvelopes).toBe(2)
+    expect(subscribeMock).toBeCalledWith(req, cb, { pathPrefix: PATH_PREFIX })
+  })
+
+  it('throws when no content topics returned', async () => {
+    const subscribeMock = createSubscribeMock(2)
+    let numEnvelopes = 0
+    const cb = (env: Envelope) => {
+      numEnvelopes++
+    }
+    const req = { contentTopics: [] }
+    const promise = client.subscribe(req, cb)
+    expect(promise).rejects.toEqual(
+      new Error('Must provide list of contentTopics to subscribe to')
+    )
+  })
+})
+
+function createQueryMock(envelopes: Envelope[], numPages = 1) {
+  let numCalls = 0
+  return jest
+    .spyOn(MessageApi, 'Query')
+    .mockImplementation(async (): Promise<QueryResponse> => {
+      numCalls++
+      return {
+        envelopes: envelopes,
+        pagingInfo: {
+          cursor: numCalls >= numPages ? undefined : CURSOR,
+        },
+      }
+    })
+}
+
+function createPublishMock() {
+  return jest
+    .spyOn(MessageApi, 'Publish')
+    .mockImplementation(async (): Promise<PublishResponse> => ({}))
+}
+
+function createSubscribeMock(numMessages: number) {
+  return jest
+    .spyOn(MessageApi, 'Subscribe')
+    .mockImplementation(
+      async (
+        req: SubscribeRequest,
+        cb: NotifyStreamEntityArrival<Envelope> | undefined
+      ): Promise<void> => {
+        for (let i = 0; i < numMessages; i++) {
+          if (cb) {
+            cb(createEnvelope())
+          }
+        }
+      }
+    )
+}
+
+function createEnvelope(): Envelope {
+  return {
+    id: 'id',
+    contentTopic: CONTENT_TOPIC,
+    timestampNs: '1',
+    message: Uint8Array.from([1, 2, 3]),
+  }
+}


### PR DESCRIPTION
## Summary
I realized there is a piece of the GRPC work that I can break out and merge in now. Should help cut down the size of the already-huge PR to replace Waku.

- Creates new API client wrapper for the MessageApi service
- Adds two new methods for using the `Query` API. `query` and `queryIterator`
- Adds tests for the API using `jest.mock` to mock out the backend
- Handles conversion of Date objects to `uint64`s in the expected format of GRPC Gateway
- Adds retries to all API methods

## Notes
Because this client uses entirely mocked API calls for the tests, and is not imported anywhere, it is safe to merge in advance of the node software being deployed