### PR TITLE
Revert "Remove version altogether"

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -4,10 +4,13 @@ import { retry, sleep } from './utils'
 import Long from 'long'
 import AuthCache from './authn/AuthCache'
 import { Authenticator } from './authn'
+import { version } from '../package.json'
 export const { MessageApi, SortDirection } = messageApi
 
 const RETRY_SLEEP_TIME = 100
 const ERR_CODE_UNAUTHENTICATED = 16
+
+const clientVersionHeaderKey = 'X-Client-Version'
 
 export type GrpcError = Error & { code?: number }
 
@@ -77,10 +80,12 @@ export default class ApiClient {
   pathPrefix: string
   maxRetries: number
   private authCache?: AuthCache
+  version: string
 
   constructor(pathPrefix: string, opts?: ApiClientOptions) {
     this.pathPrefix = pathPrefix
     this.maxRetries = opts?.maxRetries || 5
+    this.version = 'xmtp-js/' + version
   }
 
   // Raw method for querying the API
@@ -94,6 +99,9 @@ export default class ApiClient {
         {
           pathPrefix: this.pathPrefix,
           mode: 'cors',
+          headers: new Headers({
+            [clientVersionHeaderKey]: this.version,
+          }),
         },
       ],
       this.maxRetries,
@@ -117,6 +125,7 @@ export default class ApiClient {
             mode: 'cors',
             headers: new Headers({
               Authorization: `Bearer ${authToken}`,
+              [clientVersionHeaderKey]: this.version,
             }),
           },
         ],
@@ -151,6 +160,9 @@ export default class ApiClient {
         pathPrefix: this.pathPrefix,
         signal: abortController.signal,
         mode: 'cors',
+        headers: new Headers({
+          [clientVersionHeaderKey]: this.version,
+        }),
       }).catch(async (err: GrpcError) => {
         if (isAbortError(err)) {
           return

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -5,6 +5,7 @@ import Long from 'long'
 import { sleep } from './helpers'
 import { Authenticator } from '../src/authn'
 import { PrivateKey } from '../src'
+import { version } from '../package.json'
 const { MessageApi } = messageApi
 
 const PATH_PREFIX = 'http://fake:5050'
@@ -51,6 +52,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + version,
+      }),
     })
   })
 
@@ -99,6 +103,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + version,
+      }),
     })
   })
 
@@ -124,6 +131,9 @@ describe('Query', () => {
     expect(apiMock).toHaveBeenLastCalledWith(expectedReq, {
       pathPrefix: PATH_PREFIX,
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + version,
+      }),
     })
   })
 })
@@ -166,6 +176,7 @@ describe('Publish', () => {
       mode: 'cors',
       headers: new Headers({
         Authorization: `Bearer ${AUTH_TOKEN}`,
+        'X-Client-Version': 'xmtp-js/' + version,
       }),
     })
   })
@@ -239,6 +250,9 @@ describe('Subscribe', () => {
       pathPrefix: PATH_PREFIX,
       signal: expect.anything(),
       mode: 'cors',
+      headers: new Headers({
+        'X-Client-Version': 'xmtp-js/' + version,
+      }),
     })
   })
 


### PR DESCRIPTION
Whenever we have the `access-control-allow-headers` including the `x-client-version` in the dev env, and have tested with version 6.3.1 of the SDK, we can merge this.