### PR TITLE
Fix bug with limit parameter

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -181,7 +181,7 @@ export default class ApiClient {
       for (const envelope of page) {
         out.push(envelope)
         if (limit && out.length === limit) {
-          break
+          return out
         }
       }
     }

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -54,6 +54,16 @@ describe('Query', () => {
     })
   })
 
+  it('stops when limit is used', async () => {
+    const apiMock = createQueryMock([createEnvelope()], 3)
+    const result = await client.query(
+      { contentTopics: [CONTENT_TOPIC] },
+      { limit: 2 }
+    )
+    expect(result).toHaveLength(2)
+    expect(apiMock).toHaveBeenCalledTimes(2)
+  })
+
   it('stops when receiving some results and a null cursor', async () => {
     const apiMock = createQueryMock([createEnvelope()], 1)
     const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -350,6 +350,15 @@ describe('Client', () => {
         assert.equal(msg.senderAddress, alice.address)
         assert.equal(msg.content, 'Hello from Alice')
       })
+
+      it('handles limiting page size', async () => {
+        const bobConvo = await alice.conversations.newConversation(bob.address)
+        for (let i = 0; i < 5; i++) {
+          await bobConvo.send('hi')
+        }
+        const messages = await bobConvo.messages({ limit: 2 })
+        expect(messages).toHaveLength(2)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
@killthebuddh4 reported an issue with our use of the limit parameter, which I was able to reproduce, where the SDK was doing more requests than necessary on queries where the limit was less than the total result size.

The issue was caused by the SDK breaking out of an inner loop in a nested loop, but not the outer loop.

This fixes that bug by returning as soon as the limit is reached.

🤦 