### PR TITLE
streamAllMessages Fixes

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -209,7 +209,7 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
     header: proto.MessageHeaderV2,
     signed: proto.SignedContent,
     // wallet address derived from the signature of the message sender
-    senderAddress: string | undefined
+    senderAddress: string
   ) {
     super(id, bytes, obj)
     this.decrypted = signed.payload

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -169,22 +169,15 @@ export default class Conversations {
             : (msg.recipientAddress as string),
           msg.sent
         )
-
         const isNew = addConvo(convo.topic, convo)
-        if (!isNew) {
-          return undefined
-        }
 
-        return Array.from(topics.values())
+        return isNew ? Array.from(topics.values()) : undefined
       }
 
       if (msg instanceof ConversationV2) {
         const isNew = addConvo(msg.topic, msg)
-        if (!isNew) {
-          return undefined
-        }
 
-        return Array.from(topics.values())
+        return isNew ? Array.from(topics.values()) : undefined
       }
 
       return undefined
@@ -202,8 +195,8 @@ export default class Conversations {
         if (val instanceof MessageV1 || val instanceof MessageV2) {
           yield val
         }
-        // For conversation V2, we know we have already missed the message when we get the invite
-        // Load the newly created topic and yield all messages
+        // For conversation V2, we may have messages in the new topic before we started streaming.
+        // To be safe, we fetch all messages
         if (val instanceof ConversationV2) {
           for (const convoMessage of await val.messages()) {
             yield convoMessage

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -97,6 +97,13 @@ export default class Conversations {
     )
   }
 
+  /**
+   * Streams messages from all conversations.
+   *
+   * When a new conversation is initiated with the client's address, this function will automatically register it and add it to the list of conversations to watch.
+   * Callers should be aware that in some cases the first messages in a newly created legacy conversation may not be picked up by this method.
+   * This will be resolved in a future release where all new conversations will be `ConversationV2`
+   */
   async streamAllMessages(): Promise<AsyncGenerator<Message>> {
     const introTopic = buildUserIntroTopic(this.client.address)
     const inviteTopic = buildUserInviteTopic(this.client.address)

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -150,6 +150,15 @@ export default class Conversations {
       throw new Error('Unknown topic')
     }
 
+    const addConvo = (topic: string, conversation: Conversation): boolean => {
+      if (topics.has(topic)) {
+        return false
+      }
+      convoMap.set(topic, conversation)
+      topics.add(topic)
+      return true
+    }
+
     const contentTopicUpdater = (msg: Conversation | Message | null) => {
       // If we have a V1 message from the introTopic, store the conversation in our mapping
       if (msg instanceof MessageV1 && msg.contentTopic === introTopic) {
@@ -161,23 +170,19 @@ export default class Conversations {
           msg.sent
         )
 
-        if (topics.has(convo.topic)) {
+        const isNew = addConvo(convo.topic, convo)
+        if (!isNew) {
           return undefined
         }
-
-        convoMap.set(convo.topic, convo)
-        topics.add(convo.topic)
 
         return Array.from(topics.values())
       }
 
       if (msg instanceof ConversationV2) {
-        if (topics.has(msg.topic)) {
+        const isNew = addConvo(msg.topic, msg)
+        if (!isNew) {
           return undefined
         }
-
-        convoMap.set(msg.topic, msg)
-        topics.add(msg.topic)
 
         return Array.from(topics.values())
       }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -101,8 +101,8 @@ export default class Conversations {
    * Streams messages from all conversations.
    *
    * When a new conversation is initiated with the client's address, this function will automatically register it and add it to the list of conversations to watch.
-   * Callers should be aware that in some cases the first messages in a newly created legacy conversation may not be picked up by this method.
-   * This will be resolved in a future release where all new conversations will be `ConversationV2`
+   * Callers should be aware the first messages in a newly created conversation are picked up on a best effort basis and there are other potential race conditions which may cause some newly created conversations to be missed.
+   *
    */
   async streamAllMessages(): Promise<AsyncGenerator<Message>> {
     const introTopic = buildUserIntroTopic(this.client.address)

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -99,37 +99,44 @@ describe('conversations', () => {
     expect(numMessages).toBe(3)
   })
 
-  it('streams all conversation messages with existing conversations', async () => {
-    const aliceBob = await alice.conversations.newConversation(bob.address)
-    const bobAlice = await bob.conversations.newConversation(alice.address)
-
-    await aliceBob.send('gm alice -bob')
+  it('streams all conversation messages with a mix of v1 and v2 conversations', async () => {
+    const aliceBobV1 = await alice.conversations.newConversation(bob.address)
+    const aliceBobV2 = await alice.conversations.newConversation(bob.address, {
+      conversationId: 'xmtp.org/foo',
+      metadata: {},
+    })
     await sleep(100)
-    const existingConversations = await alice.conversations.list()
-    expect(existingConversations).toHaveLength(1)
 
     const stream = await alice.conversations.streamAllMessages()
-    await bobAlice.send('gm bob -alice')
+    await sleep(100)
 
-    let numMessages = 0
-    for await (const message of stream) {
-      numMessages++
-      if (numMessages == 1) {
-        expect(message.contentTopic).toBe(
-          buildDirectMessageTopic(alice.address, bob.address)
-        )
-        expect(message.content).toBe('gm bob -alice')
+    await aliceBobV1.send('V1')
+    const message1 = await stream.next()
+    expect(message1.value.content).toBe('V1')
+    expect(message1.value.contentTopic).toBe(buildUserIntroTopic(alice.address))
+
+    await aliceBobV2.send('V2')
+    const message2 = await stream.next()
+    expect(message2.value.content).toBe('V2')
+    expect(message2.value.contentTopic).toBe(aliceBobV2.topic)
+
+    await aliceBobV1.send('Second message in V1 channel')
+    const message3 = await stream.next()
+    expect(message3.value.content).toBe('Second message in V1 channel')
+    expect(message3.value.contentTopic).toBe(
+      buildDirectMessageTopic(alice.address, bob.address)
+    )
+
+    const aliceBobV2Bar = await alice.conversations.newConversation(
+      bob.address,
+      {
+        conversationId: 'xmtp.org/bar',
+        metadata: {},
       }
-      if (numMessages == 2) {
-        expect(message.contentTopic).toBe(
-          buildDirectMessageTopic(alice.address, bob.address)
-        )
-        expect(message.content).toBe('gm. hope you have a good day')
-        break
-      }
-      await aliceBob.send('gm. hope you have a good day')
-    }
-    expect(numMessages).toBe(2)
+    )
+    await aliceBobV2Bar.send('bar')
+    const message4 = await stream.next()
+    expect(message4.value.content).toBe('bar')
   })
 
   it('dedupes conversations when multiple messages are in the introduction topic', async () => {

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -68,12 +68,9 @@ describe('conversations', () => {
       charlie.address
     )
     const bobAlice = await bob.conversations.newConversation(alice.address)
-    const charlieAlice = await charlie.conversations.newConversation(
-      alice.address
-    )
 
     const stream = await alice.conversations.streamAllMessages()
-    await charlieAlice.send('gm alice -charlie')
+    await aliceCharlie.send('gm alice -charlie')
 
     let numMessages = 0
     for await (const message of stream) {


### PR DESCRIPTION
## Summary

One of the missing pieces around negotiated topics is the ability to stream all messages, whether they are coming from V1 or V2 conversations.

The existing implementation would only stream V1 messages. Getting it to work with both had some interesting wrinkles.
- When an invite is received, it is already too late to update the topic list and stream the first message. So, in that case I query the newly found topic and yield any messages found. 
- Decoding V2 messages requires keeping track of the conversation it came from, since that is the only place with the key material. Cannot process with just the message alone like we can with V1
- When a message is found on the intro topic, need to both yield the message to the listener and also use it to update the topic list

I decided to switch this over to return an async generator, which no one should notice but us. Usage is unchanged. This lets us filter the `Stream` and ignore the `Invitation` messages, while still updating the topic list.