### PR TITLE
Signed Public Key Bundle

### DIFF
--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -2,6 +2,7 @@ import { contact, publicKey } from '@xmtp/proto'
 import { PublicKeyBundle, SignedPublicKeyBundle } from './crypto'
 
 // ContactBundle packages all the information which a client uses to advertise on the network.
+// V1 uses the legacy PublicKeyBundle.
 export class ContactBundleV1 implements contact.ContactBundleV1 {
   keyBundle: PublicKeyBundle
 
@@ -22,6 +23,8 @@ export class ContactBundleV1 implements contact.ContactBundleV1 {
   }
 }
 
+// ContactBundle packages all the information which a client uses to advertise on the network.
+// V2 uses the SignedPublicKeyBundle.
 export class ContactBundleV2 implements contact.ContactBundleV2 {
   keyBundle: SignedPublicKeyBundle
 
@@ -42,8 +45,10 @@ export class ContactBundleV2 implements contact.ContactBundleV2 {
   }
 }
 
+// This is the union of all supported bundle versions.
 export type ContactBundle = ContactBundleV1 | ContactBundleV2
 
+// This is the primary function for reading contact bundles off the wire.
 export function DecodeContactBundle(bytes: Uint8Array): ContactBundle {
   let cb: contact.ContactBundle
   try {

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -1,16 +1,15 @@
 import { contact, publicKey } from '@xmtp/proto'
-import { PublicKeyBundle } from './crypto'
-import { PublicKey } from './crypto/PublicKey'
+import { PublicKeyBundle, SignedPublicKeyBundle } from './crypto'
 
-// ContactBundle packages all the infromation which a client uses to advertise on the network.
-export default class ContactBundle implements contact.ContactBundleV1 {
+// ContactBundle packages all the information which a client uses to advertise on the network.
+export class ContactBundleV1 implements contact.ContactBundleV1 {
   keyBundle: PublicKeyBundle
 
-  constructor(publicKeyBundle: PublicKeyBundle) {
-    if (!publicKeyBundle) {
+  constructor(bundle: contact.ContactBundleV1) {
+    if (!bundle.keyBundle) {
       throw new Error('missing keyBundle')
     }
-    this.keyBundle = publicKeyBundle
+    this.keyBundle = new PublicKeyBundle(bundle.keyBundle)
   }
 
   toBytes(): Uint8Array {
@@ -21,44 +20,44 @@ export default class ContactBundle implements contact.ContactBundleV1 {
       v2: undefined,
     }).finish()
   }
+}
 
-  static fromBytes(bytes: Uint8Array): ContactBundle {
-    const bundle = this.decodeV1(bytes)
+export class ContactBundleV2 implements contact.ContactBundleV2 {
+  keyBundle: SignedPublicKeyBundle
 
-    if (!bundle) {
-      throw new Error('could not parse bundle')
-    }
-
-    if (!bundle.identityKey) {
+  constructor(bundle: contact.ContactBundleV2) {
+    if (!bundle.keyBundle) {
       throw new Error('missing keyBundle')
     }
-    if (!bundle.preKey) {
-      throw new Error('missing pre-key')
-    }
-    return new ContactBundle(
-      new PublicKeyBundle(
-        new PublicKey(bundle.identityKey),
-        new PublicKey(bundle.preKey)
-      )
-    )
+    this.keyBundle = new SignedPublicKeyBundle(bundle.keyBundle)
   }
 
-  static decodeV1(bytes: Uint8Array): publicKey.PublicKeyBundle | undefined {
-    try {
-      const b = contact.ContactBundle.decode(bytes)
-      return b.v1?.keyBundle
-    } catch (e) {
-      if (
-        e instanceof RangeError ||
-        (e instanceof Error && e.message.startsWith('invalid wire type'))
-      ) {
-        // Adds a default fallback for older versions of the proto (Which may also fail)
-        try {
-          return publicKey.PublicKeyBundle.decode(bytes)
-        } catch (e) {
-          throw new Error("Couldn't decode contact bundle: " + e)
-        }
-      }
-    }
+  toBytes(): Uint8Array {
+    return contact.ContactBundle.encode({
+      v1: undefined,
+      v2: {
+        keyBundle: this.keyBundle,
+      },
+    }).finish()
   }
+}
+
+type ContactBundle = ContactBundleV1 | ContactBundleV2
+export default ContactBundle
+
+export function DecodeContactBundle(bytes: Uint8Array): ContactBundle {
+  let cb: contact.ContactBundle
+  try {
+    cb = contact.ContactBundle.decode(bytes)
+  } catch (e) {
+    const pb = publicKey.PublicKeyBundle.decode(bytes)
+    cb = { v1: { keyBundle: new PublicKeyBundle(pb) }, v2: undefined }
+  }
+  if (cb.v1) {
+    return new ContactBundleV1(cb.v1)
+  }
+  if (cb.v2) {
+    return new ContactBundleV2(cb.v2)
+  }
+  throw new Error('unknown contact bundle version')
 }

--- a/src/ContactBundle.ts
+++ b/src/ContactBundle.ts
@@ -42,8 +42,7 @@ export class ContactBundleV2 implements contact.ContactBundleV2 {
   }
 }
 
-type ContactBundle = ContactBundleV1 | ContactBundleV2
-export default ContactBundle
+export type ContactBundle = ContactBundleV1 | ContactBundleV2
 
 export function DecodeContactBundle(bytes: Uint8Array): ContactBundle {
   let cb: contact.ContactBundle

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -164,14 +164,14 @@ export default class Message implements proto.MessageV1 {
     if (!header.recipient.preKey) {
       throw new Error('missing message recipient pre-key')
     }
-    const recipient = new PublicKeyBundle(
-      new PublicKey(header.recipient.identityKey),
-      new PublicKey(header.recipient.preKey)
-    )
-    const sender = new PublicKeyBundle(
-      new PublicKey(header.sender.identityKey),
-      new PublicKey(header.sender.preKey)
-    )
+    const recipient = new PublicKeyBundle({
+      identityKey: new PublicKey(header.recipient.identityKey),
+      preKey: new PublicKey(header.recipient.preKey),
+    })
+    const sender = new PublicKeyBundle({
+      identityKey: new PublicKey(header.sender.identityKey),
+      preKey: new PublicKey(header.sender.preKey),
+    })
     if (!v1Message.ciphertext?.aes256GcmHkdfSha256) {
       throw new Error('missing message ciphertext')
     }

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -1,4 +1,4 @@
-import PublicKeyBundle from './crypto/PublicKeyBundle'
+import { PublicKeyBundle } from './crypto/PublicKeyBundle'
 
 export enum EncryptionAlgorithm {
   AES_256_GCM_HKDF_SHA_256,

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -1,7 +1,7 @@
 import { privateKey as proto } from '@xmtp/proto'
 import { PrivateKey } from './PrivateKey'
 import { PublicKey } from './PublicKey'
-import PublicKeyBundle from './PublicKeyBundle'
+import { PublicKeyBundle } from './PublicKeyBundle'
 import Ciphertext from './Ciphertext'
 import { Signer } from 'ethers'
 import { bytesToHex, getRandomValues, hexToBytes } from './utils'
@@ -55,10 +55,10 @@ export default class PrivateKeyBundle implements proto.PrivateKeyBundleV1 {
 
   // Return a key bundle with the current pre-key.
   getPublicKeyBundle(): PublicKeyBundle {
-    return new PublicKeyBundle(
-      this.identityKey.publicKey,
-      this.getCurrentPreKey().publicKey
-    )
+    return new PublicKeyBundle({
+      identityKey: this.identityKey.publicKey,
+      preKey: this.getCurrentPreKey().publicKey,
+    })
   }
 
   // sharedSecret derives a secret from peer's key bundles using a variation of X3DH protocol

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -1,22 +1,68 @@
 import { publicKey } from '@xmtp/proto'
-import { PublicKey } from './PublicKey'
+import { PublicKey, SignedPublicKey } from './PublicKey'
 
 // PublicKeyBundle packages all the keys that a participant should advertise.
 // The PreKey must be signed by the IdentityKey.
+// The IdentityKey must be signed by the wallet to authenticate it.
+export class SignedPublicKeyBundle implements publicKey.SignedPublicKeyBundle {
+  identityKey: SignedPublicKey
+  preKey: SignedPublicKey
+
+  constructor(bundle: publicKey.SignedPublicKeyBundle) {
+    if (!bundle.identityKey) {
+      throw new Error('missing identity key')
+    }
+    if (!bundle.preKey) {
+      throw new Error('missing pre-key')
+    }
+    this.identityKey = new SignedPublicKey(bundle.identityKey)
+    this.preKey = new SignedPublicKey(bundle.preKey)
+  }
+
+  walletSignatureAddress(): Promise<string> {
+    return this.identityKey.walletSignatureAddress()
+  }
+
+  equals(other: this): boolean {
+    return (
+      this.identityKey.equals(other.identityKey) &&
+      this.preKey.equals(other.preKey)
+    )
+  }
+
+  toBytes(): Uint8Array {
+    return publicKey.SignedPublicKeyBundle.encode(this).finish()
+  }
+
+  static fromBytes(bytes: Uint8Array): SignedPublicKeyBundle {
+    const decoded = publicKey.SignedPublicKeyBundle.decode(bytes)
+    return new SignedPublicKeyBundle(decoded)
+  }
+}
+
+// LEGACY: PublicKeyBundle packages all the keys that a participant should advertise.
+// The PreKey must be signed by the IdentityKey.
 // The IdentityKey can be signed by the wallet to authenticate it.
-export default class PublicKeyBundle implements publicKey.PublicKeyBundle {
+export class PublicKeyBundle implements publicKey.PublicKeyBundle {
   identityKey: PublicKey
   preKey: PublicKey
 
-  constructor(identityKey: PublicKey, preKey: PublicKey) {
-    if (!identityKey) {
+  constructor(bundle: publicKey.PublicKeyBundle) {
+    if (!bundle.identityKey) {
       throw new Error('missing identity key')
     }
-    if (!preKey) {
+    if (!bundle.preKey) {
       throw new Error('missing pre-key')
     }
-    this.identityKey = identityKey
-    this.preKey = preKey
+    this.identityKey = new PublicKey(bundle.identityKey)
+    this.preKey = new PublicKey(bundle.preKey)
+  }
+
+  equals(other: this): boolean {
+    return (
+      this.identityKey.equals(other.identityKey) &&
+      this.preKey.equals(other.preKey)
+    )
   }
 
   walletSignatureAddress(): string {
@@ -29,15 +75,6 @@ export default class PublicKeyBundle implements publicKey.PublicKeyBundle {
 
   static fromBytes(bytes: Uint8Array): PublicKeyBundle {
     const decoded = publicKey.PublicKeyBundle.decode(bytes)
-    if (!decoded.identityKey) {
-      throw new Error('missing identity key')
-    }
-    if (!decoded.preKey) {
-      throw new Error('missing pre-key')
-    }
-    return new PublicKeyBundle(
-      new PublicKey(decoded.identityKey),
-      new PublicKey(decoded.preKey)
-    )
+    return new PublicKeyBundle(decoded)
   }
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -1,4 +1,4 @@
-import PublicKeyBundle from './PublicKeyBundle'
+import { PublicKeyBundle, SignedPublicKeyBundle } from './PublicKeyBundle'
 import { SignedPrivateKey, PrivateKey } from './PrivateKey'
 import PrivateKeyBundle from './PrivateKeyBundle'
 import { UnsignedPublicKey, SignedPublicKey, PublicKey } from './PublicKey'
@@ -12,6 +12,7 @@ export {
   decrypt,
   UnsignedPublicKey,
   SignedPublicKey,
+  SignedPublicKeyBundle,
   PublicKey,
   PublicKeyBundle,
   PrivateKey,

--- a/test/ContactBundle.test.ts
+++ b/test/ContactBundle.test.ts
@@ -1,17 +1,23 @@
 import * as assert from 'assert'
-import ContactBundle from '../src/ContactBundle'
-import { PrivateKeyBundle } from '../src'
+import { ContactBundleV1, DecodeContactBundle } from '../src/ContactBundle'
+import { PrivateKeyBundle, PublicKeyBundle } from '../src'
 
 describe('ContactBundles', function () {
   it('roundtrip', async function () {
     const priv = await PrivateKeyBundle.generate()
+    const pub = priv.getPublicKeyBundle()
+    let bytes = pub.toBytes()
+    const cb = DecodeContactBundle(bytes)
+    expect(cb.keyBundle).toBeInstanceOf(PublicKeyBundle)
+    assert.ok(pub.equals(cb.keyBundle as PublicKeyBundle))
 
-    const cb1 = new ContactBundle(priv.getPublicKeyBundle())
-    const bytes1 = cb1.toBytes()
+    const cb1 = new ContactBundleV1({ keyBundle: priv.getPublicKeyBundle() })
+    bytes = cb1.toBytes()
+    const cb2 = DecodeContactBundle(bytes)
+    expect(cb2.keyBundle).toBeInstanceOf(PublicKeyBundle)
+    assert.ok(pub.equals(cb2.keyBundle as PublicKeyBundle))
 
-    const cb2 = ContactBundle.fromBytes(bytes1)
     const bytes2 = cb2.toBytes()
-
-    assert.deepEqual(bytes1, bytes2)
+    assert.deepEqual(bytes, bytes2)
   })
 })

--- a/test/TopicKeyManager.test.ts
+++ b/test/TopicKeyManager.test.ts
@@ -6,7 +6,7 @@ import {
 import KeyManager from '../src/TopicKeyManager'
 import { crypto } from '../src/crypto/encryption'
 import PrivateKeyBundle from '../src/crypto/PrivateKeyBundle'
-import PublicKeyBundle from '../src/crypto/PublicKeyBundle'
+import { PublicKeyBundle } from '../src/crypto/PublicKeyBundle'
 import { newWallet } from './helpers'
 
 const TOPICS = ['topic1', 'topic2']

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -11,8 +11,7 @@ import {
 import Stream from '../src/Stream'
 import { promiseWithTimeout } from '../src/utils'
 import assert from 'assert'
-import { publicKey } from '@xmtp/proto'
-type PublicKeyBundle = publicKey.PublicKeyBundle
+import { PublicKeyBundle } from '../src/crypto'
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
Fixes https://github.com/xmtp-labs/hq/issues/686

* Adds new `SignedPublicKeyBundle` to eventually replace `PublicKeyBundle`
* Renames `ContactBundle` to `ContactBundleV1` since that's what it implements and adds `ContactBundleV2`
* Makes `ContactBundle` a union of all supported versions, this forces turning `static ContactBundle.decodeV1(bytes)` into a more generic `DecodeContactBundle(bytes)`
* We're still publishing bare `PublicKeyBundle` to the contact topic, so enhance tests to check that `DecodeContactBundle()` can indeed handle that
* Updates `Client.getUserContactFromNetwork()` to ignore `SignedPublicKeyBundles` (V2) for now. This should allow newer clients to publish V2 bundle without breaking older clients.

I'll do the private key bundle in separate PR.

Rolling out V2 will be messy as the clients will have to manage V2 and V1 contacts separately during the transition period. They cannot be used interchangeably.