### PR TITLE
fix: include mismatched pre-key in error

### DIFF
--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -167,7 +167,7 @@ export class PrivateKeyBundleV1 implements proto.PrivateKeyBundleV1 {
   findPreKey(which: PublicKey): PrivateKey {
     const preKey = this.preKeys.find((key) => key.matches(which))
     if (!preKey) {
-      throw new NoMatchingPreKeyError()
+      throw new NoMatchingPreKeyError(which)
     }
     return preKey
   }

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -45,7 +45,7 @@ export class PrivateKeyBundleV2 implements proto.PrivateKeyBundleV2 {
   findPreKey(which: SignedPublicKey): SignedPrivateKey {
     const preKey = this.preKeys.find((key) => key.matches(which))
     if (!preKey) {
-      throw new NoMatchingPreKeyError()
+      throw new NoMatchingPreKeyError(which)
     }
     return preKey
   }

--- a/src/crypto/errors.ts
+++ b/src/crypto/errors.ts
@@ -1,5 +1,8 @@
+import PublicKey from './PublicKey'
+import { bytesToHex } from './utils'
+
 export class NoMatchingPreKeyError extends Error {
-  constructor() {
-    super('no matching pre-key')
+  constructor(peer: PublicKey) {
+    super(`no pre-key matches: ${bytesToHex(peer.secp256k1Uncompressed)}`)
   }
 }

--- a/src/crypto/errors.ts
+++ b/src/crypto/errors.ts
@@ -1,8 +1,8 @@
-import PublicKey from './PublicKey'
+import { PublicKey, SignedPublicKey } from './PublicKey'
 import { bytesToHex } from './utils'
 
 export class NoMatchingPreKeyError extends Error {
-  constructor(peer: PublicKey) {
-    super(`no pre-key matches: ${bytesToHex(peer.secp256k1Uncompressed)}`)
+  constructor(peer: PublicKey | SignedPublicKey) {
+    super(`no pre-key matches: ${bytesToHex(peer.secp256k1Uncompressed.bytes)}`)
   }
 }

--- a/src/crypto/errors.ts
+++ b/src/crypto/errors.ts
@@ -2,7 +2,9 @@ import { PublicKey, SignedPublicKey } from './PublicKey'
 import { bytesToHex } from './utils'
 
 export class NoMatchingPreKeyError extends Error {
-  constructor(peer: PublicKey | SignedPublicKey) {
-    super(`no pre-key matches: ${bytesToHex(peer.secp256k1Uncompressed.bytes)}`)
+  constructor(preKey: PublicKey | SignedPublicKey) {
+    super(
+      `no pre-key matches: ${bytesToHex(preKey.secp256k1Uncompressed.bytes)}`
+    )
   }
 }

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -51,7 +51,8 @@ describe('Message', function () {
     assert.ok(!msg.error)
     const eveDecoded = await Message.decode(eve, msg.toBytes())
     assert.equal(eveDecoded.decrypted, undefined)
-    assert.deepEqual(eveDecoded.error, new NoMatchingPreKeyError())
+    const preKey = bob.getPublicKeyBundle().preKey
+    assert.deepEqual(eveDecoded.error, new NoMatchingPreKeyError(preKey))
   })
 
   it('senderAddress and recipientAddress throw errors without wallet', async () => {


### PR DESCRIPTION
This should make it easier to debug causes of the error if it happens.

This PR just dumps the key bytes in hex, but maybe we want a more user-friendly fingerprint?