### PR TITLE
fix: add deprecation schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Older versions of the SDK will eventually become deprecated, which means:
 
 Following table shows the deprecation schedule.
 
-| Announced | Effective | Minimum Version | Rationale
-| --- | --- | --- | ---
-| 2022-08-18 | 2022-11-08 | v6.0.0 | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface
-| 2022-11-21 | 2022-11-08 | v6.4.0 | clients will start publishing V2 contact bundles to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263))
+| Announced  | Effective  | Minimum Version | Rationale                                                                                                                                                                                                     |
+| ---------- | ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2022-08-18 | 2022-11-08 | v6.0.0          | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface                                                                                             |
+| 2022-11-21 | 2022-11-08 | v6.4.0          | clients will start publishing V2 contact bundles to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263)) |
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ Older versions of the SDK will eventually become deprecated, which means:
 
 Following table shows the deprecation schedule.
 
-| Announced  | Effective  | Minimum Version | Rationale                                                                                                                                                                                                     |
-| ---------- | ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2022-08-18 | 2022-11-08 | v6.0.0          | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface                                                                                             |
-| 2022-11-21 | 2022-11-08 | v6.4.0          | clients will start publishing V2 contact bundles to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263)) |
+| Announced  | Effective  | Minimum Version | Rationale                                                                                                         |
+| ---------- | ---------- | --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 2022-08-18 | 2022-11-08 | v6.0.0          | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface |
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ XMTP communicates about breaking revisions in the [XMTP Discord community](https
 
 ### Deprecation Schedule
 
-| Announced | Effective | Version | Rationale |
+| Announced | Effective | Minimum Version | Rationale |
 | --- | --- | --- | --- |
 | 2022-08-18 | 2022-11-08 | v6.0.0 | The XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface |
-| 2022-11-21 | 2022-11-08 | v6.4.0 | The V2 contact bundles will start being published to the network, pre-v6.4.0 will not be able to tolerate this activity ([details](...)) |
+| 2022-11-21 | 2022-11-08 | v6.4.0 | The V2 contact bundles will start being published to the network, pre-v6.4.0 clients will not be able to tolerate this activity ([details](...)) |
 
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ Because `xmtp-js` is in active development, you should expect breaking revisions
 
 XMTP communicates about breaking revisions in the [XMTP Discord community](https://discord.gg/xmtp), providing as much advance notice as possible. Additionally, breaking revisions in an `xmtp-js` release are described on the [Releases page](https://github.com/xmtp/xmtp-js/releases).
 
-### Deprecation Schedule
+### Deprecation
+
+Older versions of the SDK will eventually become deprecated, which means:
+
+1. The network will not support and eventually actively reject connections from clients using deprecated versions.
+2. Bugs will not be fixed in deprecated versions.
+
+Following table shows the currently scheduled deprecations
 
 | Announced | Effective | Minimum Version | Rationale
 | --- | --- | --- | ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following table shows the deprecation schedule.
 | Announced | Effective | Minimum Version | Rationale
 | --- | --- | --- | ---
 | 2022-08-18 | 2022-11-08 | v6.0.0 | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface
-| 2022-11-21 | 2022-11-08 | v6.4.0 | V2 contact bundles will start being published to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263))
+| 2022-11-21 | 2022-11-08 | v6.4.0 | clients will start publishing V2 contact bundles to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263))
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Following table shows the deprecation schedule.
 | Announced | Effective | Minimum Version | Rationale
 | --- | --- | --- | ---
 | 2022-08-18 | 2022-11-08 | v6.0.0 | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface
