### PR TITLE
Introduce API to stream all messages for all conversations

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -631,9 +631,15 @@ async function getNodeList(env: keyof NodesList): Promise<string[]> {
   return Object.values(nodesList[env])
 }
 
-// Ensure the message received was in the original list of topics to subscribe to.
+// Ensure the message didn't have a spoofed address
 function filterForTopics(topics: string[]): MessageFilter {
   return (msg) => {
-    return msg.contentTopic !== undefined && topics.includes(msg.contentTopic)
+    const senderAddress = msg.senderAddress
+    const recipientAddress = msg.recipientAddress
+    return (
+      senderAddress !== undefined &&
+      recipientAddress !== undefined &&
+      topics.includes(buildDirectMessageTopic(senderAddress, recipientAddress))
+    )
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -500,9 +500,8 @@ export default class Client {
       for (const connections of this.waku.libp2p.connectionManager.connections.values()) {
         for (const connection of connections) {
           if (!connection.streams.length) {
-            console.log('### Shut it down in the client')
             console.log(`Closing connection to ${connection.remoteAddr}`)
-            // connectionsToClose.push(connection.close())
+            connectionsToClose.push(connection.close())
           }
         }
       }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -422,22 +422,22 @@ export default class Client {
   }
 
   streamConversationMessages(peerAddress: string): Promise<Stream<Message>> {
-    const topic = buildDirectMessageTopic(peerAddress, this.address)
+    const topics = [buildDirectMessageTopic(peerAddress, this.address)]
     return Stream.create<Message>(
       this,
-      [topic],
+      topics,
       noTransformation,
-      filterForTopic(topic)
+      filterForTopics(topics)
     )
   }
 
-  streamAllConversationMessages(
-    peerAddresses: string[]
-  ): Promise<Stream<Message>> {
-    const messageTopics = peerAddresses.map((peerAddress) =>
-      buildDirectMessageTopic(peerAddress, this.address)
+  streamAllConversationMessages(topics: string[]): Promise<Stream<Message>> {
+    return Stream.create<Message>(
+      this,
+      topics,
+      noTransformation,
+      filterForTopics(topics)
     )
-    return Stream.create<Message>(this, messageTopics, noTransformation)
   }
 
   // list stored messages from this wallet's introduction topic
@@ -489,7 +489,7 @@ export default class Client {
       )
     )
     if (opts?.checkAddresses) {
-      msgs = msgs.filter(filterForTopic(topic))
+      msgs = msgs.filter(filterForTopics([topic]))
     }
     return msgs
   }
@@ -640,14 +640,14 @@ function noTransformation(msg: Message) {
   return msg
 }
 
-function filterForTopic(topic: string): MessageFilter {
+function filterForTopics(topics: string[]): MessageFilter {
   return (msg) => {
     const senderAddress = msg.senderAddress
     const recipientAddress = msg.recipientAddress
     return (
       senderAddress !== undefined &&
       recipientAddress !== undefined &&
-      buildDirectMessageTopic(senderAddress, recipientAddress) === topic
+      topics.includes(buildDirectMessageTopic(senderAddress, recipientAddress))
     )
   }
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -416,7 +416,7 @@ export default class Client {
   streamIntroductionMessages(): Promise<Stream<Message>> {
     return Stream.create<Message>(
       this,
-      buildUserIntroTopic(this.address),
+      [buildUserIntroTopic(this.address)],
       noTransformation
     )
   }
@@ -425,10 +425,19 @@ export default class Client {
     const topic = buildDirectMessageTopic(peerAddress, this.address)
     return Stream.create<Message>(
       this,
-      topic,
+      [topic],
       noTransformation,
       filterForTopic(topic)
     )
+  }
+
+  streamAllConversationMessages(
+    peerAddresses: string[]
+  ): Promise<Stream<Message>> {
+    const messageTopics = peerAddresses.map((peerAddress) =>
+      buildDirectMessageTopic(peerAddress, this.address)
+    )
+    return Stream.create<Message>(this, messageTopics, noTransformation)
   }
 
   // list stored messages from this wallet's introduction topic
@@ -491,8 +500,9 @@ export default class Client {
       for (const connections of this.waku.libp2p.connectionManager.connections.values()) {
         for (const connection of connections) {
           if (!connection.streams.length) {
+            console.log('### Shut it down in the client')
             console.log(`Closing connection to ${connection.remoteAddr}`)
-            connectionsToClose.push(connection.close())
+            // connectionsToClose.push(connection.close())
           }
         }
       }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -31,6 +31,7 @@ export default class Message implements proto.V1Message {
   // the message receiving APIs need to return a Message to provide access to the header fields like sender/recipient
   contentType?: ContentTypeId
   content?: any // eslint-disable-line @typescript-eslint/no-explicit-any
+  contentTopic?: string // content topic that triggered the message
   error?: Error
   /**
    * Identifier that is deterministically derived from the bytes of the message

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -51,6 +51,7 @@ export default class Stream<T> {
       if (!wakuMsg.payload) {
         return
       }
+      console.log('New message: ' + wakuMsg.payload)
       const msg = await this.client.decodeMessage(wakuMsg.payload)
       // If there is a filter on the stream, and the filter returns false, ignore the message
       if (filter && !filter(msg)) {
@@ -168,11 +169,21 @@ export default class Stream<T> {
     return new Promise((resolve) => this.resolvers.unshift(resolve))
   }
 
-  // Update the list of topics and unsubscribe to trigger a disconnect & new subscription.
-  async resetTopics(topics: string[]): Promise<void> {
-    this.topics = topics
+  // Unsubscribe from the existing content topics and resubscribe to the given topics.
+  async resubscribeToTopics(topics: string[]): Promise<void> {
+    if (!this.callback) {
+      throw new Error('Missing callback for stream')
+    }
     if (this.unsubscribeFn) {
       await this.unsubscribeFn()
+      console.log('### Unsubscribed from topics: ' + this.topics)
     }
+    // TODO(elise): Commented out to test unsub/sub with the same topics.
+    // this.topics = topics
+    console.log('### Resubscribed to topics: ' + this.topics)
+    this.unsubscribeFn = await this.client.waku.filter.subscribe(
+      this.callback,
+      this.topics
+    )
   }
 }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -51,7 +51,6 @@ export default class Stream<T> {
       if (!wakuMsg.payload) {
         return
       }
-      console.log('New message: ' + wakuMsg.payload)
       const msg = await this.client.decodeMessage(wakuMsg.payload)
       // If there is a filter on the stream, and the filter returns false, ignore the message
       if (filter && !filter(msg)) {
@@ -178,8 +177,7 @@ export default class Stream<T> {
       await this.unsubscribeFn()
       console.log('### Unsubscribed from topics: ' + this.topics)
     }
-    // TODO(elise): Commented out to test unsub/sub with the same topics.
-    // this.topics = topics
+    this.topics = topics
     console.log('### Resubscribed to topics: ' + this.topics)
     this.unsubscribeFn = await this.client.waku.filter.subscribe(
       this.callback,

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -170,18 +170,15 @@ export default class Stream<T> {
 
   // Unsubscribe from the existing content topics and resubscribe to the given topics.
   async resubscribeToTopics(topics: string[]): Promise<void> {
-    if (!this.callback) {
+    if (!this.callback || !this.unsubscribeFn) {
       throw new Error('Missing callback for stream')
     }
-    if (this.unsubscribeFn) {
-      await this.unsubscribeFn()
-      console.log('### Unsubscribed from topics: ' + this.topics)
-    }
+    await this.unsubscribeFn()
     this.topics = topics
-    console.log('### Resubscribed to topics: ' + this.topics)
     this.unsubscribeFn = await this.client.waku.filter.subscribe(
       this.callback,
       this.topics
     )
+    console.log(`### Resubscribed to topics:\n${topics}`)
   }
 }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -77,7 +77,6 @@ export default class Stream<T> {
       this.callback,
       this.topics
     )
-    console.log('Subscribe to topics in start!')
     await this.listenForDisconnect()
   }
 
@@ -86,14 +85,12 @@ export default class Stream<T> {
     // Save the callback function on the class so we can clean up later
     this._disconnectCallback = async (connection: Connection) => {
       if (connection.remotePeer.toB58String() === peer?.id?.toB58String()) {
-        console.log('### Disconnect callback called!')
         console.log(`Connection to peer ${connection.remoteAddr} lost`)
         while (true) {
           try {
             if (!this.callback) {
               return
             }
-            console.log('Subscribe to topics in disconnect callback!')
             this.unsubscribeFn = await this.client.waku.filter.subscribe(
               this.callback,
               this.topics
@@ -108,7 +105,6 @@ export default class Stream<T> {
       }
     }
 
-    console.log('### Init disconnect callback!')
     this.client.waku.libp2p.connectionManager.on(
       'peer:disconnect',
       this._disconnectCallback
@@ -172,12 +168,10 @@ export default class Stream<T> {
     return new Promise((resolve) => this.resolvers.unshift(resolve))
   }
 
-  // Unsubscribe and resubscribe with new topics.
+  // Update the list of topics and unsubscribe to trigger a disconnect & new subscription.
   async resetTopics(topics: string[]): Promise<void> {
-    console.log(`New topics: ${topics}`)
     this.topics = topics
     if (this.unsubscribeFn) {
-      console.log('### Unsubscribe!')
       await this.unsubscribeFn()
     }
   }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -73,9 +73,9 @@ export default class Stream<T> {
       }
       // Check to see if we should update the stream's content topic subscription
       if (contentTopicUpdater) {
-        const newTopics = contentTopicUpdater(msg)
-        if (newTopics) {
-          this.resubscribeToTopics(newTopics)
+        const topics = contentTopicUpdater(msg)
+        if (topics) {
+          this.resubscribeToTopics(topics)
         }
       }
       // is there a Promise already pending?

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -15,7 +15,7 @@ export type MessageFilter = (msg: Message) => boolean
  * As such can be used with constructs like for-await-of, yield*, array destructing, etc.
  */
 export default class Stream<T> {
-  topic: string
+  topics: string[]
   client: Client
   // queue of incoming Waku messages
   messages: T[]
@@ -31,13 +31,13 @@ export default class Stream<T> {
 
   constructor(
     client: Client,
-    topic: string,
+    topics: string[],
     messageTransformer: MessageTransformer<T>,
     messageFilter?: MessageFilter
   ) {
     this.messages = []
     this.resolvers = []
-    this.topic = topic
+    this.topics = topics
     this.client = client
     this.callback = this.newMessageCallback(messageTransformer, messageFilter)
   }
@@ -75,7 +75,7 @@ export default class Stream<T> {
 
     this.unsubscribeFn = await this.client.waku.filter.subscribe(
       this.callback,
-      [this.topic]
+      this.topics
     )
     await this.listenForDisconnect()
   }
@@ -93,7 +93,7 @@ export default class Stream<T> {
             }
             this.unsubscribeFn = await this.client.waku.filter.subscribe(
               this.callback,
-              [this.topic]
+              this.topics
             )
             console.log(`Connection to peer ${connection.remoteAddr} restored`)
             return

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -80,6 +80,17 @@ export default class Conversations {
     )
   }
 
+  async streamAllMessages(): Promise<Stream<Message>> {
+    const peerAddresses = (await this.list()).map(
+      (conversation) => conversation.peerAddress
+    )
+    const stream = Stream.create<Message>(this.client, ...) // Need to generate the topics from the peer addresses, and specify a message transformer + filter
+    for await (const conversation of await this.stream()) {
+      // Somehow modify the stream above to include the right topics
+    }
+    return stream
+  }
+
   /**
    * Creates a new conversation for the given address. Will throw an error if the peer is not found in the XMTP network
    */

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -85,7 +85,7 @@ export default class Conversations {
   }
 
   /**
-   * Returns a stream for all new messages from all existing and new conversations.
+   * Returns a stream for all new messages from existing and new conversations.
    */
   async streamAllMessages(): Promise<Stream<Message>> {
     const conversations = await this.list()

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -108,7 +108,7 @@ export default class Conversations {
         // No need to update if we're already subscribed
         return undefined
       }
-      dmAddresses.push(this.getPeerAddress(msg))
+      dmAddresses.push(peerAddress)
       return this.buildTopicsForAllMessages(dmAddresses, introTopic)
     }
 

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -87,16 +87,21 @@ export default class Conversations {
     const messagesStream =
       this.client.streamAllConversationMessages(peerAddresses)
 
-    // TODO(elise): de-dupe conversations before triggering the unsubscribe.
     for await (const conversation of await this.stream()) {
-      console.log('New conversation: ' + conversation.peerAddress)
-      const newAddresses = (await this.list()).map(
-        (conversation) => conversation.peerAddress
-      )
-      const newTopics = newAddresses.map((peerAddress) =>
+      // TODO(elise): append the new conversation once unsubscribing is confirmed.
+      // Right now this should just trigger a resubscribe with the same addresses.
+
+      // if (!peerAddresses.includes(conversation.peerAddress)) {
+      // peerAddresses.push(conversation.peerAddress)
+      // }
+      // console.log('New conversation: ' + conversation.peerAddress)
+      // const newAddresses = (await this.list()).map(
+      //   (conversation) => conversation.peerAddress
+      // )
+      const newTopics = peerAddresses.map((peerAddress) =>
         buildDirectMessageTopic(peerAddress, this.client.address)
       )
-      ;(await messagesStream).resetTopics(newTopics)
+      ;(await messagesStream).resubscribeToTopics(newTopics)
     }
 
     return messagesStream

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -89,10 +89,9 @@ export default class Conversations {
    */
   async streamAllMessages(): Promise<Stream<Message>> {
     const conversations = await this.list()
-    const dmAddresses: string[] = []
-    for (const conversation of conversations) {
-      dmAddresses.push(conversation.peerAddress)
-    }
+    const dmAddresses: string[] = conversations.map(
+      (conversation) => conversation.peerAddress
+    )
     const introTopic = buildUserIntroTopic(this.client.address)
     const topics = this.buildTopicsForAllMessages(dmAddresses, introTopic)
 

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -87,17 +87,16 @@ export default class Conversations {
     const messagesStream =
       this.client.streamAllConversationMessages(peerAddresses)
 
-    // TODO(elise): unsubscribe message stream and resubscribe with new topics. use concat?
+    // TODO(elise): de-dupe conversations before triggering the unsubscribe.
     for await (const conversation of await this.stream()) {
       console.log('New conversation: ' + conversation.peerAddress)
       const newAddresses = (await this.list()).map(
         (conversation) => conversation.peerAddress
       )
-      // TODO(elise): Strip this out to match above?
-      const topics = newAddresses.map((peerAddress) =>
+      const newTopics = newAddresses.map((peerAddress) =>
         buildDirectMessageTopic(peerAddress, this.client.address)
       )
-      ;(await messagesStream).resetTopics(topics)
+      ;(await messagesStream).resetTopics(newTopics)
     }
 
     return messagesStream

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -86,18 +86,22 @@ describe('conversations', () => {
     const aliceBob = await alice.conversations.newConversation(bob.address)
     const bobAlice = await bob.conversations.newConversation(alice.address)
 
-    await aliceBob.send('gm alice - bob')
+    await aliceBob.send('gm alice -bob')
     await sleep(1000)
     const existingConversations = await alice.conversations.list()
     expect(existingConversations).toHaveLength(1)
 
     const stream = await alice.conversations.streamAllMessages()
-    await bobAlice.send('gm bob - alice')
+    await bobAlice.send('gm bob -alice')
 
     let numMessages = 0
     for await (const message of stream) {
       numMessages++
+      if (numMessages == 1) {
+        expect(message.content).toBe('gm bob -alice')
+      }
       if (numMessages == 2) {
+        expect(message.content).toBe('gm. hope you have a good day')
         break
       }
       await aliceBob.send('gm. hope you have a good day')

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -1,6 +1,10 @@
 import { newLocalDockerClient } from './../helpers'
 import { Client } from '../../src'
-import { sleep } from '../../src/utils'
+import {
+  buildDirectMessageTopic,
+  buildUserIntroTopic,
+  sleep,
+} from '../../src/utils'
 
 describe('conversations', () => {
   let alice: Client
@@ -67,14 +71,19 @@ describe('conversations', () => {
     for await (const message of stream) {
       numMessages++
       if (numMessages == 1) {
+        expect(message.contentTopic).toBe(buildUserIntroTopic(alice.address))
         expect(message.content).toBe('gm alice -charlie')
         await bobAlice.send('gm alice -bob')
       }
       if (numMessages == 2) {
+        expect(message.contentTopic).toBe(buildUserIntroTopic(alice.address))
         expect(message.content).toBe('gm alice -bob')
         await aliceCharlie.send('gm charlie -alice')
       }
       if (numMessages == 3) {
+        expect(message.contentTopic).toBe(
+          buildDirectMessageTopic(alice.address, charlie.address)
+        )
         expect(message.content).toBe('gm charlie -alice')
         break
       }
@@ -98,9 +107,15 @@ describe('conversations', () => {
     for await (const message of stream) {
       numMessages++
       if (numMessages == 1) {
+        expect(message.contentTopic).toBe(
+          buildDirectMessageTopic(alice.address, bob.address)
+        )
         expect(message.content).toBe('gm bob -alice')
       }
       if (numMessages == 2) {
+        expect(message.contentTopic).toBe(
+          buildDirectMessageTopic(alice.address, bob.address)
+        )
         expect(message.content).toBe('gm. hope you have a good day')
         break
       }


### PR DESCRIPTION
Closes https://github.com/xmtp/xmtp-js/issues/92

### Summary

This PR introduces a `Conversations#streamAllMessages()` API that will listen for new messages for both new and existing conversations.

The implementation is to subscribe to multiple content topics - any existing DM topics and the intro topic. The intro topic is to support the fresh account scenario and the new conversation scenario. When we detect a new conversation, we update the stream's content topics to include the new DM topic.

Note: In order to detect a new conversation, I save the `contentTopic` to the `Message` so I can tell if it is an intro topic when receiving it.

### Tested scenarios
- [x] New account without any conversations receives new messages
- [x] Existing account receives new messages for new conversations
- [x] Existing account receives new messages for existing conversations