### PR TITLE
Add sorting of messages to list endpoint

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -49,6 +49,7 @@ export type ListMessagesOptions = {
   startTime?: Date
   endTime?: Date
   limit?: number
+  direction?: messageApi.SortDirection
 }
 
 export type ListMessagesPaginatedOptions = {
@@ -491,7 +492,8 @@ export default class Client {
     const res = await this.apiClient.query(
       { contentTopics: [topic], startTime, endTime },
       {
-        direction: messageApi.SortDirection.SORT_DIRECTION_ASCENDING,
+        direction:
+          opts.direction || messageApi.SortDirection.SORT_DIRECTION_ASCENDING,
         limit,
       }
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   CompositeCodec,
   ContentTypeComposite,
 } from './codecs/Composite'
+import { SortDirection } from './ApiClient'
 
 export {
   Client,
@@ -53,4 +54,5 @@ export {
   Composite,
   CompositeCodec,
   ContentTypeComposite,
+  SortDirection,
 }

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -98,6 +98,23 @@ describe('conversation', () => {
     expect(numMessages).toBe(1)
   })
 
+  it('allows for sorted listing', async () => {
+    const aliceConversation = await alice.conversations.newConversation(
+      bob.address
+    )
+    await aliceConversation.send('1')
+    await sleep(1)
+    await aliceConversation.send('2')
+
+    const sortedAscending = await aliceConversation.messages()
+    expect(sortedAscending[0].content).toBe('1')
+
+    const sortedDescending = await aliceConversation.messages({
+      direction: SortDirection.SORT_DIRECTION_DESCENDING,
+    })
+    expect(sortedDescending[0].content).toBe('2')
+  })
+
   it('streams messages', async () => {
     const aliceConversation = await alice.conversations.newConversation(
       bob.address


### PR DESCRIPTION
## Summary

One small feature I noticed was missing was the ability to sort the direction of messages from the `listMessages` endpoints. This is particularly useful to support "give me the 3 most recent messages" without having to use the paginated API. We should totally be doing this to load the conversation list more quickly in the example app (we currently load all messages, when we really just need the first one).

Surprised more developers aren't complaining about this missing feature. Always good to be eating your own dogfood I guess.