-| 2022-11-21 | 2022-11-08 | v6.4.0 | V2 contact bundles will start being published to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](...))
+| 2022-11-21 | 2022-11-08 | v6.4.0 | V2 contact bundles will start being published to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](https://github.com/xmtp/xmtp-js/issues/178#issuecomment-1285527263))
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Because `xmtp-js` is in active development, you should expect breaking revisions
 
 XMTP communicates about breaking revisions in the [XMTP Discord community](https://discord.gg/xmtp), providing as much advance notice as possible. Additionally, breaking revisions in an `xmtp-js` release are described on the [Releases page](https://github.com/xmtp/xmtp-js/releases).
 
+### Deprecation Schedule
+
+| Announced | Effective | Version | Rationale |
+| --- | --- | --- | --- |
+| 2022-08-18 | 2022-11-08 | v6.0.0 | The XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface |
+| 2022-11-21 | 2022-11-08 | v6.4.0 | The V2 contact bundles will start being published to the network, pre-v6.4.0 will not be able to tolerate this activity ([details](...)) |
+
+
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 
 ## XMTP `production` and `dev` network environments

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Following table shows the currently scheduled deprecations
 | 2022-08-18 | 2022-11-08 | v6.0.0 | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface
 | 2022-11-21 | 2022-11-08 | v6.4.0 | V2 contact bundles will start being published to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](...))
 
-
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
 
 ## XMTP `production` and `dev` network environments

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Older versions of the SDK will eventually become deprecated, which means:
 1. The network will not support and eventually actively reject connections from clients using deprecated versions.
 2. Bugs will not be fixed in deprecated versions.
 
-Following table shows the currently scheduled deprecations
+Following table shows the deprecation schedule.
 
 | Announced | Effective | Minimum Version | Rationale
 | --- | --- | --- | ---

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ XMTP communicates about breaking revisions in the [XMTP Discord community](https
 
 ### Deprecation Schedule
 
-| Announced | Effective | Minimum Version | Rationale |
-| --- | --- | --- | --- |
-| 2022-08-18 | 2022-11-08 | v6.0.0 | The XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface |
-| 2022-11-21 | 2022-11-08 | v6.4.0 | The V2 contact bundles will start being published to the network, pre-v6.4.0 clients will not be able to tolerate this activity ([details](...)) |
+| Announced | Effective | Minimum Version | Rationale
+| --- | --- | --- | ---
+| 2022-08-18 | 2022-11-08 | v6.0.0 | XMTP network will stop supporting the Waku/libp2p based client interface in favor of the new GRPC based interface
+| 2022-11-21 | 2022-11-08 | v6.4.0 | V2 contact bundles will start being published to the network, pre-v6.4.0 clients may not be able to tolerate this activity ([details](...))
 
 
 Issues and PRs are welcome in accordance with our [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).

--- a/src/codecs/Composite.ts
+++ b/src/codecs/Composite.ts
@@ -77,7 +77,7 @@ export class CompositeCodec implements ContentCodec<Composite> {
     for (const part of content.parts) {
       parts.push(this.toProto(part, codecs))
     }
-    return { composite: { parts: parts }, part: undefined }
+    return { composite: { parts }, part: undefined }
   }
 
   private fromProto(
@@ -105,6 +105,6 @@ export class CompositeCodec implements ContentCodec<Composite> {
     for (const part of content.composite.parts) {
       parts.push(this.fromProto(part, codecs))
     }
-    return { parts: parts }
+    return { parts }
   }
 }

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -2,8 +2,8 @@ import { publicKey } from '@xmtp/proto'
 import * as secp from '@noble/secp256k1'
 import Long from 'long'
 import Signature, { WalletSigner } from './Signature'
-import { bytesToHex, equalBytes, hexToBytes } from './utils'
-import { Signer, utils, Wallet } from 'ethers'
+import { equalBytes, hexToBytes } from './utils'
+import { Signer, utils } from 'ethers'
 import { sha256 } from './encryption'
 
 // SECP256k1 public key in uncompressed format with prefix

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -82,7 +82,7 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
     'deriveKey',
   ])
   return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt: salt, info: hkdfNoInfo },
+    { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
     key,
     { name: 'AES-GCM', length: 256 },
     false,


### PR DESCRIPTION
We should have a more permanent record of our deprecation schedule, than just the Discord announcements. The README is one of the more prominent places where we could surface this. The idea here is that we'd list all deadlines in this table and remove them as they expire.

I'd be also inclined to establish an automatic deprecation of versions that are too old (a year maybe) that wouldn't be listed explicitly in this table, but the rule should be mentioned above the table here as well if we agree on something like that.