### PR TITLE
Publish v2 contact by default

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -224,7 +224,13 @@ export default class Client {
     ) {
       return
     }
-    this.publishUserContact(legacy)
+    // TEMPORARY: publish V1 contact to make sure there is one in the topic
+    // in order to preserve compatibility with pre-v7 clients.
+    // Remove when pre-v7 clients are deprecated
+    this.publishUserContact(true)
+    if (!legacy) {
+      this.publishUserContact(legacy)
+    }
   }
 
   // PRIVATE: publish the key bundle into the contact topic

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -6,11 +6,11 @@ import {
   waitForUserContact,
 } from './helpers'
 import { buildUserContactTopic } from '../src/utils'
-import Client, { KeyStoreType } from '../src/Client'
+import Client, { KeyStoreType, ClientOptions } from '../src/Client'
 
 type TestCase = {
   name: string
-  newClient: () => Promise<Client>
+  newClient: (opts?: Partial<ClientOptions>) => Promise<Client>
 }
 
 describe('Client', () => {
@@ -31,8 +31,8 @@ describe('Client', () => {
     describe(testCase.name, () => {
       let alice: Client, bob: Client
       beforeAll(async () => {
-        alice = await testCase.newClient()
-        bob = await testCase.newClient()
+        alice = await testCase.newClient({ publishLegacyContact: true })
+        bob = await testCase.newClient({ publishLegacyContact: true })
         await waitForUserContact(alice, alice)
         await waitForUserContact(bob, bob)
       })

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -16,9 +16,9 @@ describe('conversations', () => {
   let charlie: Client
 
   beforeEach(async () => {
-    alice = await newLocalHostClient()
-    bob = await newLocalHostClient()
-    charlie = await newLocalHostClient()
+    alice = await newLocalHostClient({ publishLegacyContact: true })
+    bob = await newLocalHostClient({ publishLegacyContact: true })
+    charlie = await newLocalHostClient({ publishLegacyContact: true })
     await waitForUserContact(alice, alice)
     await waitForUserContact(bob, bob)
     await waitForUserContact(charlie, charlie)
@@ -40,13 +40,11 @@ describe('conversations', () => {
 
     const aliceConversationsAfterMessage = await alice.conversations.list()
     expect(aliceConversationsAfterMessage).toHaveLength(1)
-    expect(await aliceConversationsAfterMessage[0].peerAddress).toBe(
-      bob.address
-    )
+    expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
 
     const bobConversations = await bob.conversations.list()
     expect(bobConversations).toHaveLength(1)
-    expect(await bobConversations[0].peerAddress).toBe(alice.address)
+    expect(bobConversations[0].peerAddress).toBe(alice.address)
   })
 
   it('streams conversations', async () => {
@@ -57,7 +55,7 @@ describe('conversations', () => {
     let numConversations = 0
     for await (const conversation of stream) {
       numConversations++
-      expect(await conversation.peerAddress).toBe(bob.address)
+      expect(conversation.peerAddress).toBe(bob.address)
       break
     }
     expect(numConversations).toBe(1)

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -11,7 +11,7 @@ import {
   storageSigRequestText,
 } from '../../src/store'
 import { hexToBytes } from '../../src/crypto/utils'
-import { newWallet } from '../helpers'
+import { newWallet, sleep } from '../helpers'
 import { ApiUrls } from '../../src/Client'
 import ApiClient from '../../src/ApiClient'
 
@@ -42,6 +42,7 @@ describe('Crypto', function () {
         new PrivateTopicStore(new ApiClient(ApiUrls['local']))
       )
       const bytes = await store.storePrivateKeyBundle(bob)
+      await sleep(100)
       // decrypt and decode the bundle from storage
       const bobDecoded = await store.loadPrivateKeyBundle()
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -119,5 +119,8 @@ export const newLocalHostClient = (
   })
 
 // client running against the dev cluster in AWS
-export const newDevClient = (): Promise<Client> =>
-  Client.create(newWallet(), { env: 'dev' })
+export const newDevClient = (opts?: Partial<ClientOptions>): Promise<Client> =>
+  Client.create(newWallet(), {
+    env: 'dev',
+    ...opts,
+  })

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -55,7 +55,7 @@ describe('PrivateTopicStore', () => {
 
         store.set(keyA, valueA)
         store.set(keyB, valueB)
-        await sleep(50)
+        await sleep(100)
         const responseA = await store.get(keyA)
         const responseB = await store.get(keyB)
 

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { EncryptedKeyStore, PrivateTopicStore } from '../../src/store'
 import assert from 'assert'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
-import { newWallet } from '../helpers'
+import { newWallet, sleep } from '../helpers'
 import ApiClient from '../../src/ApiClient'
 import { ApiUrls } from '../../src/Client'
 
@@ -20,6 +20,7 @@ describe('EncryptedKeyStore', () => {
     const originalBundle = await PrivateKeyBundleV1.generate(wallet)
 
     await secureStore.storePrivateKeyBundle(originalBundle)
+    await sleep(100)
     const returnedBundle = await secureStore.loadPrivateKeyBundle()
 
     assert.ok(returnedBundle)


### PR DESCRIPTION
Switching the default published contact bundle to V2. This will start spilling network traffic over to the V2 style as more and more clients adopt v7.0.0.

It also fixes the constant contact republishing on every client initialization. Instead it reads the current contact from the network and republishes it if it's different from what the private key bundle implies. This should reduce the churn on the contact topic, while still allow clients to fix up the current contact if it's stale or if there's garbage in the contact topic somehow.

In order to keep most of the test suite operating with V1 mode as before, I'm introducing a legacy client option `publishLegacyContact?: boolean` that allow overriding the default V2 behavior. This allows me to configure the client in the test suite to preserve the old behavior. It also makes this explicit in the test suite definition, so it will remind us that some tests are still running with the V1 behavior.

I'm also adding bunch of sleeps to the tests as the test were constantly failing for me running locally. There were quite a few races between sends and lists and also between streams and lists. The latter is interesting, because one would assume that if a message shows up on a stream it should show up in a list as well, but the thing to remember that streams operate from the relay whereas list operates from the store, so it is possible for the relay to deliver a message before it is actually committed to the store.

More comments inline...