### PR TITLE
Signed keys and wallet signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "~3.0.0",
+        "@xmtp/proto": "^3.1.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "node-localstorage": "^2.2.1"
@@ -3134,9 +3134,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.0.0.tgz",
-      "integrity": "sha512-JJ2h+1SxzocSBnex5BN900HVglRyGC5M7eypl0rFpugVj4Q4//A67ZtB5rSul74MVRrypNbcYXRZRAwI8U9TBg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.1.0.tgz",
+      "integrity": "sha512-eZDtCifowWEDYCPV7nSdDGlGO1TI6CsfOe7kP9sn8PECvNutYDk1NB7h+7neZLZoHQaO9U6vYrmhgJXVpaJEJw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -15938,9 +15938,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.0.0.tgz",
-      "integrity": "sha512-JJ2h+1SxzocSBnex5BN900HVglRyGC5M7eypl0rFpugVj4Q4//A67ZtB5rSul74MVRrypNbcYXRZRAwI8U9TBg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.1.0.tgz",
+      "integrity": "sha512-eZDtCifowWEDYCPV7nSdDGlGO1TI6CsfOe7kP9sn8PECvNutYDk1NB7h+7neZLZoHQaO9U6vYrmhgJXVpaJEJw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "~3.0.0",
+    "@xmtp/proto": "^3.1.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "node-localstorage": "^2.2.1"

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -1,6 +1,6 @@
 import { contact, publicKey } from '@xmtp/proto'
 import { PublicKeyBundle } from './crypto'
