### PR TITLE
Key version conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.1.0",
+        "@xmtp/proto": "^3.2.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "node-localstorage": "^2.2.1"
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.1.0.tgz",
-      "integrity": "sha512-eZDtCifowWEDYCPV7nSdDGlGO1TI6CsfOe7kP9sn8PECvNutYDk1NB7h+7neZLZoHQaO9U6vYrmhgJXVpaJEJw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
+      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16215,9 +16215,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.1.0.tgz",
-      "integrity": "sha512-eZDtCifowWEDYCPV7nSdDGlGO1TI6CsfOe7kP9sn8PECvNutYDk1NB7h+7neZLZoHQaO9U6vYrmhgJXVpaJEJw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
+      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.1.0",
+    "@xmtp/proto": "^3.2.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "node-localstorage": "^2.2.1"

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -54,7 +54,7 @@ export class SignedPrivateKey
       secp256k1Uncompressed: {
         bytes: secp.getPublicKey(secp256k1.bytes),
       },
-      createdNs: createdNs,
+      createdNs,
     })
     const signed = await signer.signKey(unsigned)
     return new SignedPrivateKey({
@@ -159,6 +159,17 @@ export class SignedPrivateKey
   static fromBytes(bytes: Uint8Array): SignedPrivateKey {
     return new SignedPrivateKey(privateKey.SignedPrivateKey.decode(bytes))
   }
+
+  static fromLegacyKey(
+    key: PrivateKey,
+    signedByWallet?: boolean
+  ): SignedPrivateKey {
+    return new SignedPrivateKey({
+      createdNs: key.timestamp.mul(1000000),
+      secp256k1: key.secp256k1,
+      publicKey: SignedPublicKey.fromLegacyKey(key.publicKey, signedByWallet),
+    })
+  }
 }
 
 // LEGACY: PrivateKey represents a secp256k1 private key.
@@ -193,7 +204,7 @@ export class PrivateKey implements privateKey.PrivateKey {
         secp256k1Uncompressed: {
           bytes: secp.getPublicKey(secp256k1.bytes),
         },
-        timestamp: timestamp,
+        timestamp,
       }),
     })
   }

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -38,6 +38,13 @@ export class SignedPublicKeyBundle implements publicKey.SignedPublicKeyBundle {
     const decoded = publicKey.SignedPublicKeyBundle.decode(bytes)
     return new SignedPublicKeyBundle(decoded)
   }
+
+  static fromLegacyBundle(bundle: PublicKeyBundle): SignedPublicKeyBundle {
+    return new SignedPublicKeyBundle({
+      identityKey: SignedPublicKey.fromLegacyKey(bundle.identityKey),
+      preKey: SignedPublicKey.fromLegacyKey(bundle.preKey),
+    })
+  }
 }
 
 // LEGACY: PublicKeyBundle packages all the keys that a participant should advertise.

--- a/test/crypto/PublicKey.test.ts
+++ b/test/crypto/PublicKey.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/crypto'
 import { Wallet } from 'ethers'
 import * as secp from '@noble/secp256k1'
-import { hexToBytes } from '../../src/crypto/utils'
+import { hexToBytes, equalBytes } from '../../src/crypto/utils'
 
 describe('Crypto', function () {
   describe('Signed Keys', function () {
@@ -78,6 +78,40 @@ describe('Crypto', function () {
       // validate the key signature and return wallet address
       const address = alice.publicKey.walletSignatureAddress()
       assert.equal(address, wallet.address)
+    })
+    it('converts legacy keys to new keys', async function () {
+      // Key signed by a wallet
+      const wallet = new Wallet(PrivateKey.generate().secp256k1.bytes)
+      const identityKey = PrivateKey.generate()
+      await identityKey.publicKey.signWithWallet(wallet)
+      const iPub = identityKey.publicKey
+      assert.equal(iPub.walletSignatureAddress(), wallet.address)
+      const iPub2 = SignedPublicKey.fromLegacyKey(iPub, true)
+      assert.ok(
+        equalBytes(
+          iPub2.secp256k1Uncompressed.bytes,
+          iPub.secp256k1Uncompressed.bytes
+        )
+      )
+      assert.equal(iPub2.generated, iPub.generated)
+      assert.ok(equalBytes(iPub2.keyBytes, iPub.bytesToSign()))
+      const address = await iPub2.walletSignatureAddress()
+      assert.equal(address, wallet.address)
+
+      // Key signed by a key
+      const preKey = PrivateKey.generate()
+      await identityKey.signKey(preKey.publicKey)
+      const pPub = preKey.publicKey
+      const pPub2 = SignedPublicKey.fromLegacyKey(pPub)
+      assert.ok(
+        equalBytes(
+          pPub2.secp256k1Uncompressed.bytes,
+          pPub.secp256k1Uncompressed.bytes
+        )
+      )
+      assert.equal(pPub2.generated, pPub.generated)
+      assert.ok(equalBytes(pPub2.keyBytes, pPub.bytesToSign()))
+      assert.ok(iPub2.verifyKey(pPub2))
     })
   })
 })


### PR DESCRIPTION
This PR adds the ability to convert the legacy style V1 key types to V2 key types. This require the ability to transfer the public key signature to the new key as is and consequently the unsigned key bytes to be identical between the two keys.

This is complicated by the fact that we've changed the timestamp resolution between the versions from ms to ns. To accommodate this discrepancy this PR allows storing ms value in `UnsignedPublicKey.createdNs` field and adjusts the `timestamp` and `created` accessors to distinguish between the two cases based on the magnitude of the value stored in `createdNs` field. Consequently this means clients should refrain from accessing `createdNs` directly.

The reason why I want to propose this ugliness is that the ability to convert V1 keys to V2 keys will simplify the transition greatly. Otherwise we'll have to regenerate (or at least resign) all user keys to enable V2 functionality. We will likely need to preserve the ability to read V1 public keys to be able to read old messages, but we should be able to drop the private keys and just converting the V1 public keys to V2 and use them with V2 private keys (assuming they are the same as the old V1 keys). This will allow preserving the key store APIs which are set up for handling single key bundle only.

So in short, this is not great, but I think it's worth it.
