### PR TITLE
Pass bytes as Uint8Array

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -184,7 +184,8 @@ export class ConversationV2 {
     if (!env.message) {
       throw new Error('empty envelope')
     }
-    const msg = xmtpEnvelope.Message.decode(b64Decode(env.message.toString()))
+    const messageBytes = b64Decode(env.message.toString())
+    const msg = xmtpEnvelope.Message.decode(messageBytes)
     if (!msg.v2) {
       throw new Error('unknown message version')
     }
@@ -209,7 +210,6 @@ export class ConversationV2 {
     ) {
       throw new Error('incomplete signed content')
     }
-
     const digest = await sha256(concat(msgv2.headerBytes, signed.payload))
     if (
       !new SignedPublicKey(signed.sender?.preKey).verify(
@@ -219,7 +219,7 @@ export class ConversationV2 {
     ) {
       throw new Error('invalid signature')
     }
-    const message = await MessageV2.create(msg, header, signed, env.message)
+    const message = await MessageV2.create(msg, header, signed, messageBytes)
     await this.client.decodeContent(message)
     return message
   }


### PR DESCRIPTION
## Summary

I noticed an issue where we were passing in the message bytes from the envelope as a string instead of a Uint8Array. This wasn't caught by the type checker, because the generated types for GRPC Gateway are always wrong for bytes fields. It also wasn't caught by the tests for some reason, even though the `v2 conversation` test does exercise this code. Maybe it's some quirk between server and client side `SubtleCrypto`?

But I have confirmed in the browser that this immediately fixes the error by using `yarn link`