### PR TITLE
fix: createToken wallet address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^1.2.0",
+        "big-integer": "^1.6.51",
         "ethers": "^5.5.3",
         "node-localstorage": "^2.2.1"
       },
@@ -3575,6 +3576,14 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/bn.js": {
       "version": "4.12.0",
@@ -16293,6 +16302,11 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
       "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==",
       "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "bn.js": {
       "version": "4.12.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^1.2.0",
+    "big-integer": "^1.6.51",
     "ethers": "^5.5.3",
     "node-localstorage": "^2.2.1"
   },

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -1,6 +1,7 @@
 import { messageApi } from '@xmtp/proto'
 import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
 import { retry, sleep } from './utils'
+import bigInt from 'big-integer'
 export const { MessageApi, SortDirection } = messageApi
 
 const RETRY_SLEEP_TIME = 100
@@ -39,7 +40,7 @@ export type SubscribeCallback = NotifyStreamEntityArrival<messageApi.Envelope>
 export type UnsubscribeFn = () => Promise<void>
 
 const toNanoString = (d: Date | undefined): undefined | string => {
-  return d && (d.valueOf() * 1_000_000).toFixed(0)
+  return d && bigInt(d.valueOf()).multiply(1_000_000).toString()
 }
 
 const isAbortError = (err?: Error): boolean => {

--- a/src/authn/AuthData.ts
+++ b/src/authn/AuthData.ts
@@ -13,7 +13,7 @@ export default class AuthData implements authnProto.AuthData {
     timestamp = timestamp || new Date()
     return new AuthData({
       walletAddr: walletAddr,
-      createdNs: timestamp.getTime() * 1000,
+      createdNs: timestamp.getTime() * 1000000,
     })
   }
 

--- a/src/authn/Authenticator.ts
+++ b/src/authn/Authenticator.ts
@@ -17,7 +17,7 @@ export default class Authenticator {
 
   async createToken(timestamp?: Date): Promise<Token> {
     const authData = AuthData.create(
-      this.identityKey.publicKey.getEthereumAddress(),
+      this.identityKey.publicKey.walletSignatureAddress(),
       timestamp || new Date()
     )
     const authDataBytes = authData.toBytes()

--- a/src/authn/Token.ts
+++ b/src/authn/Token.ts
@@ -35,4 +35,8 @@ export default class Token implements authn.Token {
   static fromBytes(bytes: Uint8Array): Token {
     return new Token(authn.Token.decode(bytes))
   }
+
+  toBase64(): string {
+    return Buffer.from(this.toBytes()).toString('base64url')
+  }
 }

--- a/test/authn/Authn.test.ts
+++ b/test/authn/Authn.test.ts
@@ -23,7 +23,7 @@ describe('authn', () => {
     const token = await authenticator.createToken(timestamp)
 
     expect(token.authData.walletAddr).toEqual(
-      privateKey.publicKey.getEthereumAddress()
+      privateKey.publicKey.walletSignatureAddress()
     )
     expect(token.authData.createdNs).toEqual(+timestamp * 1000)
     expect(token.identityKey.timestamp).toEqual(privateKey.publicKey.timestamp)

--- a/test/authn/Authn.test.ts
+++ b/test/authn/Authn.test.ts
@@ -43,7 +43,8 @@ describe('authn', () => {
 
   it('round trips safely', async () => {
     const originalToken = await authenticator.createToken()
-    const newToken = Token.fromBytes(originalToken.toBytes())
+    const bytes = originalToken.toBytes()
+    const newToken = Token.fromBytes(bytes)
     expect(originalToken.authData).toEqual(newToken.authData)
     expect(originalToken.toBytes()).toEqual(newToken.toBytes())
   })


### PR DESCRIPTION
I tried to use the branch to generate a token sample to bring over to xmtp-node-go to test compatibility. The wallet address wasn't matching so that's how I noticed this.

Also adding `toBase64()` since that's how I'm assuming we'll be embedding the token in the request header. Not sure if this is the right way to do this.