### PR TITLE
Key manager

### DIFF
--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -1,0 +1,101 @@
+import PrivateKey from './crypto/PrivateKey'
+import PrivateKeyBundle from './crypto/PrivateKeyBundle'
+import PublicKeyBundle from './crypto/PublicKeyBundle'
+
+enum EncryptionAlgorithm {
+  AES_256_GCM_HKDF_SHA_256,
+}
+
+type TopicKeyRecord = {
+  keyMaterial: Uint8Array
+  encryptionAlgorithm: EncryptionAlgorithm
+  allowedSigners: PublicKeyBundle[]
+}
+
+type TopicResult = {
+  // This would never include the client. We can assume you are in every topic available
+  topicKey: TopicKeyRecord
+  contentTopic: string
+}
+
+type WalletTopicRecord = {
+  contentTopic: string
+  createdAt: Date
+}
+
+type ContentTopic = string
+type WalletAddress = string
+
+export default class KeyManager {
+  privateKeyBundle: PrivateKeyBundle
+  private topicKeys: Map<ContentTopic, TopicKeyRecord>
+  private dmTopics: Map<WalletAddress, WalletTopicRecord[]>
+
+  constructor(bundle: PrivateKeyBundle) {
+    this.topicKeys = new Map<ContentTopic, TopicKeyRecord>()
+    this.dmTopics = new Map<WalletAddress, WalletTopicRecord[]>()
+    this.privateKeyBundle = bundle
+  }
+
+  addDirectMessageTopic(
+    contentTopic: string,
+    key: TopicKeyRecord,
+    counterparty: PublicKeyBundle,
+    createdAt: Date
+  ): void {
+    if (this.topicKeys.has(contentTopic)) {
+      throw new Error('Topic key has already been set')
+    }
+    this.topicKeys.set(contentTopic, key)
+
+    const walletAddress = counterparty.identityKey.walletSignatureAddress()
+    const counterpartyTopicList = this.dmTopics.get(walletAddress) || []
+    counterpartyTopicList.push({ contentTopic, createdAt })
+    this.dmTopics.set(walletAddress, counterpartyTopicList)
+  }
+
+  // Would be used to get all information required to decrypt/validate a given message
+  getTopicResult(contentTopic: string): TopicResult | undefined {
+    const topicKey = this.topicKeys.get(contentTopic)
+    if (!topicKey) {
+      return undefined
+    }
+    return {
+      topicKey,
+      contentTopic,
+    }
+  }
+
+  // Would be used to know which topic/key to use to send to a given wallet address
+  getLatestDirectMessageTopic(walletAddress: string): TopicResult | undefined {
+    const walletTopics = this.dmTopics.get(walletAddress)
+    if (!walletTopics || !walletTopics.length) {
+      return undefined
+    }
+    const newestTopic = this.findLatestTopic(walletTopics)
+    return this.getTopicResult(newestTopic.contentTopic)
+  }
+
+  // Would be used to get the topic list to listen for all messages from a given wallet address
+  getAllDirectMessageTopics(walletAddress: string): TopicResult[] {
+    const dmTopics = this.dmTopics
+      .get(walletAddress)
+      ?.map(({ contentTopic }) => this.getTopicResult(contentTopic))
+      .filter((res) => !!res) as TopicResult[]
+
+    return dmTopics || []
+  }
+
+  private findLatestTopic(records: WalletTopicRecord[]): WalletTopicRecord {
+    let latestRecord: WalletTopicRecord | undefined
+    for (const record of records) {
+      if (!latestRecord || record.createdAt > latestRecord.createdAt) {
+        latestRecord = record
+      }
+    }
+    if (!latestRecord) {
+      throw new Error('No record found')
+    }
+    return latestRecord
+  }
+}

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -4,7 +4,9 @@ export enum EncryptionAlgorithm {
   AES_256_GCM_HKDF_SHA_256,
 }
 
