### PR TITLE
Proof of Concept: Add node crypto fallback

### DIFF
--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -4,8 +4,8 @@ import PublicKey from './PublicKey'
 import PublicKeyBundle from './PublicKeyBundle'
 import Ciphertext from './Ciphertext'
 import * as ethers from 'ethers'
-import { bytesToHex, getRandomValues, hexToBytes } from './utils'
-import { decrypt, encrypt } from './encryption'
+import { bytesToHex, hexToBytes } from './utils'
+import { decrypt, encrypt, getRandomValues } from './encryption'
 import { NoMatchingPreKeyError } from './errors'
 
 // PrivateKeyBundle bundles the private keys corresponding to a PublicKeyBundle for convenience.

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -4,12 +4,13 @@ import PrivateKeyBundle from './PrivateKeyBundle'
 import PublicKey from './PublicKey'
 import Signature from './Signature'
 import * as utils from './utils'
-import { encrypt, decrypt } from './encryption'
+import { encrypt, decrypt, getRandomValues } from './encryption'
 
 export {
   utils,
   encrypt,
   decrypt,
+  getRandomValues,
   PublicKey,
   PublicKeyBundle,
   PrivateKey,

--- a/src/crypto/utils.ts
+++ b/src/crypto/utils.ts
@@ -1,9 +1,4 @@
 import * as secp from '@noble/secp256k1'
-import { crypto } from './encryption'
-
-export function getRandomValues<T extends ArrayBufferView | null>(array: T): T {
-  return crypto.getRandomValues(array)
-}
 
 export const bytesToHex = secp.utils.bytesToHex
 

--- a/test/crypto/index.test.ts
+++ b/test/crypto/index.test.ts
@@ -4,9 +4,9 @@ import {
   PublicKeyBundle,
   PrivateKeyBundle,
   PrivateKey,
-  utils,
   encrypt,
   decrypt,
+  getRandomValues,
 } from '../../src/crypto'
 import * as ethers from 'ethers'
 
@@ -50,7 +50,7 @@ describe('Crypto', function () {
   })
   it('derives public key from signature', async function () {
     const pri = PrivateKey.generate()
-    const digest = utils.getRandomValues(new Uint8Array(16))
+    const digest = getRandomValues(new Uint8Array(16))
     const sig = await pri.sign(digest)
     const sigPub = sig.getPublicKey(digest)
     assert.ok(sigPub)


### PR DESCRIPTION
The main goal of this PR is to provide a Node fallback when `SubtleCrypto` is not available to make our library more React Native friendly. This is _heavily_ inspired by how `noble-secp256k1` switches between [web & node crypto](https://github.com/paulmillr/noble-secp256k1/blob/2eb78c9f7b33f514e74a72e4af00ba5d0bcbba20/index.ts#L1462-L1465) for all their functionality.

Also, the only `SubtleCrypto` polyfill I found for React Native was `PeculiarVentures/webcrypto` which comes with the following [warning](https://github.com/PeculiarVentures/webcrypto#warning):
>At this time this solution should be considered suitable for research and experimentation, further code and security review is needed before utilization in a production application.

This is a draft PR because I'm unable to actually get this working using Webpack 5. I verified SubtleCrypto still works as expected in the browser, but `nodeCrypto` is undefined in React Native even though `crypto` is polyfilled locally with `crypto-browserify`. Looking at how other libraries are doing this, it seems like they are using Rollup. Do we know if similar functionality is available for Webpack?

I'm open to alternatives as well if you have other ideas!