### PR TITLE
Return message upon sending

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -312,16 +312,18 @@ export default class Client {
     }
     const timestamp = options?.timestamp || new Date()
     const msg = await this.encodeMessage(recipient, timestamp, content, options)
+    const msgBytes = msg.toBytes()
+
     await Promise.all(
       topics.map(async (topic) => {
-        const wakuMsg = await WakuMessage.fromBytes(msg.toBytes(), topic, {
+        const wakuMsg = await WakuMessage.fromBytes(msgBytes, topic, {
           timestamp,
         })
         return this.sendWakuMessage(wakuMsg)
       })
     )
 
-    return msg
+    return this.decodeMessage(msgBytes, topics[0])
   }
 
   private async sendWakuMessage(msg: WakuMessage): Promise<void> {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -290,7 +290,7 @@ export default class Client {
     peerAddress: string,
     content: any,
     options?: SendOptions
-  ): Promise<void> {
+  ): Promise<Message> {
     let topics: string[]
     const recipient = await this.getUserContact(peerAddress)
 
@@ -320,6 +320,8 @@ export default class Client {
         return this.sendWakuMessage(wakuMsg)
       })
     )
+
+    return msg
   }
 
   private async sendWakuMessage(msg: WakuMessage): Promise<void> {

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -36,7 +36,7 @@ export default class Conversation {
   async send(
     message: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     options?: SendOptions
-  ): Promise<void> {
-    await this.client.sendMessage(this.peerAddress, message, options)
+  ): Promise<Message> {
+    return this.client.sendMessage(this.peerAddress, message, options)
   }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -33,7 +33,7 @@ export default class Conversation {
   /**
    * Send a message into the conversation
    */
-  async send(
+  send(
     message: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     options?: SendOptions
   ): Promise<Message> {

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -96,6 +96,8 @@ describe('Client', () => {
         // alice sends intro
         const sentMessage = await alice.sendMessage(bob.address, 'hi bob!')
         assert.equal(sentMessage.content, 'hi bob!')
+        assert.ok(sentMessage.id)
+        assert.ok(sentMessage.sent)
         let msg = await aliceIntros.next()
         assert.equal(msg.value.content, 'hi bob!')
 

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -94,7 +94,8 @@ describe('Client', () => {
         const aliceBob = await alice.streamConversationMessages(bob.address)
 
         // alice sends intro
-        await alice.sendMessage(bob.address, 'hi bob!')
+        const sentMessage = await alice.sendMessage(bob.address, 'hi bob!')
+        assert.equal(sentMessage.content, 'hi bob!')
         let msg = await aliceIntros.next()
         assert.equal(msg.value.content, 'hi bob!')
 


### PR DESCRIPTION
## Summary
Through conversations with developers we realized that there is demand for returning the sent message from the `sendMessage` function. This can be used for immediately updating the UI before confirmation.

This PR adds a return value to `sendMessage`. This should be a non-breaking change as the API previously returned `void`.