### PR TITLE
V2 Conversations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.2.0",
+        "@xmtp/proto": "^3.4.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "node-localstorage": "^2.2.1"
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
-      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.4.0.tgz",
+      "integrity": "sha512-DIXgEVTDV9nctUhxLqMzdInmIqShKaTNa0wv61qFvaH8SRN5o3gq9uIuQLFGwxWZLK75GAFa+0orsX1T4eAXiw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16215,9 +16215,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.2.0.tgz",
-      "integrity": "sha512-+WdyuwAU/br7uZcdENATn68fME/vNUUn/iHt1JI44VzQj5ZdR6XzNAhzQpQMMLikXDJrLhBl0cou2eVP1/glvw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.4.0.tgz",
+      "integrity": "sha512-DIXgEVTDV9nctUhxLqMzdInmIqShKaTNa0wv61qFvaH8SRN5o3gq9uIuQLFGwxWZLK75GAFa+0orsX1T4eAXiw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.2.0",
+    "@xmtp/proto": "^3.4.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "node-localstorage": "^2.2.1"

--- a/src/Invitation.ts
+++ b/src/Invitation.ts
@@ -1,19 +1,30 @@
 import Long from 'long'
 import { SignedPublicKeyBundle } from './crypto/PublicKeyBundle'
-import { invitation } from '@xmtp/proto'
+import { messageApi, invitation, fetcher } from '@xmtp/proto'
 import Ciphertext from './crypto/Ciphertext'
-import { decrypt, encrypt } from './crypto'
+import { decrypt, encrypt, utils } from './crypto'
 import { PrivateKeyBundleV2 } from './crypto/PrivateKeyBundle'
