### PR TITLE
feat: make peeraddress case-safe

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -7,7 +7,7 @@ import {
   mapPaginatedStream,
 } from './utils'
 import Stream, { MessageFilter, noTransformation } from './Stream'
-import { Signer } from 'ethers'
+import { ethers, Signer } from 'ethers'
 import {
   EncryptedKeyStore,
   KeyStore,
@@ -213,11 +213,11 @@ export default class Client {
    * Returns the cached PublicKeyBundle if one is known for the given address or fetches
    * one from the network
    */
-
   async getUserContact(
     peerAddress: string
   ): Promise<PublicKeyBundle | undefined> {
-    const existingBundle = this.knownPublicKeyBundles.get(peerAddress)
+    const safeAddress = ethers.utils.getAddress(peerAddress)
+    const existingBundle = this.knownPublicKeyBundles.get(safeAddress)
 
     if (existingBundle) {
       return existingBundle
@@ -225,11 +225,11 @@ export default class Client {
 
     const newBundle = await getUserContactFromNetwork(
       this.apiClient,
-      peerAddress
+      safeAddress
     )
 
     if (newBundle) {
-      this.knownPublicKeyBundles.set(peerAddress, newBundle)
+      this.knownPublicKeyBundles.set(safeAddress, newBundle)
     }
 
     return newBundle

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -72,6 +72,27 @@ describe('Client', () => {
         assert.deepEqual(alice.keys.getPublicKeyBundle(), alicePublic)
       })
 
+      it('user contacts are case-insensitive to given address', async () => {
+        return pollFor(
+          async () => {
+            const contact1 = await bob.getUserContact(alice.address)
+            const contact2 = await bob.getUserContact(
+              alice.address.toUpperCase()
+            )
+            const contact3 = await bob.getUserContact(
+              alice.address.toLowerCase()
+            )
+            assert.ok(contact1)
+            assert.ok(contact2)
+            assert.ok(contact3)
+            assert.deepEqual(contact1, contact2)
+            assert.deepEqual(contact2, contact3)
+          },
+          20000,
+          200
+        )
+      })
+
       it('send, stream and list messages', async () => {
         const bobIntros = await bob.streamIntroductionMessages()
         const bobAlice = await bob.streamConversationMessages(alice.address)
@@ -387,6 +408,31 @@ describe('canMessage', () => {
       { env: 'local' }
     )
     expect(canMessageUnregisteredClient).toBeFalsy()
+  })
+
+  it('is case-insensitive to given peerAddress', async () => {
+    const registeredClient = await newLocalHostClient()
+    await waitForUserContact(registeredClient, registeredClient)
+    const upperCaseCanMessage = await Client.canMessage(
+      registeredClient.address.toUpperCase(),
+      {
+        env: 'local',
+      }
+    )
+    expect(upperCaseCanMessage).toBeTruthy()
+
+    const lowerCaseCanMessage = await Client.canMessage(
+      registeredClient.address.toLowerCase(),
+      {
+        env: 'local',
+      }
+    )
+    expect(lowerCaseCanMessage).toBeTruthy()
+
+    const invalidClient = await Client.canMessage('bad_address', {
+      env: 'local',
+    })
+    expect(invalidClient).toBeFalsy()
   })
 })
 

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -146,4 +146,20 @@ describe('conversations', () => {
     expect(aliceConversationsList).toHaveLength(1)
     expect(bobConversationList).toHaveLength(1)
   })
+
+  it('new conversations are case-insensitive to given address', async () => {
+    const aliceToBob = await alice.conversations.newConversation(
+      bob.address.toLowerCase()
+    )
+    await aliceToBob.send('gm')
+    await sleep(50)
+
+    const aliceConversationsAfterMessage = await alice.conversations.list()
+    expect(aliceConversationsAfterMessage).toHaveLength(1)
+    expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
+
+    const bobConversations = await bob.conversations.list()
+    expect(bobConversations).toHaveLength(1)
+    expect(bobConversations[0].peerAddress).toBe(alice.address)
+  })
 })


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtp-js/issues/172

This PR updates `Client#getUserContact` to be case-safe so we can use `canMessage()` and `newConversation()` passing a lowercase address for example.
