### PR TITLE
WIP - Invite Loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.2.0",
+        "@xmtp/proto": "3.3.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "node-localstorage": "^2.2.1"
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
-      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.3.0.tgz",
+      "integrity": "sha512-khmtW3AOZE8BvEYdlI4ppc15LJ33x311DWFEeU8Zn/8yQe21Z+xW7sKmeQJuP9cZWPM6PEOKP2nOxCtrKn9QdQ==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16215,9 +16215,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
-      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.3.0.tgz",
+      "integrity": "sha512-khmtW3AOZE8BvEYdlI4ppc15LJ33x311DWFEeU8Zn/8yQe21Z+xW7sKmeQJuP9cZWPM6PEOKP2nOxCtrKn9QdQ==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.2.0",
+    "@xmtp/proto": "3.3.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "node-localstorage": "^2.2.1"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -545,7 +545,6 @@ export default class Client {
       },
       {
         direction: SortDirection.SORT_DIRECTION_ASCENDING,
-        limit: 100,
       }
     )
     for (const { message, timestampNs } of envelopes) {

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -6,10 +6,13 @@ export enum EncryptionAlgorithm {
   AES_256_GCM_HKDF_SHA_256,
 }
 
+type ContentTopic = string
+type WalletAddress = string
+
 /**
- * TopicKeyRecord encapsulates the key, algorithm, and a list of allowed signers
+ * TopicKey encapsulates the key, algorithm, and a list of allowed signers
  */
-export type TopicKeyRecord = {
+export type TopicKey = {
   keyMaterial: Uint8Array
   encryptionAlgorithm: EncryptionAlgorithm
 }
@@ -18,13 +21,14 @@ export type TopicKeyRecord = {
  * TopicResult is the public interface for receiving a TopicKey
  */
 export type TopicResult = {
-  topicKey: TopicKeyRecord
+  topicKey: TopicKey
   contentTopic: string
   // Callers should validate that the signature comes from the list of allowed signers
   // Not strictly necessary, but it prevents against compromised topic keys being
   // used by third parties who would sign the message with a different key
   allowedSigners: SignedPublicKeyBundle[]
   context?: InvitationContext
+  peerAddress: WalletAddress
 }
 
 type IndexedTopicResult = Omit<TopicResult, 'contentTopic'>
@@ -34,9 +38,6 @@ type WalletTopicRecord = {
   contentTopic: string
   createdAtNs: Long
 }
-
-type ContentTopic = string
-type WalletAddress = string
 
 /**
  * Custom error type for cases where the caller attempted to add a second key to the same topic
@@ -135,5 +136,16 @@ export default class TopicKeyManager {
       .filter((res) => !!res) as TopicResult[]
 
     return dmTopics || []
+  }
+
+  /**
+   * Gets all the results with no grouping or sorting
+   */
+  getAll(): TopicResult[] {
+    const out: TopicResult[] = []
+    for (const [contentTopic, result] of this.topicKeys) {
+      out.push({ ...result, contentTopic })
+    }
+    return out
   }
 }

--- a/src/TopicKeyManager.ts
+++ b/src/TopicKeyManager.ts
@@ -90,7 +90,7 @@ export default class TopicKeyManager {
     walletAddress: string,
     data: IndexedTopicResult,
     createdAtNs: Long
-  ): void {
+  ): TopicResult {
     if (this.topicKeys.has(contentTopic)) {
       throw new DuplicateTopicError(contentTopic)
     }
@@ -98,6 +98,8 @@ export default class TopicKeyManager {
     const counterpartyTopicList = this.dmTopics.get(walletAddress) || []
     counterpartyTopicList.push({ contentTopic, createdAtNs })
     this.dmTopics.set(walletAddress, counterpartyTopicList)
+
+    return { contentTopic, ...data }
   }
 
   /**

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -13,7 +13,9 @@ import Message from '../Message'
  */
 export default class Conversation {
   peerAddress: string
+  context?: InvitationContext
   private client: Client
+  private topics: string[]
 
   constructor(
     client: Client,
@@ -23,6 +25,8 @@ export default class Conversation {
   ) {
     this.peerAddress = address
     this.client = client
+    this.topics = topics
+    this.context = context
   }
 
   /**

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -15,7 +15,12 @@ export default class Conversation {
   peerAddress: string
   private client: Client
 
-  constructor(client: Client, address: string) {
+  constructor(
+    client: Client,
+    address: string,
+    topics: string[],
+    context?: InvitationContext
+  ) {
     this.peerAddress = address
     this.client = client
   }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -25,6 +25,7 @@ export default class Conversations {
    */
   async list(): Promise<Conversation[]> {
     const v1Addresses = await this.getV1Addresses()
+    await this.client.loadInvites()
     const topicResults = this.client.allTopics()
     const out: Conversation[] = []
     for (const result of topicResults) {
@@ -191,7 +192,7 @@ export default class Conversations {
       throw new Error(`Recipient ${peerAddress} is not on the XMTP network`)
     }
 
-    return new Conversation(this.client, peerAddres, [
+    return new Conversation(this.client, peerAddress, [
       buildDirectMessageTopic(this.client.address, peerAddress),
     ])
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,12 +15,20 @@ export const buildDirectMessageTopic = (
   return buildContentTopic(`dm-${members.join('-')}`)
 }
 
+export const buildDirectMessageTopicV2 = (randomString: string): string => {
+  return buildContentTopic(`dm-${randomString}`)
+}
+
 export const buildUserContactTopic = (walletAddr: string): string => {
   return buildContentTopic(`contact-${walletAddr}`)
 }
 
 export const buildUserIntroTopic = (walletAddr: string): string => {
   return buildContentTopic(`intro-${walletAddr}`)
+}
+
+export const buildUserInviteTopic = (walletAddr: string): string => {
+  return buildContentTopic(`invite-${walletAddr}`)
 }
 
 export const buildUserPrivateStoreTopic = (walletAddr: string): string => {
@@ -102,4 +110,8 @@ export async function* mapPaginatedStream<Out>(
 
 export function dateToNs(date: Date): Long {
   return Long.fromNumber(date.valueOf()).multiply(1_000_000)
+}
+
+export function nsLongToDate(nsDate: Long): Date {
+  return new Date(nsDate.div(1_000_000).toNumber())
 }

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -62,10 +62,12 @@ describe('Client', () => {
       it('user contacts are filtered to valid contacts', async () => {
         // publish bob's keys to alice's contact topic
         const bobPublic = bob.keys.getPublicKeyBundle()
-        await alice.publishEnvelope({
-          message: bobPublic.toBytes(),
-          contentTopic: buildUserContactTopic(alice.address),
-        })
+        await alice.publishEnvelopes([
+          {
+            message: bobPublic.toBytes(),
+            contentTopic: buildUserContactTopic(alice.address),
+          },
+        ])
         const alicePublic = await alice.getUserContact(alice.address)
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
       })

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -86,10 +86,12 @@ describe('conversation', () => {
     // This should be readable
     await aliceConversation.send('gm')
     // This should not be readable
-    await alice.publishEnvelope({
-      message: Uint8Array.from([1, 2, 3]),
-      contentTopic: buildDirectMessageTopic(alice.address, bob.address),
-    })
+    await alice.publishEnvelopes([
+      {
+        message: Uint8Array.from([1, 2, 3]),
+        contentTopic: buildDirectMessageTopic(alice.address, bob.address),
+      },
+    ])
 
     let numMessages = 0
     for await (const page of aliceConversation.messagesPaginated()) {


### PR DESCRIPTION
## Summary

Sharing this PR as a very-unfinished draft, just so we can have a conversation about the approach taken before I get any further. It also can't be merged until we have support for reading V2 messages.

I've made notes on the parts of the code worth looking at. Ignore the rest. There's no tests, there are probably bugs, I'll probably refactor some of this, etc etc.

## Invite Loading Constraints

With the move to negotiated topics selecting the right pattern used to read each account’s invite topic is critical. Before sending or reading any DM, the client needs to have loaded the invite related to that topic.

Since there is only one invite topic per blockchain address, and users will have at least one invite for each ongoing conversation, the topic has the potential to get quite large.

There are a limited number of tools we can use to selectively read from this topic, given that the contents are either encrypted or obscured inside protobuf headers.

- We can sort by timestamp in either ascending or descending order
- We can query for a time range
- We can limit the size of each page of results

## Use Cases
These are the main use cases that will require data from the invite topic.

1. Loading all conversations (`client.conversations.list()`)
2. Loading a single conversation (`client.conversations.findOrCreate()`) in order to send a message. This may or may not include a `conversationId` to narrow the scope.
3. Streaming new conversations as they come in (`client.conversations.stream()`)

## Optimizations Possible
I don’t see a universal solution that is the perfect for all three cases. Many optimizations that would help one use-case would disadvantage another.

In many ways, the problem mirrors the access patterns required in a limited database with a very slow disk. Sometimes you need to do a full table scan, sometimes a partial scan, and sometimes you can rely on indexes.

### Use Case 1
By definition, loading all conversations will involve reading all invites. No optimizations possible for the first time run in a client session. Full table scan is desired.

If we were to load this list in ascending order we do have the possibility of keeping a marker of the timestamp of the newest invite found. On subsequent calls, we could limit the results to only invites newer than that timestamp (minus ~30 seconds to account for race conditions), making subsequent calls very cheap. It is reasonable to assume that most invites will be older than the last `list()` call in a session and excluded from the results.

### Use Case 2
It is possible to optimize this use-case. The client could iterate through a paginated list of invitations and stop when it had found an invite matching the `address/conversationId` combination desired. This is true with or without conversation tagging. Topic rotations would complicate this approach, since there would be more than one invite for an `address/conversationId` combo. To solve for that case we would need to include a marker on all but the first invitation marking that it was a continuation of an existing invite. We would then continue iterating through the list until we found the first invite.

We could even include the timestamp of the previous invite in the marker, which would allow the client to skip ahead to the right starting point to find the next invite. This would turn the invites into more of a linked list, resulting in a greater number of queries but less results returned. The number of serial round trips to the server in that scenario may work out to be more costly than simply requesting more invites than are needed and hoping we find more than one matching invite in a page of results. This would depend on the average number of rotations.

Any approach that involves stopping early will be a substantial improvement for finding recent conversations, but may be less optimal in other scenarios.

- Loading the oldest conversation would require loading all invites, since  this approach needs to happen in descending order (at least in a world with topic rotation)
- Loading multiple conversations at different times. By stopping early, we prevent ourselves from building a complete cache of older records that can be re-used for subsequent queries. We can still store invites that were collected incidentally (we were looking for conversations with address A, but came across conversations with B, C, and D along the way), but the cache will not be complete until we happen upon a query that takes us to the last page of results. An invite not already seen may be earlier than the earliest result of the last run, or later than the latest.
- Page size matters a lot here. Too small a page size and you will have a lot of requests to find the invite you need. Too large a page size and you will read many invites unrelated to your query (including potentially invites the client has seen before). You could get clever with using range queries based on previously seen results to omit certain ranges that have already been scanned, but that can get very complicated very fast.

	We will have to handle the uncertainty of having an incomplete cache by reading some of the same invites multiple times to satisfy different queries. At the very least, the first page of results will need to be read a lot.


### Use Case 3
Streaming in a world where we have a single invite per `address/conversationId` combination is very straightforward. We get a new invite and can use it as-is. No optimization needed.

If we were to have topic rotation, things get more complicated. If the newly streamed invite was a continuation of a previous conversation we would have to go through the same process as use-case 2 to join the new invite with older ones. Even if we had already cached some previous invites for that `address/conversationId` combination, we would still need to check and ensure that new invites had not been sent in the time between when the cache was loaded and when the stream had started.

## Conclusion
If I had to pick one optimization, my vote is for the optimizations for use-case 1. We know it is a very common pattern in the SDK to list all conversations and then send messages to those convos. If the average application has to load the full invite list at any point, it is the most efficient solution. And in many cases it is the most efficient approach even when the client never lists all conversations.

By loading conversations in ascending order, we only have to go through the pain of a “full table scan” once in a client session. All subsequent calls, including the ones in use-case 2 and 3, would only have to query for results after the newest discovered invite. This will almost always be a very small result set.

A hybrid of the optimizations for use-case 1 and use-case 2 might be possible, but are pretty complicated and feel like a premature optimization at this point. Open to ideas on how we can do this more cleanly.

## Drawbacks
- Given that we don’t have a concept of trusted timestamps, it would be possible to send a backdated invite that would not be picked up in a subsequent loading of the invite topic. This would resolve itself on a browser refresh or a new client instantiation
- This will be slower than other solutions for apps that only send to a single address (for example, a customer support app)