-import { dateToNs } from './utils'
+import { dateToNs, buildDirectMessageTopicV2 } from './utils'
+const { b64Decode } = fetcher
+
+export type InvitationContext = {
+  conversationId: string
+  metadata: { [k: string]: string }
+}
 
 /**
  * InvitationV1 is a protobuf message to be encrypted and used as the ciphertext in a SealedInvitationV1 message
  */
 export class InvitationV1 implements invitation.InvitationV1 {
   topic: string
+  context: InvitationContext | undefined
   aes256GcmHkdfSha256: invitation.InvitationV1_Aes256gcmHkdfsha256 // eslint-disable-line camelcase
 
-  constructor({ topic, aes256GcmHkdfSha256 }: invitation.InvitationV1) {
+  constructor({
+    topic,
+    context,
+    aes256GcmHkdfSha256,
+  }: invitation.InvitationV1) {
     if (!topic || !topic.length) {
       throw new Error('Missing topic')
     }
@@ -25,7 +36,23 @@ export class InvitationV1 implements invitation.InvitationV1 {
       throw new Error('Missing key material')
     }
     this.topic = topic
+    this.context = context
     this.aes256GcmHkdfSha256 = aes256GcmHkdfSha256
+  }
+
+  static createRandom(context?: invitation.InvitationV1_Context): InvitationV1 {
+    const topic = buildDirectMessageTopicV2(
+      Buffer.from(utils.getRandomValues(new Uint8Array(32)))
+        .toString('base64')
+        .replace(/=*$/g, '')
+    )
+    const keyMaterial = utils.getRandomValues(new Uint8Array(32))
+
+    return new InvitationV1({
+      topic,
+      aes256GcmHkdfSha256: { keyMaterial },
+      context,
+    })
   }
 
   toBytes(): Uint8Array {
@@ -165,6 +192,23 @@ export class SealedInvitation implements invitation.SealedInvitation {
 
   static fromBytes(bytes: Uint8Array): SealedInvitation {
     return new SealedInvitation(invitation.SealedInvitation.decode(bytes))
+  }
+
+  static async fromEnvelope(
+    env: messageApi.Envelope
+  ): Promise<SealedInvitation> {
+    if (!env.message || !env.timestampNs) {
+      throw new Error('invalid invitation envelope')
+    }
+    const sealed = SealedInvitation.fromBytes(
+      b64Decode(env.message as unknown as string)
+    )
+    const envelopeTime = Long.fromString(env.timestampNs)
+    const headerTime = sealed.v1.header.createdNs
+    if (!headerTime.equals(envelopeTime)) {
+      throw new Error('envelope and header timestamp mistmatch')
+    }
+    return sealed
   }
 
   /**

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -1,17 +1,12 @@
 import { UnsubscribeFn } from './ApiClient'
-import Message from './Message'
 import Client from './Client'
-import { messageApi, fetcher } from '@xmtp/proto'
+import { messageApi } from '@xmtp/proto'
 
-export type MessageTransformer<T> = (msg: Message) => T
+export type MessageDecoder<M> = (
+  env: messageApi.Envelope
+) => Promise<M | undefined>
 
-export type MessageFilter = (msg: Message) => boolean
-
-export type ContentTopicUpdater = (msg: Message) => string[] | undefined
-
-export const noTransformation = (msg: Message): Message => {
-  return msg
-}
+export type ContentTopicUpdater<M> = (msg: M) => string[] | undefined
 
 /**
  * Stream implements an Asynchronous Iterable over messages received from a topic.
@@ -33,37 +28,28 @@ export default class Stream<T> {
   constructor(
     client: Client,
     topics: string[],
-    messageTransformer: MessageTransformer<T>,
-    messageFilter?: MessageFilter,
-    contentTopicUpdater?: ContentTopicUpdater
+    decoder: MessageDecoder<T>,
+    contentTopicUpdater?: ContentTopicUpdater<T>
   ) {
     this.messages = []
     this.resolvers = []
     this.topics = topics
     this.client = client
-    this.callback = this.newMessageCallback(
-      messageTransformer,
-      messageFilter,
-      contentTopicUpdater
-    )
+    this.callback = this.newMessageCallback(decoder, contentTopicUpdater)
   }
 
   // returns new closure to handle incoming messages
   private newMessageCallback(
-    transformer: MessageTransformer<T>,
-    filter?: MessageFilter,
-    contentTopicUpdater?: ContentTopicUpdater
+    decoder: MessageDecoder<T>,
+    contentTopicUpdater?: ContentTopicUpdater<T>
   ): (env: messageApi.Envelope) => Promise<void> {
     return async (env: messageApi.Envelope) => {
       if (!env.message) {
         return
       }
-      const msg = await this.client.decodeMessage(
-        fetcher.b64Decode(env.message as unknown as string),
-        env.contentTopic
-      )
-      // If there is a filter on the stream, and the filter returns false, ignore the message
-      if (filter && !filter(msg)) {
+      const msg = await decoder(env)
+      // decoder can return undefined to signal a message to ignore/skip.
+      if (!msg) {
         return
       }
       // Check to see if we should update the stream's content topic subscription
@@ -77,10 +63,10 @@ export default class Stream<T> {
       const resolver = this.resolvers.pop()
       if (resolver) {
         // yes, resolve it
-        resolver({ value: transformer(msg) })
+        resolver({ value: msg })
       } else {
         // no, push the message into the queue
-        this.messages.unshift(transformer(msg))
+        this.messages.unshift(msg)
       }
     }
   }
@@ -104,17 +90,10 @@ export default class Stream<T> {
   static async create<T>(
     client: Client,
     topics: string[],
-    messageTransformer: MessageTransformer<T>,
-    messageFilter?: MessageFilter,
-    contentTopicUpdater?: ContentTopicUpdater
+    decoder: MessageDecoder<T>,
+    contentTopicUpdater?: ContentTopicUpdater<T>
   ): Promise<Stream<T>> {
-    const stream = new Stream(
-      client,
-      topics,
-      messageTransformer,
-      messageFilter,
-      contentTopicUpdater
-    )
+    const stream = new Stream(client, topics, decoder, contentTopicUpdater)
     await stream.start()
     return stream
   }

--- a/src/codecs/Composite.ts
+++ b/src/codecs/Composite.ts
@@ -77,7 +77,7 @@ export class CompositeCodec implements ContentCodec<Composite> {
     for (const part of content.parts) {
       parts.push(this.toProto(part, codecs))
     }
-    return { composite: { parts: parts }, part: undefined }
+    return { composite: { parts }, part: undefined }
   }
 
   private fromProto(
@@ -105,6 +105,6 @@ export class CompositeCodec implements ContentCodec<Composite> {
     for (const part of content.composite.parts) {
       parts.push(this.fromProto(part, codecs))
     }
-    return { parts: parts }
+    return { parts }
   }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -4,39 +4,53 @@ import Client, {
   ListMessagesPaginatedOptions,
   SendOptions,
 } from '../Client'
-import Message from '../Message'
+import {
+  InvitationContext,
+  InvitationV1,
+  SealedInvitationHeaderV1,
+} from '../Invitation'
+import { MessageV1, MessageV2 } from '../Message'
+import { messageApi, xmtpEnvelope, fetcher } from '@xmtp/proto'
+import { encrypt, decrypt, SignedPublicKey, Signature } from '../crypto'
+import Ciphertext from '../crypto/Ciphertext'
+import { sha256 } from '../crypto/encryption'
+import { dateToNs, nsToDate } from '../utils'
+const { b64Decode } = fetcher
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
 /**
  * Conversation class allows you to view, stream, and send messages to/from a peer address
  */
-export default class Conversation {
+export class ConversationV1 {
   peerAddress: string
+  createdAt: Date
+  context = null
   private client: Client
 
-  constructor(client: Client, address: string) {
+  constructor(client: Client, address: string, createdAt: Date) {
     this.peerAddress = address
     this.client = client
+    this.createdAt = createdAt
   }
 
   /**
    * Returns a list of all messages to/from the peerAddress
    */
-  async messages(opts?: ListMessagesOptions): Promise<Message[]> {
+  async messages(opts?: ListMessagesOptions): Promise<MessageV1[]> {
     return this.client.listConversationMessages(this.peerAddress, opts)
   }
 
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<Message[]> {
+  ): AsyncGenerator<MessageV1[]> {
     return this.client.listConversationMessagesPaginated(this.peerAddress, opts)
   }
 
   /**
    * Returns a Stream of any new messages to/from the peerAddress
    */
-  streamMessages(): Promise<Stream<Message>> {
+  streamMessages(): Promise<Stream<MessageV1>> {
     return this.client.streamConversationMessages(this.peerAddress)
   }
 
@@ -46,7 +60,176 @@ export default class Conversation {
   send(
     message: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     options?: SendOptions
-  ): Promise<Message> {
+  ): Promise<MessageV1> {
     return this.client.sendMessage(this.peerAddress, message, options)
   }
+}
+
+export class ConversationV2 {
+  topic: string
+  keyMaterial: Uint8Array // MUST be kept secret
+  context?: InvitationContext
+  private header: SealedInvitationHeaderV1
+  private client: Client
+  peerAddress: string
+
+  constructor(
+    client: Client,
+    invitation: InvitationV1,
+    header: SealedInvitationHeaderV1,
+    peerAddress: string
+  ) {
+    this.topic = invitation.topic
+    this.keyMaterial = invitation.aes256GcmHkdfSha256.keyMaterial
+    this.context = invitation.context
+    this.client = client
+    this.header = header
+    this.peerAddress = peerAddress
+  }
+
+  static async create(
+    client: Client,
+    invitation: InvitationV1,
+    header: SealedInvitationHeaderV1
+  ): Promise<ConversationV2> {
+    const myKeys = client.keys.getPublicKeyBundle()
+    const peer = myKeys.equals(header.sender) ? header.recipient : header.sender
+    const peerAddress = await peer.walletSignatureAddress()
+    return new ConversationV2(client, invitation, header, peerAddress)
+  }
+
+  get createdAt(): Date {
+    return nsToDate(this.header.createdNs)
+  }
+
+  /**
+   * Returns a list of all messages to/from the peerAddress
+   */
+  async messages(opts?: ListMessagesOptions): Promise<MessageV2[]> {
+    return this.client.listEnvelopes(
+      [this.topic],
+      this.decodeMessage.bind(this),
+      opts
+    )
+  }
+
+  messagesPaginated(
+    opts?: ListMessagesPaginatedOptions
+  ): AsyncGenerator<MessageV2[]> {
+    return this.client.listEnvelopesPaginated(
+      [this.topic],
+      this.decodeMessage.bind(this),
+      opts
+    )
+  }
+
+  /**
+   * Returns a Stream of any new messages to/from the peerAddress
+   */
+  streamMessages(): Promise<Stream<MessageV2>> {
+    return Stream.create<MessageV2>(
+      this.client,
+      [this.topic],
+      this.decodeMessage.bind(this)
+    )
+  }
+
+  /**
+   * Send a message into the conversation
+   */
+  async send(
+    message: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    options?: SendOptions
+  ): Promise<MessageV2> {
+    const msg = await this.encodeMessage(message, options)
+    this.client.publishEnvelopes([
+      {
+        contentTopic: this.topic,
+        message: msg.toBytes(),
+        timestamp: msg.sent,
+      },
+    ])
+    return msg
+  }
+
+  private async encodeMessage(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    content: any,
+    options?: SendOptions
+  ): Promise<MessageV2> {
+    const payload = await this.client.encodeContent(content, options)
+    const header: xmtpEnvelope.MessageHeaderV2 = {
+      topic: this.topic,
+      createdNs: dateToNs(options?.timestamp || new Date()),
+    }
+    const headerBytes = xmtpEnvelope.MessageHeaderV2.encode(header).finish()
+    const digest = await sha256(concat(headerBytes, payload))
+    const signed = {
+      payload,
+      sender: this.client.keys.getPublicKeyBundle(),
+      signature: await this.client.keys.getCurrentPreKey().sign(digest),
+    }
+    const signedBytes = xmtpEnvelope.SignedContent.encode(signed).finish()
+    const ciphertext = await encrypt(signedBytes, this.keyMaterial, headerBytes)
+    const protoMsg = {
+      v1: undefined,
+      v2: { headerBytes, ciphertext },
+    }
+    const bytes = xmtpEnvelope.Message.encode(protoMsg).finish()
+    const msg = await MessageV2.create(protoMsg, header, signed, bytes)
+    return msg
+  }
+
+  private async decodeMessage(env: messageApi.Envelope): Promise<MessageV2> {
+    if (!env.message) {
+      throw new Error('empty envelope')
+    }
+    const msg = xmtpEnvelope.Message.decode(b64Decode(env.message.toString()))
+    if (!msg.v2) {
+      throw new Error('unknown message version')
+    }
+    const msgv2 = msg.v2
+    const header = xmtpEnvelope.MessageHeaderV2.decode(msgv2.headerBytes)
+    if (header.topic !== this.topic) {
+      throw new Error('topic mismatch')
+    }
+    if (!msgv2.ciphertext) {
+      throw new Error('missing ciphertext')
+    }
+    const decrypted = await decrypt(
+      new Ciphertext(msgv2.ciphertext),
+      this.keyMaterial,
+      msgv2.headerBytes
+    )
+    const signed = xmtpEnvelope.SignedContent.decode(decrypted)
+    if (
+      !signed.sender?.identityKey ||
+      !signed.sender?.preKey ||
+      !signed.signature
+    ) {
+      throw new Error('incomplete signed content')
+    }
+
+    const digest = await sha256(concat(msgv2.headerBytes, signed.payload))
+    if (
+      !new SignedPublicKey(signed.sender?.preKey).verify(
+        new Signature(signed.signature),
+        digest
+      )
+    ) {
+      throw new Error('invalid signature')
+    }
+    const message = await MessageV2.create(msg, header, signed, env.message)
+    await this.client.decodeContent(message)
+    return message
+  }
+}
+
+export type Conversation = ConversationV1 | ConversationV2
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const ab = new Uint8Array(a.length + b.length)
+  ab.set(a)
+  ab.set(b, a.length)
+  return ab
 }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -1,14 +1,19 @@
-import Conversation from './Conversation'
-import Message from '../Message'
-import Stream, {
-  MessageFilter,
-  MessageTransformer,
-  noTransformation,
-} from '../Stream'
+import { SignedPublicKeyBundle } from './../crypto/PublicKeyBundle'
+import { InvitationContext } from './../Invitation'
+import { Conversation, ConversationV1, ConversationV2 } from './Conversation'
+import { MessageV1 } from '../Message'
+import Stream from '../Stream'
 import Client from '../Client'
-import { buildDirectMessageTopic, buildUserIntroTopic } from '../utils'
+import {
+  buildDirectMessageTopic,
+  buildUserIntroTopic,
+  buildUserInviteTopic,
+} from '../utils'
+import { SealedInvitation, InvitationV1 } from '../Invitation'
+import { PublicKeyBundle } from '../crypto'
+import { messageApi } from '@xmtp/proto'
 
-const messageHasHeaders: MessageFilter = (msg: Message) => {
+const messageHasHeaders = (msg: MessageV1): boolean => {
   return Boolean(msg.recipientAddress && msg.senderAddress)
 }
 /**
@@ -24,28 +29,22 @@ export default class Conversations {
    * List all conversations with the current wallet found in the network, deduped by peer address
    */
   async list(): Promise<Conversation[]> {
-    const messages = await this.client.listIntroductionMessages()
-    const seenPeers: Set<string> = new Set()
-    for (const message of messages) {
-      // Ignore all messages without sender or recipient address headers
-      // Makes getPeerAddress safe
-      if (!messageHasHeaders(message)) {
-        continue
-      }
+    const seenPeers = await this.getIntroductionPeers()
 
-      const peerAddress = this.getPeerAddress(message)
+    const conversations: Conversation[] = []
+    seenPeers.forEach((sent, peerAddress) =>
+      conversations.push(new ConversationV1(this.client, peerAddress, sent))
+    )
 
-      if (peerAddress) {
-        seenPeers.add(peerAddress)
-      }
+    for (const sealed of await this.client.listInvitations()) {
+      const unsealed = await sealed.v1.getInvitation(this.client.keys)
+      conversations.push(
+        await ConversationV2.create(this.client, unsealed, sealed.v1.header)
+      )
     }
 
-    return (
-      Array.from(seenPeers)
-        // Consistently order the results
-        .sort()
-        .map((peerAddress) => new Conversation(this.client, peerAddress))
-    )
+    conversations.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    return conversations
   }
 
   /**
@@ -53,21 +52,12 @@ export default class Conversations {
    * Will dedupe to not return the same conversation twice in the same stream.
    * Does not dedupe any other previously seen conversations
    */
-  stream(): Promise<Stream<Conversation>> {
-    const messageTransformer: MessageTransformer<Conversation> = (
-      msg: Message
-    ) => {
-      const peerAddress = this.getPeerAddress(msg)
-      return new Conversation(this.client, peerAddress)
-    }
-
+  async stream(): Promise<Stream<Conversation>> {
     const seenPeers: Set<string> = new Set()
+    const introTopic = buildUserIntroTopic(this.client.address)
+    const inviteTopic = buildUserInviteTopic(this.client.address)
 
-    const filter = (msg: Message): boolean => {
-      if (!messageHasHeaders(msg)) {
-        return false
-      }
-      const peerAddress = this.getPeerAddress(msg)
+    const newPeer = (peerAddress: string): boolean => {
       // Check if we have seen the peer already in this stream
       if (seenPeers.has(peerAddress)) {
         return false
@@ -76,27 +66,48 @@ export default class Conversations {
       return true
     }
 
+    const decodeConversation = async (env: messageApi.Envelope) => {
+      if (env.contentTopic === introTopic) {
+        const msg = await this.client.decodeEnvelope(env)
+        const peerAddress = this.getPeerAddress(msg)
+        if (!newPeer(peerAddress)) {
+          return undefined
+        }
+        return new ConversationV1(this.client, peerAddress, msg.sent)
+      }
+      if (env.contentTopic === inviteTopic) {
+        const sealed = await SealedInvitation.fromEnvelope(env)
+        const unsealed = await sealed.v1.getInvitation(this.client.keys)
+        return await ConversationV2.create(
+          this.client,
+          unsealed,
+          sealed.v1.header
+        )
+      }
+      throw new Error('unrecognized invite topic')
+    }
+
     return Stream.create<Conversation>(
       this.client,
-      [buildUserIntroTopic(this.client.address)],
-      messageTransformer,
-      filter
+      [inviteTopic, introTopic],
+      decodeConversation.bind(this)
     )
   }
 
   /**
    * Returns a stream for all new messages from existing and new conversations.
    */
-  async streamAllMessages(): Promise<Stream<Message>> {
+  async streamAllMessages(): Promise<Stream<MessageV1>> {
     const conversations = await this.list()
-    const dmAddresses: string[] = conversations.map(
-      (conversation) => conversation.peerAddress
-    )
+    const dmAddresses: string[] = []
+    for (const conversation of conversations) {
+      dmAddresses.push(conversation.peerAddress)
+    }
     const introTopic = buildUserIntroTopic(this.client.address)
     const topics = this.buildTopicsForAllMessages(dmAddresses, introTopic)
 
     // If we detect a new intro topic, update the stream's direct message topics to include the new topic
-    const contentTopicUpdater = (msg: Message): string[] | undefined => {
+    const contentTopicUpdater = (msg: MessageV1): string[] | undefined => {
       if (msg.contentTopic !== introTopic || !messageHasHeaders(msg)) {
         return undefined
       }
@@ -113,7 +124,7 @@ export default class Conversations {
     }
 
     // Filter intro topics if already streaming direct messages for that address to avoid duplicates
-    const filter = (msg: Message): boolean => {
+    const filter = (msg: MessageV1): boolean => {
       if (
         msg.contentTopic === introTopic &&
         messageHasHeaders(msg) &&
@@ -124,13 +135,38 @@ export default class Conversations {
       return true
     }
 
-    return Stream.create<Message>(
+    return Stream.create<MessageV1>(
       this.client,
       topics,
-      noTransformation,
-      filter,
+      async (env) => {
+        const msg = await this.client.decodeEnvelope(env)
+        return filter(msg) ? msg : undefined
+      },
       contentTopicUpdater
     )
+  }
+
+  private async getIntroductionPeers(): Promise<Map<string, Date>> {
+    const messages = await this.client.listIntroductionMessages()
+    const seenPeers: Map<string, Date> = new Map()
+    for (const message of messages) {
+      // Ignore all messages without sender or recipient address headers
+      // Makes getPeerAddress safe
+      if (!messageHasHeaders(message)) {
+        continue
+      }
+
+      const peerAddress = this.getPeerAddress(message)
+
+      if (peerAddress) {
+        const have = seenPeers.get(peerAddress)
+        if (!have || have > message.sent) {
+          seenPeers.set(peerAddress, message.sent)
+        }
+      }
+    }
+
+    return seenPeers
   }
 
   /**
@@ -151,16 +187,102 @@ export default class Conversations {
   /**
    * Creates a new conversation for the given address. Will throw an error if the peer is not found in the XMTP network
    */
-  async newConversation(peerAddress: string): Promise<Conversation> {
-    const contact = await this.client.getUserContact(peerAddress)
+  async newConversation(
+    peerAddress: string,
+    context?: InvitationContext
+  ): Promise<Conversation> {
+    let contact = await this.client.getUserContact(peerAddress)
     if (!contact) {
       throw new Error(`Recipient ${peerAddress} is not on the XMTP network`)
     }
 
-    return new Conversation(this.client, peerAddress)
+    // If this is a V1 conversation continuation
+    if (contact instanceof PublicKeyBundle && !context?.conversationId) {
+      return new ConversationV1(this.client, peerAddress, new Date())
+    }
+
+    if (!context?.conversationId) {
+      const intros = await this.getIntroductionPeers()
+      const introSentTime = intros.get(peerAddress)
+      // If intro already exists, return V1 conversation
+      if (introSentTime) {
+        return new ConversationV1(this.client, peerAddress, introSentTime)
+      }
+    }
+
+    // Coerce the contact into a V2 bundle
+    if (contact instanceof PublicKeyBundle) {
+      contact = SignedPublicKeyBundle.fromLegacyBundle(contact)
+    }
+
+    for (const sealedInvite of await this.client.listInvitations()) {
+      const isSamePeer =
+        sealedInvite.v1.header.recipient.equals(contact) ||
+        sealedInvite.v1.header.sender.equals(contact)
+      if (!isSamePeer) {
+        continue
+      }
+      try {
+        // Need to decode invite even without a context to ensure decryption succeeds and invite is valid
+        const invite = await sealedInvite.v1.getInvitation(this.client.keys)
+        // If the contexts match, return early
+        if (isMatchingContext(context, invite.context)) {
+          return await ConversationV2.create(
+            this.client,
+            invite,
+            sealedInvite.v1.header
+          )
+        }
+      } catch (e) {
+        console.warn('Error decoding invite', e)
+      }
+    }
+
+    // If no existing invite, send a new one
+    const invitation = InvitationV1.createRandom(context)
+    const sealedInvite = await this.sendInvitation(
+      contact,
+      invitation,
+      new Date()
+    )
+    return ConversationV2.create(
+      this.client,
+      invitation,
+      sealedInvite.v1.header
+    )
   }
 
-  private getPeerAddress(message: Message): string {
+  private async sendInvitation(
+    recipient: SignedPublicKeyBundle,
+    invitation: InvitationV1,
+    created: Date
+  ): Promise<SealedInvitation> {
+    const sealed = await SealedInvitation.createV1({
+      sender: this.client.keys,
+      recipient,
+      created,
+      invitation,
+    })
+
+    const peerAddress = await recipient.walletSignatureAddress()
+
+    this.client.publishEnvelopes([
+      {
+        contentTopic: buildUserInviteTopic(peerAddress),
+        message: sealed.toBytes(),
+        timestamp: created,
+      },
+      {
+        contentTopic: buildUserInviteTopic(this.client.address),
+        message: sealed.toBytes(),
+        timestamp: created,
+      },
+    ])
+
+    return sealed
+  }
+
+  private getPeerAddress(message: MessageV1): string {
     const peerAddress =
       message.recipientAddress === this.client.address
         ? message.senderAddress
@@ -169,4 +291,12 @@ export default class Conversations {
     // This assertion is safe, so long as messages have been through the filter
     return peerAddress as string
   }
+}
+
+function isMatchingContext(
+  contextA?: InvitationContext,
+  contextB?: InvitationContext
+): boolean {
+  // Use == to allow null and undefined to be equivalent
+  return contextA?.conversationId === contextB?.conversationId
 }

--- a/src/conversations/index.ts
+++ b/src/conversations/index.ts
@@ -1,2 +1,2 @@
 export { default as Conversations } from './Conversations'
-export { default as Conversation } from './Conversation'
+export { Conversation } from './Conversation'

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -2,8 +2,8 @@ import { publicKey } from '@xmtp/proto'
 import * as secp from '@noble/secp256k1'
 import Long from 'long'
 import Signature, { WalletSigner } from './Signature'
-import { bytesToHex, equalBytes, hexToBytes } from './utils'
-import { Signer, utils, Wallet } from 'ethers'
+import { equalBytes, hexToBytes } from './utils'
+import { Signer, utils } from 'ethers'
 import { sha256 } from './encryption'
 
 // SECP256k1 public key in uncompressed format with prefix

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -41,7 +41,9 @@ export class SignedPublicKeyBundle implements publicKey.SignedPublicKeyBundle {
 
   static fromLegacyBundle(bundle: PublicKeyBundle): SignedPublicKeyBundle {
     return new SignedPublicKeyBundle({
-      identityKey: SignedPublicKey.fromLegacyKey(bundle.identityKey),
+      // Note: I am assuming all PublicKeyBundles passed into this have had their identity keys signed by a wallet
+      // Maybe that is not universally true in the future
+      identityKey: SignedPublicKey.fromLegacyKey(bundle.identityKey, true),
       preKey: SignedPublicKey.fromLegacyKey(bundle.preKey),
     })
   }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -82,7 +82,7 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
     'deriveKey',
   ])
   return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt: salt, info: hkdfNoInfo },
+    { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
     key,
     { name: 'AES-GCM', length: 256 },
     false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import Message from './Message'
+import { Message } from './Message'
 import {
   PublicKey,
   PublicKeyBundle,
   SignedPublicKeyBundle,
   PrivateKey,
-  PrivateKeyBundleV1,
-  PrivateKeyBundleV2,
+  PrivateKeyBundle,
 } from './crypto'
 import Stream from './Stream'
 import Client, {
@@ -14,7 +13,7 @@ import Client, {
   SendOptions,
   Compression,
 } from './Client'
-import { Conversation, Conversations } from './conversations'
+import { Conversations, Conversation } from './conversations'
 import {
   ContentTypeId,
   ContentCodec,
@@ -37,8 +36,7 @@ export {
   ListMessagesOptions,
   Message,
   PrivateKey,
-  PrivateKeyBundleV1,
-  PrivateKeyBundleV2,
+  PrivateKeyBundle,
   PublicKey,
   PublicKeyBundle,
   SignedPublicKeyBundle,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,10 @@ export const buildDirectMessageTopic = (
   return buildContentTopic(`dm-${members.join('-')}`)
 }
 
+export const buildDirectMessageTopicV2 = (randomString: string): string => {
+  return buildContentTopic(`dm-${randomString}`)
+}
+
 export const buildUserContactTopic = (walletAddr: string): string => {
   return buildContentTopic(`contact-${walletAddr}`)
 }
@@ -23,6 +27,9 @@ export const buildUserIntroTopic = (walletAddr: string): string => {
   return buildContentTopic(`intro-${walletAddr}`)
 }
 
+export const buildUserInviteTopic = (walletAddr: string): string => {
+  return buildContentTopic(`invite-${walletAddr}`)
+}
 export const buildUserPrivateStoreTopic = (walletAddr: string): string => {
   return buildContentTopic(`privatestore-${walletAddr}`)
 }
@@ -74,7 +81,7 @@ export async function retry<T extends (...arg0: any[]) => any>(
   }
 }
 
-type EnvelopeMapper<Out> = (env: messageApi.Envelope) => Promise<Out>
+export type EnvelopeMapper<Out> = (env: messageApi.Envelope) => Promise<Out>
 
 // Takes an async generator returning pages of envelopes and converts to an async
 // generator returning pages of an arbitrary type using a mapper function
@@ -102,4 +109,8 @@ export async function* mapPaginatedStream<Out>(
 
 export function dateToNs(date: Date): Long {
   return Long.fromNumber(date.valueOf()).multiply(1_000_000)
+}
+
+export function nsToDate(ns: Long): Date {
+  return new Date(ns.divide(1_000_000).toNumber())
 }

--- a/test/ContactBundle.test.ts
+++ b/test/ContactBundle.test.ts
@@ -1,11 +1,11 @@
 import * as assert from 'assert'
 import { decodeContactBundle, encodeContactBundle } from '../src/ContactBundle'
+import { PublicKeyBundle, SignedPublicKeyBundle } from '../src'
 import {
   PrivateKeyBundleV1,
   PrivateKeyBundleV2,
-  PublicKeyBundle,
-  SignedPublicKeyBundle,
-} from '../src'
+} from '../src/crypto/PrivateKeyBundle'
+
 import { newWallet } from './helpers'
 
 describe('ContactBundles', function () {

--- a/test/Invitation.test.ts
+++ b/test/Invitation.test.ts
@@ -13,6 +13,7 @@ import Ciphertext from '../src/crypto/Ciphertext'
 const createInvitation = (): InvitationV1 => {
   return new InvitationV1({
     topic: crypto.getRandomValues(new Uint8Array(32)).toString(),
+    context: undefined,
     aes256GcmHkdfSha256: {
       keyMaterial: crypto.getRandomValues(new Uint8Array(32)),
     },
@@ -183,6 +184,7 @@ describe('Invitations', () => {
       const topic = 'foo'
       const invite = new InvitationV1({
         topic,
+        context: undefined,
         aes256GcmHkdfSha256: {
           keyMaterial,
         },
@@ -205,13 +207,18 @@ describe('Invitations', () => {
         () =>
           new InvitationV1({
             topic,
+            context: undefined,
             aes256GcmHkdfSha256: { keyMaterial: new Uint8Array() },
           })
       ).toThrow('Missing key material')
 
       expect(
         () =>
-          new InvitationV1({ topic: '', aes256GcmHkdfSha256: { keyMaterial } })
+          new InvitationV1({
+            topic: '',
+            context: undefined,
+            aes256GcmHkdfSha256: { keyMaterial },
+          })
       ).toThrow('Missing topic')
     })
   })

--- a/test/Keygen.test.ts
+++ b/test/Keygen.test.ts
@@ -28,7 +28,7 @@ describe('Key Generation', () => {
       ...opts,
       privateKeyOverride: keys,
     })
-    expect(client.keys.encode()).toEqual(keys)
+    expect(client.legacyKeys.encode()).toEqual(keys)
   })
 
   test('LocalStorage store', async () => {
@@ -43,7 +43,7 @@ describe('Key Generation', () => {
       ...opts,
       privateKeyOverride: keys,
     })
-    expect(client.keys.encode()).toEqual(keys)
+    expect(client.legacyKeys.encode()).toEqual(keys)
   })
 
   // Make sure that the keys are being saved to the network upon generation

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -1,3 +1,7 @@
+import {
+  ConversationV1,
+  ConversationV2,
+} from './../../src/conversations/Conversation'
 import { newLocalHostClient, waitForUserContact } from './../helpers'
 import { Client } from '../../src'
 import {
@@ -32,15 +36,17 @@ describe('conversations', () => {
 
     const aliceToBob = await alice.conversations.newConversation(bob.address)
     await aliceToBob.send('gm')
-    await sleep(50)
+    await sleep(100)
 
     const aliceConversationsAfterMessage = await alice.conversations.list()
     expect(aliceConversationsAfterMessage).toHaveLength(1)
-    expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
+    expect(await aliceConversationsAfterMessage[0].peerAddress).toBe(
+      bob.address
+    )
 
     const bobConversations = await bob.conversations.list()
     expect(bobConversations).toHaveLength(1)
-    expect(bobConversations[0].peerAddress).toBe(alice.address)
+    expect(await bobConversations[0].peerAddress).toBe(alice.address)
   })
 
   it('streams conversations', async () => {
@@ -51,7 +57,7 @@ describe('conversations', () => {
     let numConversations = 0
     for await (const conversation of stream) {
       numConversations++
-      expect(conversation.peerAddress).toBe(bob.address)
+      expect(await conversation.peerAddress).toBe(bob.address)
       break
     }
     expect(numConversations).toBe(1)
@@ -98,7 +104,7 @@ describe('conversations', () => {
     const bobAlice = await bob.conversations.newConversation(alice.address)
 
     await aliceBob.send('gm alice -bob')
-    await sleep(50)
+    await sleep(100)
     const existingConversations = await alice.conversations.list()
     expect(existingConversations).toHaveLength(1)
 
@@ -137,7 +143,7 @@ describe('conversations', () => {
       aliceConversation.send('gm'),
       bobConversation.send('gm'),
     ])
-    await sleep(50)
+    await sleep(100)
 
     const [aliceConversationsList, bobConversationList] = await Promise.all([
       alice.conversations.list(),
@@ -145,5 +151,125 @@ describe('conversations', () => {
     ])
     expect(aliceConversationsList).toHaveLength(1)
     expect(bobConversationList).toHaveLength(1)
+  })
+
+  describe('newConversation', () => {
+    it('uses an existing v1 conversation when one exists', async () => {
+      const aliceConvo = await alice.conversations.newConversation(bob.address)
+      expect(aliceConvo instanceof ConversationV1).toBeTruthy()
+      await aliceConvo.send('gm')
+      const bobConvo = await bob.conversations.newConversation(alice.address)
+      expect(bobConvo instanceof ConversationV1).toBeTruthy()
+    })
+
+    it('continues to use v1 conversation even after upgrading bundle', async () => {
+      const aliceConvo = await alice.conversations.newConversation(bob.address)
+      await aliceConvo.send('gm')
+      expect(aliceConvo instanceof ConversationV1).toBeTruthy()
+      await bob.publishUserContact(false)
+      alice.forgetContact(bob.address)
+      await sleep(100)
+
+      const aliceConvo2 = await alice.conversations.newConversation(bob.address)
+      expect(aliceConvo2 instanceof ConversationV1).toBeTruthy()
+    })
+
+    it('creates a new V2 conversation when no existing convo and V2 bundle', async () => {
+      await bob.publishUserContact(false)
+      alice.forgetContact(bob.address)
+      await sleep(100)
+
+      const aliceConvo = await alice.conversations.newConversation(bob.address)
+      expect(aliceConvo instanceof ConversationV2).toBeTruthy()
+    })
+
+    it('creates a v2 conversation when conversation ID is present', async () => {
+      const conversationId = 'xmtp.org/foo'
+      const aliceConvo = await alice.conversations.newConversation(
+        bob.address,
+        { conversationId, metadata: { foo: 'bar' } }
+      )
+      await sleep(100)
+
+      expect(aliceConvo instanceof ConversationV2).toBeTruthy()
+      expect(aliceConvo.context?.conversationId).toBe(conversationId)
+      expect(aliceConvo.context?.metadata.foo).toBe('bar')
+
+      // Ensure alice received an invite
+      const aliceInvites = await alice.listInvitations()
+      expect(aliceInvites).toHaveLength(1)
+      expect(
+        aliceInvites[0].v1.header.sender.equals(alice.keys.getPublicKeyBundle())
+      ).toBeTruthy()
+      expect(
+        aliceInvites[0].v1.header.recipient.equals(
+          bob.keys.getPublicKeyBundle()
+        )
+      ).toBeTruthy()
+
+      // Ensure bob received an invite
+      const bobInvites = await bob.listInvitations()
+      expect(bobInvites).toHaveLength(1)
+      const invite = await bobInvites[0].v1.getInvitation(bob.keys)
+      expect(invite.context?.conversationId).toBe(conversationId)
+    })
+
+    it('re-uses same invite when multiple conversations started with the same ID', async () => {
+      const conversationId = 'xmtp.org/foo'
+      const aliceConvo1 = await alice.conversations.newConversation(
+        bob.address,
+        { conversationId, metadata: {} }
+      )
+      await sleep(100)
+
+      const aliceConvo2 = await alice.conversations.newConversation(
+        bob.address,
+        { conversationId, metadata: {} }
+      )
+
+      if (
+        aliceConvo1 instanceof ConversationV2 &&
+        aliceConvo2 instanceof ConversationV2
+      ) {
+        expect(aliceConvo2.topic).toBe(aliceConvo1.topic)
+      } else {
+        throw new Error('Not a v2 conversation')
+      }
+
+      const aliceInvites = await alice.listInvitations()
+      expect(aliceInvites).toHaveLength(1)
+      const invite = await aliceInvites[0].v1.getInvitation(alice.keys)
+      expect(invite.topic).toBe(aliceConvo1.topic)
+    })
+
+    it('sends multiple invites when different IDs are used', async () => {
+      const conversationId1 = 'xmtp.org/foo'
+      const conversationId2 = 'xmtp.org/bar'
+      const aliceConvo1 = await alice.conversations.newConversation(
+        bob.address,
+        { conversationId: conversationId1, metadata: {} }
+      )
+      await sleep(100)
+
+      const aliceConvo2 = await alice.conversations.newConversation(
+        bob.address,
+        { conversationId: conversationId2, metadata: {} }
+      )
+      await sleep(100)
+
+      if (
+        !(aliceConvo1 instanceof ConversationV2) ||
+        !(aliceConvo2 instanceof ConversationV2)
+      ) {
+        throw new Error('Not a V2 conversation')
+      }
+
+      expect(aliceConvo1.topic === aliceConvo2.topic).toBeFalsy()
+      const aliceInvites = await alice.listInvitations()
+      expect(aliceInvites).toHaveLength(2)
+
+      const bobInvites = await bob.listInvitations()
+      expect(bobInvites).toHaveLength(2)
+    })
   })
 })

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,7 +1,6 @@
 import { Wallet } from 'ethers'
 import {
   PrivateKey,
-  Message,
   ContentCodec,
   ContentTypeId,
   TextCodec,
@@ -11,7 +10,7 @@ import {
 import Stream from '../src/Stream'
 import { promiseWithTimeout } from '../src/utils'
 import assert from 'assert'
-import { PublicKeyBundle } from '../src/crypto'
+import { PublicKeyBundle, SignedPublicKeyBundle } from '../src/crypto'
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
@@ -40,7 +39,7 @@ export async function pollFor<T>(
 export async function waitForUserContact(
   c1: Client,
   c2: Client
-): Promise<PublicKeyBundle | undefined> {
+): Promise<PublicKeyBundle | SignedPublicKeyBundle> {
   return pollFor(
     async () => {
       const contact = await c1.getUserContact(c2.address)
@@ -52,11 +51,11 @@ export async function waitForUserContact(
   )
 }
 
-export async function dumpStream(
-  stream: Stream<Message>,
+export async function dumpStream<T>(
+  stream: Stream<T>,
   timeoutMs = 1000
-): Promise<Message[]> {
-  const messages: Message[] = []
+): Promise<T[]> {
+  const messages: T[] = []
   try {
     while (true) {
       const result = await promiseWithTimeout(


### PR DESCRIPTION
## TODO
* [ ] acceptable test coverage of new features
* [x] replace unions with proper interfaces
* [x] make sure conversation_ids are scoped to peerAddress
* [x] squash commits and properly mark as BREAKING CHANGE to trigger major version increment
* [x] rebase on 'beta' branch

## Changes

* Client maintains both V1 and V2 private key bundles (`keys` vs `legacyKeys`), still publishing V1 only
* Client supports  reading both V1 and V2 peer contact bundles
* Client keeps publishing V1 contact bundle by default (tests can make it publish V2 contact)
* MessageV1/V2 classes to support header differences
* Both Message classes support `senderAddress()` & `sent`; `recipientAddress` not supported by V2 and should be abandoned (we could make it work in 1:1 convos if we link messages back to their conversations, but it won't work in group chat context)
* Stream generalized to support both message versions (streamAllMessages yet to be fixed in a follow up)
* ConversationV1/V2 classes to support different semantics
* ConversationV2 implements MessageV2 encoding/decoding (Client retains V1 version of that)
* listing/streaming conversations reads both the intro and invite topics and creates both kinds of conversations
* creating V2 conversation sends invites to both the sender and the recipient
* see below for the expanded behavior of `newConversation`
 
## Breaking changes

* `Message` is now `MessageV1 | MessageV2`
* `Conversation` is now `ConversationV1 | ConversationV2`
* Many of the `Client` methods are now restricted to `MessageV1` only as they are only pertinent to the V1 protocol; analogous V2 functionality can be found on `Conversation(s)`
* `Client.publishEnvelope()` is replaced by `Client.publishEnvelopes()` (not meant for general use)

## V1 vs V2 conversation rules

1.  V1 conversations will continue to be supported in read/write mode.
2. `newConversation` behavior
  a. if conversation_id defined => V2 conversation
  b. if peer contact v1 => V1 conversation - (to support old peer clients)
  c. if pre-existing v1 convo => V1 conversation - (to avoid splitting pre-existing conversations) 
  d. otherwise V2 conversation, but
    1. if v2 convo with the same conversation_id exists => continue that convo (no new invites)
    2. otherwise create a new V2 convo with the new ID
 