### PR TITLE
Replace prepare with prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "node tools/cleanup && npm run clean:proto",
     "clean:proto": "rm -rf src/proto/*.ts",
     "package": "npm pack",
-    "prepare": "npm run build",
+    "prepublish": "npm run build",
     "test": "npm run test:node",
     "test:node": "jest --no-cache --runInBand --env='node' --forceExit --testTimeout=30000",
     "test:jsdom": "jest --no-cache --runInBand --env='./jest.jsdom.env.js' --forceExit --testTimeout=30000",


### PR DESCRIPTION
## Summary

Before the `xmtp-js` package was public, we had a lot of users importing the SDK from Github directly. At that time, I made a change to run our build scripts in the `prepare` hook, which runs on every `npm install`. This allowed people importing from GH to have the actual built package and not just the source code.

Today, everyone uses NPM. But we still have it in the `prepare` script, which causes unnecessary builds in our local and CI environments. This change should shave about 30s off of each of our Github Actions.

This PR only runs the build in `prepublish`, which should be the only time it is strictly necessary to build all the packages. This will break anyone who is still importing directly from Github, but that should be basically no one at this point.