### PR TITLE
Sanitize random topics

### DIFF
--- a/src/Invitation.ts
+++ b/src/Invitation.ts
@@ -45,6 +45,9 @@ export class InvitationV1 implements invitation.InvitationV1 {
       Buffer.from(utils.getRandomValues(new Uint8Array(32)))
         .toString('base64')
         .replace(/=*$/g, '')
+        // Replace slashes with dashes so that the topic is still easily split by /
+        // We do not treat this as needing to be valid Base64 anywhere
+        .replace('/', '-')
     )
     const keyMaterial = utils.getRandomValues(new Uint8Array(32))
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const buildDirectMessageTopic = (
 }
 
 export const buildDirectMessageTopicV2 = (randomString: string): string => {
-  return buildContentTopic(`dm-${randomString}`)
+  return buildContentTopic(`m-${randomString}`)
 }
 
 export const buildUserContactTopic = (walletAddr: string): string => {


### PR DESCRIPTION
## Summary

Changes format for randomly generated topic names so that they can be more easily parsed.

With V1 topics, topics are always something like `/xmtp/0/dm-0x32c46ed7104a5e7600ea376E17ECb75A1f7d4c4D-0xdA7033378c28F51C24F55fee3587484b385FBaAE/proto`.

We can easily parse it by splitting on slashes. With V2 topics, I am Base64 encoding the random topic bytes to generate the topic string. This means we can have topics that look like `/xmtp/0/dm-e7s9zsPdpp/1v6Xvio1mBI5f1JIM6WK26LnunQxE4DA/proto`, which includes slashes in the random portion.

This replaces slashes with dashes.

It also adjusts the prefix to be `m-` instead of `dm-` to support group messages in the future.