### PR TITLE
Add conversation reference to messages

### DIFF
--- a/src/Message.ts
+++ b/src/Message.ts
@@ -65,6 +65,7 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
   header: proto.MessageHeaderV1 // eslint-disable-line camelcase
   // wallet address derived from the signature of the message recipient
   senderAddress: string | undefined
+  conversation = undefined
 
   constructor(
     id: string,

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -146,7 +146,7 @@ export class ConversationV2 {
     options?: SendOptions
   ): Promise<MessageV2> {
     const msg = await this.encodeMessage(message, options)
-    this.client.publishEnvelopes([
+    await this.client.publishEnvelopes([
       {
         contentTopic: this.topic,
         message: msg.toBytes(),
@@ -180,7 +180,7 @@ export class ConversationV2 {
       v2: { headerBytes, ciphertext },
     }
     const bytes = xmtpEnvelope.Message.encode(protoMsg).finish()
-    const msg = await MessageV2.create(protoMsg, header, signed, bytes)
+    const msg = await MessageV2.create(protoMsg, header, signed, bytes, this)
     return msg
   }
 
@@ -224,7 +224,13 @@ export class ConversationV2 {
     ) {
       throw new Error('invalid signature')
     }
-    const message = await MessageV2.create(msg, header, signed, messageBytes)
+    const message = await MessageV2.create(
+      msg,
+      header,
+      signed,
+      messageBytes,
+      this
+    )
     message.contentTopic = env.contentTopic
     await this.client.decodeContent(message)
     return message

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -1,3 +1,4 @@
+import { Message } from '@components/Messages/Message'
 import { buildDirectMessageTopic } from './../../src/utils'
 import { MessageV1, MessageV2 } from '../../src/Message'
 import { Client } from '../../src'
@@ -194,5 +195,36 @@ describe('conversation', () => {
     await bc.send('gm to you too')
     expect((await bs.next()).value.content).toBe('gm to you too')
     expect((await as.next()).value.content).toBe('gm to you too')
+  })
+
+  it('conversation filtering', async () => {
+    const conversationId = 'xmtp.org/foo'
+    const title = 'foo'
+    const convo = await alice.conversations.newConversation(bob.address, {
+      conversationId,
+      metadata: {
+        title,
+      },
+    })
+
+    const stream = await convo.streamMessages()
+    await sleep(100)
+    const sentMessage = await convo.send('foo')
+    if (!(sentMessage instanceof MessageV2)) {
+      throw new Error('Not a V2 message')
+    }
+    expect(sentMessage.conversation.context?.conversationId).toBe(
+      conversationId
+    )
+
+    const firstMessageFromStream: Message = (await stream.next()).value
+    expect(firstMessageFromStream instanceof MessageV2).toBeTruthy()
+    expect(firstMessageFromStream.content).toBe('foo')
+    expect(firstMessageFromStream.conversation.context.id).toBe(conversationId)
+
+    const messages = await convo.messages()
+    expect(messages).toHaveLength(1)
+    expect(messages[0].content).toBe('foo')
+    expect(messages[0].conversation).toBe(convo)
   })
 })


### PR DESCRIPTION
## Summary

In many places, we may want a reference to the conversation the message originated from attached to the message for convenience. But the most important is in `streamAllMessages` where there may be multiple sources for a given message, and no obvious reference to point back to (the conversation may not even be loaded by the caller of `streamAllMessages`).

I've only added the reference to V2 messages for now. Implementing in V1 would be a much more involved process, and would require a big refactor. 