-// TopicKeyRecord encapsulates the key, algorithm, and a list of allowed signers
+/**
+ * TopicKeyRecord encapsulates the key, algorithm, and a list of allowed signers
+ */
 export type TopicKeyRecord = {
   keyMaterial: Uint8Array
   encryptionAlgorithm: EncryptionAlgorithm
@@ -14,7 +16,9 @@ export type TopicKeyRecord = {
   allowedSigners: PublicKeyBundle[]
 }
 
-// TopicResult is the public interface for receiving a TopicKey
+/**
+ * TopicResult is the public interface for receiving a TopicKey
+ */
 export type TopicResult = {
   topicKey: TopicKeyRecord
   contentTopic: string
@@ -29,6 +33,9 @@ type WalletTopicRecord = {
 type ContentTopic = string
 type WalletAddress = string
 
+/**
+ * Custom error type for cases where the caller attempted to add a second key to the same topic
+ */
 export class DuplicateTopicError extends Error {
   constructor(topic: string) {
     super(`Topic ${topic} has already been added`)
@@ -50,6 +57,9 @@ const findLatestTopic = (records: WalletTopicRecord[]): WalletTopicRecord => {
   return latestRecord
 }
 
+/**
+ * TopicKeyManager stores the mapping between topics -> keys and wallet addresses -> keys
+ */
 export default class TopicKeyManager {
   // Mapping of content topics to the keys used for decryption on that topic
   private topicKeys: Map<ContentTopic, TopicKeyRecord>
@@ -61,7 +71,14 @@ export default class TopicKeyManager {
     this.dmTopics = new Map<WalletAddress, WalletTopicRecord[]>()
   }
 
-  // Create a TopicKeyRecord for the topic and store it for later access
+  /**
+   * Create a TopicKeyRecord for the topic and store it for later access
+   *
+   * @param contentTopic The topic
+   * @param key TopicKeyRecord that contains the topic key and encryption algorithm
+   * @param counterparty The other user's PublicKeyBundle
+   * @param createdAt Date
+   */
   addDirectMessageTopic(
     contentTopic: string,
     key: TopicKeyRecord,
@@ -79,7 +96,12 @@ export default class TopicKeyManager {
     this.dmTopics.set(walletAddress, counterpartyTopicList)
   }
 
-  // Would be used to get all information required to decrypt/validate a given message
+  /**
+   * Would be used to get all information required to decrypt/validate a given message
+   *
+   * @param contentTopic The topic name
+   * @returns TopicResult | undefined
+   */
   getByTopic(contentTopic: string): TopicResult | undefined {
     const topicKey = this.topicKeys.get(contentTopic)
     if (!topicKey) {
@@ -91,7 +113,12 @@ export default class TopicKeyManager {
     }
   }
 
-  // Would be used to know which topic/key to use to send to a given wallet address
+  /**
+   *  Used to know which topic/key to use to send to a given wallet address
+   *
+   * @param walletAddress The wallet address
+   * @returns TopicResult | undefined
+   */
   getLatestByWalletAddress(walletAddress: string): TopicResult | undefined {
     const walletTopics = this.dmTopics.get(walletAddress)
     if (!walletTopics || !walletTopics.length) {
@@ -101,7 +128,12 @@ export default class TopicKeyManager {
     return this.getByTopic(newestTopic.contentTopic)
   }
 
-  // Would be used to get the topic list to listen for all messages from a given wallet address
+  /**
+   * Used to get the topic list to listen for all messages from a given wallet address
+   *
+   * @param walletAddress The wallet address
+   * @returns TopicResult[]
+   */
   getAllByWalletAddress(walletAddress: string): TopicResult[] {
     const dmTopics = this.dmTopics
       .get(walletAddress)

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -80,7 +80,7 @@ export default class TopicKeyManager {
   }
 
   // Would be used to get all information required to decrypt/validate a given message
-  getTopicResult(contentTopic: string): TopicResult | undefined {
+  getByTopic(contentTopic: string): TopicResult | undefined {
     const topicKey = this.topicKeys.get(contentTopic)
     if (!topicKey) {
       return undefined
@@ -92,20 +92,20 @@ export default class TopicKeyManager {
   }
 
   // Would be used to know which topic/key to use to send to a given wallet address
-  getLatestDirectMessageTopic(walletAddress: string): TopicResult | undefined {
+  getLatestByWalletAddress(walletAddress: string): TopicResult | undefined {
     const walletTopics = this.dmTopics.get(walletAddress)
     if (!walletTopics || !walletTopics.length) {
       return undefined
     }
     const newestTopic = findLatestTopic(walletTopics)
-    return this.getTopicResult(newestTopic.contentTopic)
+    return this.getByTopic(newestTopic.contentTopic)
   }
 
   // Would be used to get the topic list to listen for all messages from a given wallet address
-  getAllDirectMessageTopics(walletAddress: string): TopicResult[] {
+  getAllByWalletAddress(walletAddress: string): TopicResult[] {
     const dmTopics = this.dmTopics
       .get(walletAddress)
-      ?.map(({ contentTopic }) => this.getTopicResult(contentTopic))
+      ?.map(({ contentTopic }) => this.getByTopic(contentTopic))
       .filter((res) => !!res) as TopicResult[]
 
     return dmTopics || []

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -98,9 +98,6 @@ export default class TopicKeyManager {
 
   /**
    * Would be used to get all information required to decrypt/validate a given message
-   *
-   * @param contentTopic The topic name
-   * @returns TopicResult | undefined
    */
   getByTopic(contentTopic: string): TopicResult | undefined {
     const topicKey = this.topicKeys.get(contentTopic)
@@ -115,9 +112,6 @@ export default class TopicKeyManager {
 
   /**
    *  Used to know which topic/key to use to send to a given wallet address
-   *
-   * @param walletAddress The wallet address
-   * @returns TopicResult | undefined
    */
   getLatestByWalletAddress(walletAddress: string): TopicResult | undefined {
     const walletTopics = this.dmTopics.get(walletAddress)
@@ -130,9 +124,6 @@ export default class TopicKeyManager {
 
   /**
    * Used to get the topic list to listen for all messages from a given wallet address
-   *
-   * @param walletAddress The wallet address
-   * @returns TopicResult[]
    */
   getAllByWalletAddress(walletAddress: string): TopicResult[] {
     const dmTopics = this.dmTopics

--- a/test/TopicKeyManager.test.ts
+++ b/test/TopicKeyManager.test.ts
@@ -38,7 +38,7 @@ describe('TopicKeyManager', () => {
     keyManager.addDirectMessageTopic(TOPICS[0], record, sender, sentAt)
 
     // Lookup latest result by address
-    const topicResultByAddress = keyManager.getLatestDirectMessageTopic(
+    const topicResultByAddress = keyManager.getLatestByWalletAddress(
       senderWallet.address
     )
     expect(topicResultByAddress?.contentTopic).toEqual(TOPICS[0])
@@ -47,14 +47,12 @@ describe('TopicKeyManager', () => {
     )
 
     // Lookup all results by address
-    const allResults = keyManager.getAllDirectMessageTopics(
-      senderWallet.address
-    )
+    const allResults = keyManager.getAllByWalletAddress(senderWallet.address)
     expect(allResults).toHaveLength(1)
     expect(allResults[0]).toEqual(topicResultByAddress)
 
     // Lookup result by topic
-    const topicResultByTopic = keyManager.getTopicResult(TOPICS[0])
+    const topicResultByTopic = keyManager.getByTopic(TOPICS[0])
     expect(topicResultByTopic).toEqual(topicResultByAddress)
   })
 
@@ -73,16 +71,16 @@ describe('TopicKeyManager', () => {
 
     // Should use the record with the latest date
     expect(
-      keyManager.getLatestDirectMessageTopic(senderWallet.address)?.contentTopic
+      keyManager.getLatestByWalletAddress(senderWallet.address)?.contentTopic
     ).toEqual(TOPICS[1])
 
     // Should return both results
-    expect(
-      keyManager.getAllDirectMessageTopics(senderWallet.address)
-    ).toHaveLength(2)
+    expect(keyManager.getAllByWalletAddress(senderWallet.address)).toHaveLength(
+      2
+    )
 
     // It should still be possible to look up the older topic using the topic name directly
-    expect(keyManager.getTopicResult(TOPICS[0])?.topicKey.keyMaterial).toEqual(
+    expect(keyManager.getByTopic(TOPICS[0])?.topicKey.keyMaterial).toEqual(
       record1.keyMaterial
     )
   })
@@ -99,6 +97,7 @@ describe('TopicKeyManager', () => {
       sender,
       new Date()
     )
+
     expect(() =>
       keyManager.addDirectMessageTopic(
         TOPICS[0],

--- a/test/TopicKeyManager.test.ts
+++ b/test/TopicKeyManager.test.ts
@@ -1,0 +1,111 @@
+import {
+  TopicKeyRecord,
+  EncryptionAlgorithm,
+  DuplicateTopicError,
+} from './../src/TopicKeyManager'
+import KeyManager from '../src/TopicKeyManager'
+import { crypto } from '../src/crypto/encryption'
+import PrivateKeyBundle from '../src/crypto/PrivateKeyBundle'
+import PublicKeyBundle from '../src/crypto/PublicKeyBundle'
+import { newWallet } from './helpers'
+
+const TOPICS = ['topic1', 'topic2', 'topic3']
+
+const createTopicKeyRecord = (
+  allowedSigners: PublicKeyBundle[] = []
+): TopicKeyRecord => {
+  return {
+    keyMaterial: crypto.getRandomValues(new Uint8Array(32)),
+    encryptionAlgorithm: EncryptionAlgorithm.AES_256_GCM_HKDF_SHA_256,
+    allowedSigners: allowedSigners,
+  }
+}
+
+describe('TopicKeyManager', () => {
+  let keyManager: KeyManager
+  beforeEach(async () => {
+    keyManager = new KeyManager()
+  })
+
+  it('can add and retrieve a topic key', async () => {
+    const senderWallet = newWallet()
+    const sender = (
+      await PrivateKeyBundle.generate(senderWallet)
+    ).getPublicKeyBundle()
+    const sentAt = new Date()
+    const record = createTopicKeyRecord([sender])
+
+    keyManager.addDirectMessageTopic(TOPICS[0], record, sender, sentAt)
+
+    // Lookup latest result by address
+    const topicResultByAddress = keyManager.getLatestDirectMessageTopic(
+      senderWallet.address
+    )
+    expect(topicResultByAddress?.contentTopic).toEqual(TOPICS[0])
+    expect(topicResultByAddress?.topicKey.keyMaterial).toEqual(
+      record.keyMaterial
+    )
+
+    // Lookup all results by address
+    const allResults = keyManager.getAllDirectMessageTopics(
+      senderWallet.address
+    )
+    expect(allResults).toHaveLength(1)
+    expect(allResults[0]).toEqual(topicResultByAddress)
+
+    // Lookup result by topic
+    const topicResultByTopic = keyManager.getTopicResult(TOPICS[0])
+    expect(topicResultByTopic).toEqual(topicResultByAddress)
+  })
+
+  it('can add multiple topic keys for a wallet', async () => {
+    const senderWallet = newWallet()
+    const sender = (
+      await PrivateKeyBundle.generate(senderWallet)
+    ).getPublicKeyBundle()
+    const record1 = createTopicKeyRecord([sender])
+    const record2 = createTopicKeyRecord([sender])
+    const d1 = new Date(+new Date() - 100)
+    const d2 = new Date()
+
+    keyManager.addDirectMessageTopic(TOPICS[0], record1, sender, d1)
+    keyManager.addDirectMessageTopic(TOPICS[1], record2, sender, d2)
+
+    // Should use the record with the latest date
+    expect(
+      keyManager.getLatestDirectMessageTopic(senderWallet.address)?.contentTopic
+    ).toEqual(TOPICS[1])
+
+    // Should return both results
+    expect(
+      keyManager.getAllDirectMessageTopics(senderWallet.address)
+    ).toHaveLength(2)
+
+    // It should still be possible to look up the older topic using the topic name directly
+    expect(keyManager.getTopicResult(TOPICS[0])?.topicKey.keyMaterial).toEqual(
+      record1.keyMaterial
+    )
+  })
+
+  it('cannot add multiple records for the same topic', async () => {
+    const senderWallet = newWallet()
+    const sender = (
+      await PrivateKeyBundle.generate(senderWallet)
+    ).getPublicKeyBundle()
+
+    keyManager.addDirectMessageTopic(
+      TOPICS[0],
+      createTopicKeyRecord([sender]),
+      sender,
+      new Date()
+    )
+    expect(() =>
+      keyManager.addDirectMessageTopic(
+        TOPICS[0],
+        createTopicKeyRecord([sender]),
+        sender,
+        new Date()
+      )
+    ).toThrow(DuplicateTopicError)
+  })
+})

--- a/test/TopicKeyManager.test.ts
+++ b/test/TopicKeyManager.test.ts
@@ -9,7 +9,7 @@ import PrivateKeyBundle from '../src/crypto/PrivateKeyBundle'
 import PublicKeyBundle from '../src/crypto/PublicKeyBundle'
 import { newWallet } from './helpers'
 
-const TOPICS = ['topic1', 'topic2', 'topic3']
+const TOPICS = ['topic1', 'topic2']
 
 const createTopicKeyRecord = (
   allowedSigners: PublicKeyBundle[] = []
@@ -54,6 +54,12 @@ describe('TopicKeyManager', () => {
     // Lookup result by topic
     const topicResultByTopic = keyManager.getByTopic(TOPICS[0])
     expect(topicResultByTopic).toEqual(topicResultByAddress)
+  })
+
+  it('returns undefined when no topic key has been added', async () => {
+    expect(keyManager.getByTopic(TOPICS[0])).toBeUndefined()
+    expect(keyManager.getLatestByWalletAddress(TOPICS[0])).toBeUndefined()
+    expect(keyManager.getAllByWalletAddress(TOPICS[0])).toHaveLength(0)
   })
 
   it('can add multiple topic keys for a wallet', async () => {


### PR DESCRIPTION
## Summary
I wanted to break out this discrete piece of work for negotiated topics, since it can be safely merged to `main`.

It's a simple and narrowly scoped manager class for `TopicKey`s. I initially planned a broader `KeyManager` interface that would handle all types of keys, including `PrivateKeyBundle`s but ultimately couldn't find the synergy of having them all in one place. I think the right solution is probably to have general encrypt/decrypt functions on the client that make use of this class amongst others to get the right key and encrypt/decrypt a given message using the appropriate protocol for the message.

The functionality of this module:
1. Store `TopicKey`s, enforcing the "one key per topic" rule
2. Retrieve the `TopicKey` for a given topic to decrypt a received message
3. Retrieve the latest `TopicKey` for a given wallet to encrypt a message before sending

All encryption/decryption will be handled by the caller.

## Links
- [RFC](https://github.com/xmtp-labs/hq/blob/main/eng/RFCs/20220819-key-passing.md)