### PR TITLE
Make get user contact case-safe

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -213,7 +213,6 @@ export default class Client {
    * Returns the cached PublicKeyBundle if one is known for the given address or fetches
    * one from the network
    */
-
   async getUserContact(
     peerAddress: string
   ): Promise<PublicKeyBundle | undefined> {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -7,7 +7,7 @@ import {
   mapPaginatedStream,
 } from './utils'
 import Stream, { MessageFilter, noTransformation } from './Stream'
-import { Signer } from 'ethers'
+import { ethers, Signer } from 'ethers'
 import {
   EncryptedKeyStore,
   KeyStore,
@@ -217,7 +217,8 @@ export default class Client {
   async getUserContact(
     peerAddress: string
   ): Promise<PublicKeyBundle | undefined> {
-    const existingBundle = this.knownPublicKeyBundles.get(peerAddress)
+    const safeAddress = ethers.utils.getAddress(peerAddress)
+    const existingBundle = this.knownPublicKeyBundles.get(safeAddress)
 
     if (existingBundle) {
       return existingBundle
@@ -225,11 +226,11 @@ export default class Client {
 
     const newBundle = await getUserContactFromNetwork(
       this.apiClient,
-      peerAddress
+      safeAddress
     )
 
     if (newBundle) {
-      this.knownPublicKeyBundles.set(peerAddress, newBundle)
+      this.knownPublicKeyBundles.set(safeAddress, newBundle)
     }
 
     return newBundle

--- a/src/authn/Authenticator.ts
+++ b/src/authn/Authenticator.ts
@@ -32,7 +32,7 @@ export default class Authenticator {
           // @ts-ignore
           this.identityKey.publicKey
         ),
-        authDataBytes: authDataBytes,
+        authDataBytes,
         // The generated types are overly strict and don't like our additional methods
         // eslint-disable-next-line
         // @ts-ignore

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -39,7 +39,7 @@ export class UnsignedPublicKey implements publicKey.UnsignedPublicKey {
     }
     secp256k1UncompressedCheck(obj.secp256k1Uncompressed)
     this.secp256k1Uncompressed = obj.secp256k1Uncompressed
-    this.createdNs = obj.createdNs
+    this.createdNs = obj.createdNs.toUnsigned()
   }
 
   // The time the key was generated.
@@ -49,9 +49,11 @@ export class UnsignedPublicKey implements publicKey.UnsignedPublicKey {
 
   // creation time in milliseconds
   get timestamp(): Long {
-    return this.createdNs < MS_NS_TIMESTAMP_THRESHOLD
-      ? this.createdNs
-      : this.createdNs.div(1000000)
+    return (
+      this.createdNs < MS_NS_TIMESTAMP_THRESHOLD
+        ? this.createdNs
+        : this.createdNs.div(1000000)
+    ).toUnsigned()
   }
 
   // Verify that signature was created from the digest using matching private key.

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -70,6 +70,27 @@ describe('Client', () => {
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
       })
 
+      it('user contacts are case-insensitive', async () => {
+        return pollFor(
+          async () => {
+            const contact1 = await bob.getUserContact(alice.address)
+            const contact2 = await bob.getUserContact(
+              alice.address.toUpperCase()
+            )
+            const contact3 = await bob.getUserContact(
+              alice.address.toLowerCase()
+            )
+            assert.ok(contact1)
+            assert.ok(contact2)
+            assert.ok(contact3)
+            assert.deepEqual(contact1, contact2)
+            assert.deepEqual(contact2, contact3)
+          },
+          20000,
+          200
+        )
+      })
+
       it.only('send, stream and list messages', async () => {
         const bobIntros = await bob.streamIntroductionMessages()
         const bobAlice = await bob.streamConversationMessages(alice.address)

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -46,6 +46,8 @@ describe('Client', () => {
       beforeAll(async () => {
         alice = await testCase.newClient()
         bob = await testCase.newClient()
+        await waitForUserContact(alice, alice)
+        await waitForUserContact(bob, bob)
       })
       afterAll(async () => {
         if (alice) await alice.close()
@@ -53,9 +55,9 @@ describe('Client', () => {
       })
 
       it('user contacts published', async () => {
-        const alicePublic = await waitForUserContact(alice, alice)
+        const alicePublic = await alice.getUserContact(alice.address)
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
-        const bobPublic = await waitForUserContact(bob, bob)
+        const bobPublic = await bob.getUserContact(bob.address)
         assert.deepEqual(bob.keys.getPublicKeyBundle(), bobPublic)
       })
 
@@ -91,7 +93,7 @@ describe('Client', () => {
         )
       })
 
-      it.only('send, stream and list messages', async () => {
+      it('send, stream and list messages', async () => {
         const bobIntros = await bob.streamIntroductionMessages()
         const bobAlice = await bob.streamConversationMessages(alice.address)
         const aliceIntros = await alice.streamIntroductionMessages()
@@ -181,6 +183,7 @@ describe('Client', () => {
       it('messaging yourself', async () => {
         const convo = await alice.streamConversationMessages(alice.address)
         const intro = await alice.streamIntroductionMessages()
+        await sleep(100)
         const messages = ['Hey me!', 'Yo!', 'Over and out']
         for (let message of messages) {
           await alice.sendMessage(alice.address, message)
@@ -262,6 +265,7 @@ describe('Client', () => {
 
       it('for-await-of with stream', async () => {
         const convo = await alice.streamConversationMessages(bob.address)
+        await sleep(100)
         let count = 5
         await alice.sendMessage(bob.address, 'msg ' + count)
         for await (const msg of convo) {
@@ -293,6 +297,7 @@ describe('Client', () => {
 
       it('can send compressed messages', async () => {
         const convo = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         const content = 'A'.repeat(111)
         await alice.sendMessage(bob.address, content, {
           contentType: ContentTypeText,
@@ -306,6 +311,7 @@ describe('Client', () => {
 
       it('can send custom content type', async () => {
         const stream = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         const key = PrivateKey.generate().publicKey
 
         // alice doesn't recognize the type
@@ -357,6 +363,7 @@ describe('Client', () => {
 
       it('filters out spoofed messages', async () => {
         const stream = await bob.streamConversationMessages(alice.address)
+        await sleep(100)
         // mallory takes over alice's client
         const malloryWallet = newWallet()
         const mallory = await PrivateKeyBundleV1.generate(malloryWallet)
@@ -387,6 +394,7 @@ describe('Client', () => {
 describe('canMessage', () => {
   it('can confirm a user is on the network statically', async () => {
     const registeredClient = await newLocalHostClient()
+    await waitForUserContact(registeredClient, registeredClient)
     const canMessageRegisteredClient = await Client.canMessage(
       registeredClient.address,
       {

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -409,6 +409,31 @@ describe('canMessage', () => {
     )
     expect(canMessageUnregisteredClient).toBeFalsy()
   })
+
+  it('is case-insensitive to given peerAddress', async () => {
+    const registeredClient = await newLocalHostClient()
+    await waitForUserContact(registeredClient, registeredClient)
+    const upperCaseCanMessage = await Client.canMessage(
+      registeredClient.address.toUpperCase(),
+      {
+        env: 'local',
+      }
+    )
+    expect(upperCaseCanMessage).toBeTruthy()
+
+    const lowerCaseCanMessage = await Client.canMessage(
+      registeredClient.address.toLowerCase(),
+      {
+        env: 'local',
+      }
+    )
+    expect(lowerCaseCanMessage).toBeTruthy()
+
+    const invalidClient = await Client.canMessage('bad_address', {
+      env: 'local',
+    })
+    expect(invalidClient).toBeFalsy()
+  })
 })
 
 describe('ClientOptions', () => {

--- a/test/Keygen.test.ts
+++ b/test/Keygen.test.ts
@@ -1,5 +1,5 @@
 import { ApiUrls } from './../src/Client'
-import { newWallet } from './helpers'
+import { newWallet, sleep } from './helpers'
 import Client, {
   ClientOptions,
   defaultOptions,
@@ -59,6 +59,7 @@ describe('Key Generation', () => {
       wallet,
       new PrivateTopicStore(apiClient)
     )
+    await sleep(500)
 
     expect((await store.loadPrivateKeyBundle())?.identityKey.toBytes()).toEqual(
       bundle.identityKey.toBytes()

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -2,7 +2,7 @@ import { buildDirectMessageTopic } from './../../src/utils'
 import { Client, Message } from '../../src'
 import { SortDirection } from '../../src/ApiClient'
 import { sleep } from '../../src/utils'
-import { newLocalHostClient } from '../helpers'
+import { newLocalHostClient, waitForUserContact } from '../helpers'
 
 describe('conversation', () => {
   let alice: Client
@@ -11,11 +11,13 @@ describe('conversation', () => {
   beforeEach(async () => {
     alice = await newLocalHostClient()
     bob = await newLocalHostClient()
+    await waitForUserContact(alice, alice)
+    await waitForUserContact(bob, bob)
   })
 
   afterEach(async () => {
-    await alice.close()
-    await bob.close()
+    if (alice) await alice.close()
+    if (bob) await bob.close()
   })
 
   it('lists all messages', async () => {
@@ -125,6 +127,7 @@ describe('conversation', () => {
 
     // Start the stream before sending the message to ensure delivery
     const stream = await aliceConversation.streamMessages()
+    await sleep(100)
     await bobConversation.send('gm')
 
     let numMessages = 0

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -1,4 +1,4 @@
-import { newLocalHostClient } from './../helpers'
+import { newLocalHostClient, waitForUserContact } from './../helpers'
 import { Client } from '../../src'
 import {
   buildDirectMessageTopic,
@@ -15,12 +15,15 @@ describe('conversations', () => {
     alice = await newLocalHostClient()
     bob = await newLocalHostClient()
     charlie = await newLocalHostClient()
+    await waitForUserContact(alice, alice)
+    await waitForUserContact(bob, bob)
+    await waitForUserContact(charlie, charlie)
   })
 
   afterEach(async () => {
-    await alice.close()
-    await bob.close()
-    await charlie.close()
+    if (alice) await alice.close()
+    if (bob) await bob.close()
+    if (charlie) await charlie.close()
   })
 
   it('lists all conversations', async () => {

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -146,4 +146,20 @@ describe('conversations', () => {
     expect(aliceConversationsList).toHaveLength(1)
     expect(bobConversationList).toHaveLength(1)
   })
+
+  it('new conversations are case-insensitive to given address', async () => {
+    const aliceToBob = await alice.conversations.newConversation(
+      bob.address.toLowerCase()
+    )
+    await aliceToBob.send('gm')
+    await sleep(50)
+
+    const aliceConversationsAfterMessage = await alice.conversations.list()
+    expect(aliceConversationsAfterMessage).toHaveLength(1)
+    expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
+
+    const bobConversations = await bob.conversations.list()
+    expect(bobConversations).toHaveLength(1)
+    expect(bobConversations[0].peerAddress).toBe(alice.address)
+  })
 })


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtp-js/issues/172

This PR updates `Client#getUserContact` to be case-safe so we can use `canMessage()` and `newConversation()` passing a lowercase address for example.
