### PR TITLE
Force new version

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -108,7 +108,7 @@ export default class ApiClient {
         if (isAbortError(err)) {
           console.log('AbortError detected. Stream ending')
         } else {
-          console.log('Error detected. Resubscribing', err)
+          console.log('Subscription error detected. Resubscribing', err)
           // If connection was initiated less than 1 second ago, sleep for a bit
           // TODO: exponential backoff + eventually giving up
           if (+new Date() - startTime < 1000) {


### PR DESCRIPTION
It seems that our `semantic-release` system isn't able to read commit messages from squashed commits. This led to the last PR not generating a release of the `xmtp-js` NPM package.

I have a [separate issue](https://github.com/xmtp-labs/hq/issues/653) to solve this, but in the meantime I am creating a new version through a new commit.