### PR TITLE
Lock proto version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^1.2.0",
+        "@xmtp/proto": "1.2.0",
         "cross-fetch": "^3.1.5",
         "ethers": "^5.5.3",
         "js-waku": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^1.2.0",
+    "@xmtp/proto": "1.2.0",
     "cross-fetch": "^3.1.5",
     "ethers": "^5.5.3",
     "js-waku": "^0.24.0",

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -79,7 +79,7 @@ export default class Message implements proto.V1Message {
   }
 
   get sent(): Date | undefined {
-    return this.header ? new Date(this.header?.timestamp.toNumber()) : undefined
+    return this.header ? new Date(this.header?.timestamp) : undefined
   }
 
   // wallet address derived from the signature of the message sender

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -79,9 +79,7 @@ export default class Message implements proto.V1Message {
   }
 
   get sent(): Date | undefined {
-    return this.header
-      ? new Date(this.header?.timestamp.div(1_000_000).toNumber())
-      : undefined
+    return this.header ? new Date(this.header?.timestamp.toNumber()) : undefined
   }
 
   // wallet address derived from the signature of the message sender

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -79,7 +79,9 @@ export default class Message implements proto.V1Message {
   }
 
   get sent(): Date | undefined {
-    return this.header ? new Date(this.header?.timestamp) : undefined
+    return this.header
+      ? new Date(this.header?.timestamp.div(1_000_000).toNumber())
+      : undefined
   }
 
   // wallet address derived from the signature of the message sender


### PR DESCRIPTION
## Summary
We incorrectly tagged a breaking change as a patch release in `@xmtp/proto`, which caused us to accidentally upgrade to the latest version.