-import PublicKey from './crypto/PublicKey'
+import { PublicKey } from './crypto/PublicKey'
 
 // ContactBundle packages all the infromation which a client uses to advertise on the network.
 export default class ContactBundle implements contact.ContactBundleV1 {

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -1,26 +1,177 @@
 import { privateKey } from '@xmtp/proto'
 import * as secp from '@noble/secp256k1'
 import Long from 'long'
-import Signature from './Signature'
-import PublicKey from './PublicKey'
+import Signature, {
+  ECDSACompactWithRecovery,
+  ecdsaSignerKey,
+  KeySigner,
+} from './Signature'
+import { PublicKey, SignedPublicKey, UnsignedPublicKey } from './PublicKey'
 import Ciphertext from './Ciphertext'
 import { decrypt, encrypt, sha256 } from './encryption'
+import { equalBytes } from './utils'
 
-// PrivateKey represents a secp256k1 private key.
-export default class PrivateKey implements privateKey.PrivateKey {
+// SECP256k1 private key
+type secp256k1 = {
+  bytes: Uint8Array // D big-endian, 32 bytes
+}
+
+// Validate SECP256k1 private key
+function secp256k1Check(key: secp256k1): void {
+  if (key.bytes.length !== 32) {
+    throw new Error(`invalid private key length: ${key.bytes.length}`)
+  }
+}
+
+// A private key signed with another key pair or a wallet.
+export class SignedPrivateKey
+  implements privateKey.SignedPrivateKey, KeySigner
+{
+  createdNs: Long // time the key was generated, ns since epoch
+  secp256k1: secp256k1 // eslint-disable-line camelcase
+  publicKey: SignedPublicKey // caches corresponding PublicKey
+
+  constructor(obj: privateKey.SignedPrivateKey) {
+    if (!obj.secp256k1) {
+      throw new Error('invalid private key')
+    }
+    secp256k1Check(obj.secp256k1)
+    this.secp256k1 = obj.secp256k1
+    this.createdNs = obj.createdNs
+    if (!obj.publicKey) {
+      throw new Error('missing public key')
+    }
+    this.publicKey = new SignedPublicKey(obj.publicKey)
+  }
+
+  // Create a random key pair signed by the signer.
+  static async generate(signer: KeySigner): Promise<SignedPrivateKey> {
+    const secp256k1 = {
+      bytes: secp.utils.randomPrivateKey(),
+    }
+    const createdNs = Long.fromNumber(new Date().getTime()).mul(1000000)
+    const unsigned = new UnsignedPublicKey({
+      secp256k1Uncompressed: {
+        bytes: secp.getPublicKey(secp256k1.bytes),
+      },
+      createdNs: createdNs,
+    })
+    const signed = await signer.signKey(unsigned)
+    return new SignedPrivateKey({
+      secp256k1,
+      createdNs,
+      publicKey: signed,
+    })
+  }
+
+  // Time the key was generated.
+  generated(): Date | undefined {
+    return new Date(this.createdNs.div(1000000).toNumber())
+  }
+
+  // Sign provided digest.
+  async sign(digest: Uint8Array): Promise<Signature> {
+    const [signature, recovery] = await secp.sign(
+      digest,
+      this.secp256k1.bytes,
+      {
+        recovered: true,
+        der: false,
+      }
+    )
+    return new Signature({
+      ecdsaCompact: { bytes: signature, recovery },
+    })
+  }
+
+  // Sign provided public key.
+  async signKey(pub: UnsignedPublicKey): Promise<SignedPublicKey> {
+    const keyBytes = pub.toBytes()
+    const digest = await sha256(keyBytes)
+    const signature = await this.sign(digest)
+    return new SignedPublicKey({
+      keyBytes,
+      signature,
+    })
+  }
+
+  // Return public key of the signer of the provided signed key.
+  static async signerKey(
+    key: SignedPublicKey,
+    signature: ECDSACompactWithRecovery
+  ): Promise<UnsignedPublicKey | undefined> {
+    const digest = await sha256(key.bytesToSign())
+    return ecdsaSignerKey(digest, signature)
+  }
+
+  // Derive shared secret from peer's PublicKey;
+  // the peer can derive the same secret using their private key and our public key.
+  sharedSecret(peer: SignedPublicKey | UnsignedPublicKey): Uint8Array {
+    return secp.getSharedSecret(
+      this.secp256k1.bytes,
+      peer.secp256k1Uncompressed.bytes,
+      false
+    )
+  }
+
+  // encrypt plain bytes using a shared secret derived from peer's PublicKey;
+  // additionalData allows including unencrypted parts of a Message in the authentication
+  // protection provided by the encrypted part (to make the whole Message tamper evident)
+  encrypt(
+    plain: Uint8Array,
+    peer: UnsignedPublicKey,
+    additionalData?: Uint8Array
+  ): Promise<Ciphertext> {
+    const secret = this.sharedSecret(peer)
+    return encrypt(plain, secret, additionalData)
+  }
+
+  // decrypt Ciphertext using a shared secret derived from peer's PublicKey;
+  // throws if any part of Ciphertext or additionalData was tampered with
+  decrypt(
+    encrypted: Ciphertext,
+    peer: UnsignedPublicKey,
+    additionalData?: Uint8Array
+  ): Promise<Uint8Array> {
+    const secret = this.sharedSecret(peer)
+    return decrypt(encrypted, secret, additionalData)
+  }
+
+  // Does the provided PublicKey correspond to this PrivateKey?
+  matches(key: SignedPublicKey): boolean {
+    return this.publicKey.equals(key)
+  }
+
+  // Is other the same/equivalent key?
+  equals(other: this): boolean {
+    return (
+      equalBytes(this.secp256k1.bytes, other.secp256k1.bytes) &&
+      this.publicKey.equals(other.publicKey)
+    )
+  }
+
+  // Encode this key into bytes.
+  toBytes(): Uint8Array {
+    return privateKey.SignedPrivateKey.encode(this).finish()
+  }
+
+  // Decode key from bytes.
+  static fromBytes(bytes: Uint8Array): SignedPrivateKey {
+    return new SignedPrivateKey(privateKey.SignedPrivateKey.decode(bytes))
+  }
+}
+
+// LEGACY: PrivateKey represents a secp256k1 private key.
+export class PrivateKey implements privateKey.PrivateKey {
   timestamp: Long
-  secp256k1: privateKey.PrivateKey_Secp256k1 | undefined // eslint-disable-line camelcase
+  secp256k1: secp256k1 // eslint-disable-line camelcase
   publicKey: PublicKey // caches corresponding PublicKey
 
   constructor(obj: privateKey.PrivateKey) {
     if (!obj.secp256k1) {
       throw new Error('invalid private key')
     }
-    if (obj.secp256k1.bytes.length !== 32) {
-      throw new Error(
-        `invalid private key length: ${obj.secp256k1.bytes.length}`
-      )
-    }
+    secp256k1Check(obj.secp256k1)
     this.timestamp = obj.timestamp
     this.secp256k1 = obj.secp256k1
     if (!obj.publicKey) {
@@ -48,17 +199,11 @@ export default class PrivateKey implements privateKey.PrivateKey {
   }
 
   generated(): Date | undefined {
-    if (!this.timestamp) {
-      return undefined
-    }
     return new Date(this.timestamp.toNumber())
   }
 
   // sign provided digest
   async sign(digest: Uint8Array): Promise<Signature> {
-    if (!this.secp256k1) {
-      throw new Error('invalid private key')
-    }
     const [signature, recovery] = await secp.sign(
       digest,
       this.secp256k1.bytes,
@@ -74,9 +219,6 @@ export default class PrivateKey implements privateKey.PrivateKey {
 
   // sign provided public key
   async signKey(pub: PublicKey): Promise<PublicKey> {
-    if (!pub.secp256k1Uncompressed) {
-      throw new Error('invalid public key')
-    }
     const digest = await sha256(pub.bytesToSign())
     pub.signature = await this.sign(digest)
     return pub
@@ -85,12 +227,6 @@ export default class PrivateKey implements privateKey.PrivateKey {
   // derive shared secret from peer's PublicKey;
   // the peer can derive the same secret using their PrivateKey and our PublicKey
   sharedSecret(peer: PublicKey): Uint8Array {
-    if (!peer.secp256k1Uncompressed) {
-      throw new Error('invalid public key')
-    }
-    if (!this.secp256k1) {
-      throw new Error('invalid private key')
-    }
     return secp.getSharedSecret(
       this.secp256k1.bytes,
       peer.secp256k1Uncompressed.bytes,
@@ -121,15 +257,17 @@ export default class PrivateKey implements privateKey.PrivateKey {
     return decrypt(encrypted, secret, additionalData)
   }
 
-  // Does the provided PublicKey correspnd to this PrivateKey?
+  // Does the provided PublicKey correspond to this PrivateKey?
   matches(key: PublicKey): boolean {
     return this.publicKey.equals(key)
   }
 
+  // Encode this key into bytes.
   toBytes(): Uint8Array {
     return privateKey.PrivateKey.encode(this).finish()
   }
 
+  // Decode key from bytes.
   static fromBytes(bytes: Uint8Array): PrivateKey {
     return new PrivateKey(privateKey.PrivateKey.decode(bytes))
   }

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -1,5 +1,5 @@
 import { publicKey } from '@xmtp/proto'
-import PublicKey from './PublicKey'
+import { PublicKey } from './PublicKey'
 
 // PublicKeyBundle packages all the keys that a participant should advertise.
 // The PreKey must be signed by the IdentityKey.

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -1,30 +1,85 @@
 import { signature } from '@xmtp/proto'
 import Long from 'long'
 import * as secp from '@noble/secp256k1'
-import PublicKey from './PublicKey'
+import { PublicKey, UnsignedPublicKey, SignedPublicKey } from './PublicKey'
+import { SignedPrivateKey } from './PrivateKey'
+import { Signer, utils } from 'ethers'
+import { bytesToHex, equalBytes, hexToBytes } from './utils'
 
-// Signature represents an ECDSA signature with recovery bit.
+// ECDSA signature with recovery bit.
+export type ECDSACompactWithRecovery = {
+  bytes: Uint8Array // compact representation [ R || S ], 64 bytes
+  recovery: number // recovery bit
+}
+
+// Validate signature.
+function ecdsaCheck(sig: ECDSACompactWithRecovery): void {
+  if (sig.bytes.length !== 64) {
+    throw new Error(`invalid signature length: ${sig.bytes.length}`)
+  }
+  if (sig.recovery !== 0 && sig.recovery !== 1) {
+    throw new Error(`invalid recovery bit: ${sig.recovery}`)
+  }
+}
+
+// Compare signatures.
+function ecdsaEqual(
+  a: ECDSACompactWithRecovery,
+  b: ECDSACompactWithRecovery
+): boolean {
+  return a.recovery === b.recovery && equalBytes(a.bytes, b.bytes)
+}
+
+// Derive public key of the signer from the digest and the signature.
+export function ecdsaSignerKey(
+  digest: Uint8Array,
+  signature: ECDSACompactWithRecovery
+): UnsignedPublicKey | undefined {
+  const bytes = secp.recoverPublicKey(
+    digest,
+    signature.bytes,
+    signature.recovery
+  )
+  return bytes
+    ? new UnsignedPublicKey({
+        secp256k1Uncompressed: { bytes },
+        createdNs: Long.fromNumber(0),
+      })
+    : undefined
+}
+
 export default class Signature implements signature.Signature {
-  ecdsaCompact: signature.Signature_ECDSACompact | undefined // eslint-disable-line camelcase
-  walletEcdsaCompact: signature.Signature_WalletECDSACompact | undefined // eslint-disable-line camelcase
+  // SECP256k1/SHA256 ECDSA signature
+  ecdsaCompact: ECDSACompactWithRecovery | undefined // eslint-disable-line camelcase
+  // SECP256k1/keccak256 ECDSA signature created with ethers.Signer.signMessage (see WalletSigner)
+  walletEcdsaCompact: ECDSACompactWithRecovery | undefined // eslint-disable-line camelcase
 
   constructor(obj: Partial<signature.Signature>) {
-    if (!obj.ecdsaCompact) {
+    if (obj.ecdsaCompact) {
+      ecdsaCheck(obj.ecdsaCompact)
+      this.ecdsaCompact = obj.ecdsaCompact
+    } else if (obj.walletEcdsaCompact) {
+      ecdsaCheck(obj.walletEcdsaCompact)
+      this.walletEcdsaCompact = obj.walletEcdsaCompact
+    } else {
       throw new Error('invalid signature')
     }
-    if (obj.ecdsaCompact.bytes.length !== 64) {
-      throw new Error(
-        `invalid signature length: ${obj.ecdsaCompact.bytes.length}`
-      )
-    }
-    this.ecdsaCompact = obj.ecdsaCompact
-    if (obj.ecdsaCompact.recovery !== 0 && obj.ecdsaCompact.recovery !== 1) {
-      throw new Error(`invalid recovery bit: ${obj.ecdsaCompact.recovery}`)
-    }
-    this.ecdsaCompact.recovery = obj.ecdsaCompact.recovery
   }
 
-  // Return the public key that validates this signature given the provided digest.
+  // Return the public key that validates provided key's signature.
+  async signerKey(
+    key: SignedPublicKey
+  ): Promise<UnsignedPublicKey | undefined> {
+    if (this.ecdsaCompact) {
+      return SignedPrivateKey.signerKey(key, this.ecdsaCompact)
+    } else if (this.walletEcdsaCompact) {
+      return WalletSigner.signerKey(key, this.walletEcdsaCompact)
+    } else {
+      return undefined
+    }
+  }
+
+  // LEGACY: Return the public key that validates this signature given the provided digest.
   // Return undefined if the signature is malformed.
   getPublicKey(digest: Uint8Array): PublicKey | undefined {
     if (!this.ecdsaCompact) {
@@ -43,11 +98,79 @@ export default class Signature implements signature.Signature {
       : undefined
   }
 
+  // Is this the same/equivalent signature as other?
+  equals(other: Signature): boolean {
+    if (this.ecdsaCompact && other.ecdsaCompact) {
+      return ecdsaEqual(this.ecdsaCompact, other.ecdsaCompact)
+    }
+    if (this.walletEcdsaCompact && other.walletEcdsaCompact) {
+      return ecdsaEqual(this.walletEcdsaCompact, other.walletEcdsaCompact)
+    }
+    return false
+  }
+
   toBytes(): Uint8Array {
     return signature.Signature.encode(this).finish()
   }
 
   static fromBytes(bytes: Uint8Array): Signature {
     return new Signature(signature.Signature.decode(bytes))
+  }
+}
+
+// A signer that can be used to sign public keys.
+export interface KeySigner {
+  signKey(key: UnsignedPublicKey): Promise<SignedPublicKey>
+}
+
+// A wallet based KeySigner.
+export class WalletSigner implements KeySigner {
+  wallet: Signer
+
+  constructor(wallet: Signer) {
+    this.wallet = wallet
+  }
+
+  static identitySigRequestText(keyBytes: Uint8Array): string {
+    // Note that an update to this signature request text will require
+    // addition of backward compatibility for existing signatures
+    // and/or a migration; otherwise clients will fail to verify previously
+    // signed keys.
+    return (
+      'XMTP : Create Identity\n' +
+      `${bytesToHex(keyBytes)}\n` +
+      '\n' +
+      'For more info: https://xmtp.org/signatures/'
+    )
+  }
+
+  static signerKey(
+    key: SignedPublicKey,
+    signature: ECDSACompactWithRecovery
+  ): UnsignedPublicKey | undefined {
+    const digest = hexToBytes(
+      utils.hashMessage(this.identitySigRequestText(key.bytesToSign()))
+    )
+    return ecdsaSignerKey(digest, signature)
+  }
+
+  async signKey(key: UnsignedPublicKey): Promise<SignedPublicKey> {
+    const keyBytes = key.toBytes()
+    const sigString = await this.wallet.signMessage(
+      WalletSigner.identitySigRequestText(keyBytes)
+    )
+    const eSig = utils.splitSignature(sigString)
+    const r = hexToBytes(eSig.r)
+    const s = hexToBytes(eSig.s)
+    const sigBytes = new Uint8Array(64)
+    sigBytes.set(r)
+    sigBytes.set(s, r.length)
+    const signature = new Signature({
+      walletEcdsaCompact: {
+        bytes: sigBytes,
+        recovery: eSig.recoveryParam,
+      },
+    })
+    return new SignedPublicKey({ keyBytes, signature })
   }
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,8 +1,8 @@
 import PublicKeyBundle from './PublicKeyBundle'
-import PrivateKey from './PrivateKey'
+import { SignedPrivateKey, PrivateKey } from './PrivateKey'
 import PrivateKeyBundle from './PrivateKeyBundle'
-import PublicKey from './PublicKey'
-import Signature from './Signature'
+import { UnsignedPublicKey, SignedPublicKey, PublicKey } from './PublicKey'
+import Signature, { WalletSigner } from './Signature'
 import * as utils from './utils'
 import { encrypt, decrypt } from './encryption'
 
@@ -10,9 +10,13 @@ export {
   utils,
   encrypt,
   decrypt,
+  UnsignedPublicKey,
+  SignedPublicKey,
   PublicKey,
   PublicKeyBundle,
   PrivateKey,
+  SignedPrivateKey,
   PrivateKeyBundle,
   Signature,
+  WalletSigner,
 }

--- a/test/ContactBundle.test.ts
+++ b/test/ContactBundle.test.ts
@@ -1,6 +1,5 @@
 import * as assert from 'assert'
 import ContactBundle from '../src/ContactBundle'
-import * as ethers from 'ethers'
 import { PrivateKeyBundle } from '../src'
 
 describe('ContactBundles', function () {

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert'
 import { PrivateKey, PrivateKeyBundle } from '../../src/crypto'
-import * as ethers from 'ethers'
+import { Wallet } from 'ethers'
 import { hexToBytes } from '../../src/crypto/utils'
 
 describe('Crypto', function () {
@@ -9,7 +9,7 @@ describe('Crypto', function () {
       // create a wallet using a generated key
       const bobPri = PrivateKey.generate()
       assert.ok(bobPri.secp256k1)
-      const wallet = new ethers.Wallet(bobPri.secp256k1.bytes)
+      const wallet = new Wallet(bobPri.secp256k1.bytes)
       // generate key bundle
       const bob = await PrivateKeyBundle.generate(wallet)
       // encrypt and serialize the bundle for storage
@@ -48,7 +48,7 @@ describe('Crypto', function () {
         )
       )
       assert.ok(pri.secp256k1)
-      const wallet = new ethers.Wallet(pri.secp256k1.bytes)
+      const wallet = new Wallet(pri.secp256k1.bytes)
       const bundle = await PrivateKeyBundle.generate(wallet)
       const preKey = hexToBytes(
         'f51bd1da9ec2239723ae2cf6a9f8d0ac37546b27e634002c653d23bacfcc67ad'

--- a/test/crypto/PublicKey.test.ts
+++ b/test/crypto/PublicKey.test.ts
@@ -1,10 +1,42 @@
 import * as assert from 'assert'
 import Long from 'long'
-import { PrivateKey, PublicKey, utils } from '../../src/crypto'
-import * as ethers from 'ethers'
+import {
+  PrivateKey,
+  PublicKey,
+  SignedPublicKey,
+  SignedPrivateKey,
+  UnsignedPublicKey,
+  WalletSigner,
+  utils,
+} from '../../src/crypto'
+import { Wallet } from 'ethers'
+import * as secp from '@noble/secp256k1'
 import { hexToBytes } from '../../src/crypto/utils'
 
 describe('Crypto', function () {
+  describe('Signed Keys', function () {
+    it('generate, verify, encode, decode', async function () {
+      const wallet = new Wallet(secp.utils.randomPrivateKey())
+      const keySigner = new WalletSigner(wallet)
+      const idPri = await SignedPrivateKey.generate(keySigner)
+      const idPub = idPri.publicKey
+      const prePri = await SignedPrivateKey.generate(idPri)
+      const prePub = prePri.publicKey
+      assert.ok(idPub.verifyKey(prePub))
+      let signer = await idPub.signerKey()
+      assert.ok(signer)
+      assert.equal(wallet.address, signer.getEthereumAddress())
+      signer = await prePub.signerKey()
+      assert.ok(signer)
+      assert.equal(idPub.getEthereumAddress(), signer.getEthereumAddress())
+      let bytes = idPub.toBytes()
+      const idPub2 = SignedPublicKey.fromBytes(bytes)
+      assert.ok(idPub.equals(idPub2))
+      bytes = idPri.toBytes()
+      const idPri2 = SignedPrivateKey.fromBytes(bytes)
+      assert.ok(idPri.equals(idPri2))
+    })
+  })
   describe('PublicKey', function () {
     it('derives address from public key', function () {
       // using the sample from https://kobl.one/blog/create-full-ethereum-keypair-and-address/
@@ -25,7 +57,9 @@ describe('Crypto', function () {
           '08aaa9dad3ed2f12220a206fd789a6ee2376bb6595b4ebace57c7a79e6e4f1f12c8416d611399eda6c74cb1a4c08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a'
         )
       )
-      const actual = alice.publicKey.identitySigRequestText()
+      const actual = WalletSigner.identitySigRequestText(
+        alice.publicKey.bytesToSign()
+      )
       const expected =
         'XMTP : Create Identity\n08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a\n\nFor more info: https://xmtp.org/signatures/'
       assert.equal(actual, expected)
@@ -35,7 +69,7 @@ describe('Crypto', function () {
       // create a wallet using a generated key
       const alice = PrivateKey.generate()
       assert.ok(alice.secp256k1)
-      const wallet = new ethers.Wallet(alice.secp256k1.bytes)
+      const wallet = new Wallet(alice.secp256k1.bytes)
       // sanity check that we agree with the wallet about the address
       assert.ok(wallet.address, alice.publicKey.getEthereumAddress())
       // sign the public key using the wallet

--- a/test/crypto/index.test.ts
+++ b/test/crypto/index.test.ts
@@ -8,7 +8,6 @@ import {
   encrypt,
   decrypt,
 } from '../../src/crypto'
-import * as ethers from 'ethers'
 
 describe('Crypto', function () {
   it('signs keys and verifies signatures', async function () {


### PR DESCRIPTION
Implements https://github.com/xmtp-labs/hq/issues/678

This is the first step towards implementing xmtp/proto 3.0.0, as most of the other changes depend on the signed key types. In the process I realized that it wasn't possible to accommodate the new signed public key type without introducing a new private key type as well, thus the [v3.1.0](https://github.com/xmtp/proto/pull/16). I tried a less disruptive route of keeping the new key types for marshalled format only, but it proved impossible as information is lost when I tried to roll everything into the pre-existing key types.

This PR
* adds new key classes and marks the pre-existing ones as legacy, i.e.
  * `PublicKey`  =>  `UnsignedPublicKey` & `SignedPublicKey` (note that `PublicKey` now extends `UnsignedPublicKey`)
  * `PrivateKey` => `SignedPrivateKey` (it didn't seem worth it to extract shared bits to a common superclass, there wasn't much to share, the type signatures were off)
* Adds some private object types to replace direct use of the proto types that force undefined checks all over the place, makes the code tidier (`secp256k1`, `secp256k1Uncompressed`, `ECDSACompactWithRecovery`)
* New key types are generated with `SignedPrivateKey.generate(signer: KeySigner)` as the signed keys must be created signed from the beginning. `WalletSigner` should be used to sign a key with a wallet. This deprecates `PublicKey.signWithWallet()`
* `SignedPublicKey.walletSignatureAddress()` now throws for keys that weren't signed by a wallet since we now know if that's the case. `SignedPublicKey.signerKey()` is a new more generic version of it that works for pre-keys as well.
* All the special handling of wallet signatures is now in `WalletSigner` (with some left overs in PublicKey as I didn't want to increase amount of changes there)

The new and old types aren't expected to mix, i.e. there's no support to sign a PublicKey with SignedPrivateKey and such. Many of the methods only refer to types of the compatible type.

There is some cleanup that wasn't strictly necessary, but seemed worthwhile while I was going through this code, e.g. tightening the imports (e.g. making ethers imports more specific).

There is a bit more explicit branching based on the types of things than I'd like, primarily on the Signature that now needs to accommodate two signature types. There's probably a way to map the union on the protocol side to a class hierarchy, but I didn't want to make things even messier than it already is. We may want to re-evaluate though as the number of types grows in the future.


