### PR TITLE
Include client version header with API requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "@jsbits/get-package-version": "^1.0.3",
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^3.1.0",
@@ -2136,6 +2137,14 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jsbits/get-package-version": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsbits/get-package-version/-/get-package-version-1.0.3.tgz",
+      "integrity": "sha512-IJy1jRL01x7p6UEpgKa1lVLstMUx8EiIR8pPoS5sBfsHEoeLkzYiNpAfxPx8zLDUJyS1yBbChJjcWdPqyH285w==",
+      "engines": {
+        "node": ">=4.2"
       }
     },
     "node_modules/@noble/secp256k1": {
@@ -15087,6 +15096,11 @@
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0"
       }
+    },
+    "@jsbits/get-package-version": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@jsbits/get-package-version/-/get-package-version-1.0.3.tgz",
+      "integrity": "sha512-IJy1jRL01x7p6UEpgKa1lVLstMUx8EiIR8pPoS5sBfsHEoeLkzYiNpAfxPx8zLDUJyS1yBbChJjcWdPqyH285w=="
     },
     "@noble/secp256k1": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     ]
   },
   "dependencies": {
+    "@jsbits/get-package-version": "^1.0.3",
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^3.1.0",

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -10,8 +10,6 @@ export const { MessageApi, SortDirection } = messageApi
 const RETRY_SLEEP_TIME = 100
 const ERR_CODE_UNAUTHENTICATED = 16
 
-const getClientVersion = () => 'xmtp-js/' + getPackageVersion()
-
 const clientVersionHeaderKey = 'X-Client-Version'
 
 export type GrpcError = Error & { code?: number }
@@ -82,10 +80,12 @@ export default class ApiClient {
   pathPrefix: string
   maxRetries: number
   private authCache?: AuthCache
+  version: string
 
   constructor(pathPrefix: string, opts?: ApiClientOptions) {
     this.pathPrefix = pathPrefix
     this.maxRetries = opts?.maxRetries || 5
+    this.version = 'xmtp-js/' + getPackageVersion()
   }
 
   // Raw method for querying the API
@@ -100,7 +100,7 @@ export default class ApiClient {
           pathPrefix: this.pathPrefix,
           mode: 'cors',
           headers: new Headers({
-            [clientVersionHeaderKey]: getClientVersion(),
+            [clientVersionHeaderKey]: this.version,
           }),
         },
       ],
@@ -125,7 +125,7 @@ export default class ApiClient {
             mode: 'cors',
             headers: new Headers({
               Authorization: `Bearer ${authToken}`,
-              [clientVersionHeaderKey]: getClientVersion(),
+              [clientVersionHeaderKey]: this.version,
             }),
           },
         ],
@@ -161,7 +161,7 @@ export default class ApiClient {
         signal: abortController.signal,
         mode: 'cors',
         headers: new Headers({
-          [clientVersionHeaderKey]: getClientVersion(),
+          [clientVersionHeaderKey]: this.version,
         }),
       }).catch(async (err: GrpcError) => {
         if (isAbortError(err)) {

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -5,6 +5,7 @@ import Long from 'long'
 import { sleep } from './helpers'
 import { Authenticator } from '../src/authn'
 import { PrivateKey } from '../src'
+import getPackageVersion from '@jsbits/get-package-version'
 const { MessageApi } = messageApi
 
 const PATH_PREFIX = 'http://fake:5050'
@@ -51,6 +52,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + getPackageVersion(),
+      }),
     })
   })
 
@@ -99,6 +103,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + getPackageVersion(),
+      }),
     })
   })
 
@@ -124,6 +131,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenLastCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + getPackageVersion(),
+      }),
     })
   })
 })
@@ -164,7 +174,10 @@ describe('Publish', () => {
     expect(publishMock).toHaveBeenCalledWith(expectedRequest, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
-      headers: new Headers({ Authorization: `Bearer ${AUTH_TOKEN}` }),
+      headers: new Headers({
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'X-Client-Version': 'xmtp-js/' + getPackageVersion(),
+      }),
     })
   })
 
@@ -237,6 +250,9 @@ describe('Subscribe', () => {
       pathPrefix: PATH_PREFIX,
       signal: expect.anything(),
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + getPackageVersion(),
+      }),
     })
   })
 


### PR DESCRIPTION
This PR updates publish/subscribe/query API requests to include a `X-Client-Version` header with the current package version in the form `xmtp-js/1.0.0`