### PR TITLE
Pass a `Headers` object in our publish requests

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -109,7 +109,7 @@ export default class ApiClient {
           {
             pathPrefix: this.pathPrefix,
             mode: 'cors',
-            headers: { Authorization: `Bearer ${authToken}` },
+            headers: new Headers({ Authorization: `Bearer ${authToken}` }),
           },
         ],
         this.maxRetries,

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -154,9 +154,7 @@ describe('Publish', () => {
     expect(publishMock).toHaveBeenCalledWith(expectedRequest, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
-      headers: {
-        Authorization: `Bearer ${AUTH_TOKEN}`,
-      },
+      headers: new Headers({ Authorization: `Bearer ${AUTH_TOKEN}` }),
     })
   })
 


### PR DESCRIPTION
This resolves an issue with React Native's `fetch` API specific to Android where before it would error with `TypeError: Network request failed`. Luckily, I found [someone else who ran into this](https://stackoverflow.com/a/55238033) and passing in a new `Headers` object in instead of the json fixes the issue. I confirmed it still works on iOS as well.