### PR TITLE
Deflake some tests

### DIFF
--- a/src/authn/Authenticator.ts
+++ b/src/authn/Authenticator.ts
@@ -32,7 +32,7 @@ export default class Authenticator {
           // @ts-ignore
           this.identityKey.publicKey
         ),
-        authDataBytes: authDataBytes,
+        authDataBytes,
         // The generated types are overly strict and don't like our additional methods
         // eslint-disable-next-line
         // @ts-ignore

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -39,7 +39,7 @@ export class UnsignedPublicKey implements publicKey.UnsignedPublicKey {
     }
     secp256k1UncompressedCheck(obj.secp256k1Uncompressed)
     this.secp256k1Uncompressed = obj.secp256k1Uncompressed
-    this.createdNs = obj.createdNs
+    this.createdNs = obj.createdNs.toUnsigned()
   }
 
   // The time the key was generated.
@@ -49,9 +49,11 @@ export class UnsignedPublicKey implements publicKey.UnsignedPublicKey {
 
   // creation time in milliseconds
   get timestamp(): Long {
-    return this.createdNs < MS_NS_TIMESTAMP_THRESHOLD
-      ? this.createdNs
-      : this.createdNs.div(1000000)
+    return (
+      this.createdNs < MS_NS_TIMESTAMP_THRESHOLD
+        ? this.createdNs
+        : this.createdNs.div(1000000)
+    ).toUnsigned()
   }
 
   // Verify that signature was created from the digest using matching private key.

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -46,6 +46,8 @@ describe('Client', () => {
       beforeAll(async () => {
         alice = await testCase.newClient()
         bob = await testCase.newClient()
+        await waitForUserContact(alice, alice)
+        await waitForUserContact(bob, bob)
       })
       afterAll(async () => {
         if (alice) await alice.close()
@@ -53,9 +55,9 @@ describe('Client', () => {
       })
 
       it('user contacts published', async () => {
-        const alicePublic = await waitForUserContact(alice, alice)
+        const alicePublic = await alice.getUserContact(alice.address)
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
-        const bobPublic = await waitForUserContact(bob, bob)
+        const bobPublic = await bob.getUserContact(bob.address)
         assert.deepEqual(bob.keys.getPublicKeyBundle(), bobPublic)
       })
 
@@ -70,7 +72,7 @@ describe('Client', () => {
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
       })
 
-      it.only('send, stream and list messages', async () => {
+      it('send, stream and list messages', async () => {
         const bobIntros = await bob.streamIntroductionMessages()
         const bobAlice = await bob.streamConversationMessages(alice.address)
         const aliceIntros = await alice.streamIntroductionMessages()
@@ -160,6 +162,7 @@ describe('Client', () => {
       it('messaging yourself', async () => {
         const convo = await alice.streamConversationMessages(alice.address)
         const intro = await alice.streamIntroductionMessages()
+        await sleep(100)
         const messages = ['Hey me!', 'Yo!', 'Over and out']
         for (let message of messages) {
           await alice.sendMessage(alice.address, message)
@@ -241,6 +244,7 @@ describe('Client', () => {
 
       it('for-await-of with stream', async () => {
         const convo = await alice.streamConversationMessages(bob.address)
+        await sleep(100)
         let count = 5
         await alice.sendMessage(bob.address, 'msg ' + count)
         for await (const msg of convo) {
@@ -272,6 +276,7 @@ describe('Client', () => {
 
       it('can send compressed messages', async () => {
         const convo = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         const content = 'A'.repeat(111)
         await alice.sendMessage(bob.address, content, {
           contentType: ContentTypeText,
@@ -285,6 +290,7 @@ describe('Client', () => {
 
       it('can send custom content type', async () => {
         const stream = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         const key = PrivateKey.generate().publicKey
 
         // alice doesn't recognize the type
@@ -336,6 +342,7 @@ describe('Client', () => {
 
       it('filters out spoofed messages', async () => {
         const stream = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         // mallory takes over alice's client
         const malloryWallet = newWallet()
         const mallory = await PrivateKeyBundleV1.generate(malloryWallet)
@@ -366,6 +373,7 @@ describe('Client', () => {
 describe('canMessage', () => {
   it('can confirm a user is on the network statically', async () => {
     const registeredClient = await newLocalHostClient()
+    await waitForUserContact(registeredClient, registeredClient)
     const canMessageRegisteredClient = await Client.canMessage(
       registeredClient.address,
       {

--- a/test/Keygen.test.ts
+++ b/test/Keygen.test.ts
@@ -1,5 +1,5 @@
 import { ApiUrls } from './../src/Client'
-import { newWallet } from './helpers'
+import { newWallet, sleep } from './helpers'
 import Client, {
   ClientOptions,
   defaultOptions,
@@ -59,6 +59,7 @@ describe('Key Generation', () => {
       wallet,
       new PrivateTopicStore(apiClient)
     )
+    await sleep(500)
 
     expect((await store.loadPrivateKeyBundle())?.identityKey.toBytes()).toEqual(
       bundle.identityKey.toBytes()

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -2,7 +2,7 @@ import { buildDirectMessageTopic } from './../../src/utils'
 import { Client, Message } from '../../src'
 import { SortDirection } from '../../src/ApiClient'
 import { sleep } from '../../src/utils'
-import { newLocalHostClient } from '../helpers'
+import { newLocalHostClient, waitForUserContact } from '../helpers'
 
 describe('conversation', () => {
   let alice: Client
@@ -11,11 +11,13 @@ describe('conversation', () => {
   beforeEach(async () => {
     alice = await newLocalHostClient()
     bob = await newLocalHostClient()
+    await waitForUserContact(alice, alice)
+    await waitForUserContact(bob, bob)
   })
 
   afterEach(async () => {
-    await alice.close()
-    await bob.close()
+    if (alice) await alice.close()
+    if (bob) await bob.close()
   })
 
   it('lists all messages', async () => {
@@ -125,6 +127,7 @@ describe('conversation', () => {
 
     // Start the stream before sending the message to ensure delivery
     const stream = await aliceConversation.streamMessages()
+    await sleep(100)
     await bobConversation.send('gm')
 
     let numMessages = 0

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -1,4 +1,4 @@
-import { newLocalHostClient } from './../helpers'
+import { newLocalHostClient, waitForUserContact } from './../helpers'
 import { Client } from '../../src'
 import {
   buildDirectMessageTopic,
@@ -15,12 +15,15 @@ describe('conversations', () => {
     alice = await newLocalHostClient()
     bob = await newLocalHostClient()
     charlie = await newLocalHostClient()
+    await waitForUserContact(alice, alice)
+    await waitForUserContact(bob, bob)
+    await waitForUserContact(charlie, charlie)
   })
 
   afterEach(async () => {
-    await alice.close()
-    await bob.close()
-    await charlie.close()
+    if (alice) await alice.close()
+    if (bob) await bob.close()
+    if (charlie) await charlie.close()
   })
 
   it('lists all conversations', async () => {


### PR DESCRIPTION
Deflake the following classes of test failures:

```
  ● conversations › streams all conversation messages with existing conversations

    validating token: token timestamp is in the future


  ● conversation › allows for sorted listing

    Recipient 0xeB270247784Ee79232f81ea74021a8bF248bf34A is not on the XMTP network

      155 |     const contact = await this.client.getUserContact(peerAddress)
      156 |     if (!contact) {
    > 157 |       throw new Error(`Recipient ${peerAddress} is not on the XMTP network`)
          |             ^
      158 |     }
      159 |
      160 |     return new Conversation(this.client, peerAddress)

      at Conversations.<anonymous> (src/conversations/Conversations.ts:157:13)
      at fulfilled (src/conversations/Conversations.ts:24:58)

  ● conversations › streams all conversation messages with existing conversations

    TypeError: Cannot read properties of undefined (reading 'close')

      21 |     await alice.close()
      22 |     await bob.close()
    > 23 |     await charlie.close()
         |                   ^
      24 |   })
      25 |
      26 |   it('lists all conversations', async () => {

      at test/conversations/Conversations.test.ts:23:19
      at fulfilled (test/conversations/Conversations.test.ts:5:58)

  ● canMessage › can confirm a user is on the network statically

    expect(received).toBeTruthy()

    Received: false

      375 |       }
      376 |     )
    > 377 |     expect(canMessageRegisteredClient).toBeTruthy()
          |                                        ^
      378 |
      379 |     const canMessageUnregisteredClient = await Client.canMessage(
      380 |       newWallet().address,

      at test/Client.test.ts:377:40
      at fulfilled (test/Client.test.ts:24:58)

  ● Key Generation › Ensure persistence

    expect(received).toEqual(expected) // deep equality

    Expected: {"data": [8, 157, 222, 150, 154, 188, 48, 18, 34, 10, 32, 153, 107, 75, 35, 3, 128, 216, 93, 50, 162, 239, 182, 46, 205, 148, 252, 98, 196, 137, 116, 90, 205, 84, 89, 155, 250, 151, 121, 75, 20, 43, 153, 26, 146, 1, 8, 157, 222, 150, 154, 188, 48, 18, 68, 10, 66, 10, 64, 181, 149, 161, 188, 58, 124, 238, 179, 206, 177, 208, 16, 220, 90, 129, 250, 179, 189, 26, 27, 198, 172, 239, 3, 102, 242, 96, 129, 218, 164, 254, 76, 84, 136, 217, 117, 48, 76, 161, 241, 229, 239, 16, 69, 200, 234, 58, 235, 155, 172, 130, 157, 204, 62, 149, 157, 179, 134, 58, 17, 200, 236, 161, 152, 26, 67, 10, 65, 4, 160, 143, 47, 192, 162, 124, 225, 217, 25, 216, 46, 86, 105, 151, 73, 112, 1, 99, 86, 116, 84, 14, 57, 231, 181, 140, 177, 7, 126, 60, 138, 139, 86, 19, 39, 30, 148, 170, 251, 44, 169, 226, 108, 154, 178, 96, 49, 226, 74, 30, 92, 217, 79, 205, 149, 140, 98, 32, 245, 188, 164, 205, 16, 42], "type": "Buffer"}
    Received: undefined

      61 |     )
      62 |
    > 63 |     expect((await store.loadPrivateKeyBundle())?.identityKey.toBytes()).toEqual(
         |                                                                         ^
      64 |       bundle.identityKey.toBytes()
      65 |     )
      66 |   })

      at test/Keygen.test.ts:63:73
      at fulfilled (test/Keygen.test.ts:24:58)
          at runMicrotasks (<anonymous>)

  ● Client › local host node › for-await-of with stream

    thrown: "Exceeded timeout of 30000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      242 |       })
      243 |
    > 244 |       it('for-await-of with stream', async () => {
          |       ^
      245 |         const convo = await alice.streamConversationMessages(bob.address)
      246 |         let count = 5
      247 |         await alice.sendMessage(bob.address, 'msg ' + count)

      at test/Client.test.ts:244:7
      at test/Client.test.ts:44:5
          at Array.forEach (<anonymous>)
      at test/Client.test.ts:43:9
      at Object.<anonymous> (test/Client.test.ts:29:1)

  ● Client › local host node › can send custom content type

    thrown: "Exceeded timeout of 30000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      286 |       })
      287 |
    > 288 |       it('can send custom content type', async () => {
          |       ^
      289 |         const stream = await bob.streamConversationMessages(alice.address)
      290 |         const key = PrivateKey.generate().publicKey
      291 |

      at test/Client.test.ts:288:7
      at test/Client.test.ts:44:5
          at Array.forEach (<anonymous>)
      at test/Client.test.ts:43:9
      at Object.<anonymous> (test/Client.test.ts:29:1)
```