### PR TITLE
Beta: Expose ns to Date timestamp converters

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -1,6 +1,6 @@
 import { messageApi } from '@xmtp/proto'
 import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
-import { dateToNs, retry, sleep } from './utils'
+import { retry, sleep, toNanoString } from './utils'
 import AuthCache from './authn/AuthCache'
 import { Authenticator } from './authn'
 import { version } from '../package.json'
@@ -45,10 +45,6 @@ export type ApiClientOptions = {
 export type SubscribeCallback = NotifyStreamEntityArrival<messageApi.Envelope>
 
 export type UnsubscribeFn = () => Promise<void>
-
-const toNanoString = (d: Date | undefined): undefined | string => {
-  return d && dateToNs(d).toString()
-}
 
 const isAbortError = (err?: Error): boolean => {
   if (!err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,4 @@ export {
   ContentTypeComposite,
 } from './codecs/Composite'
 export { SortDirection } from './ApiClient'
-export { nsToDate, dateToNs } from './utils'
+export { nsToDate, dateToNs, fromNanoString, toNanoString } from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,4 @@ export {
   ContentTypeComposite,
 } from './codecs/Composite'
 export { SortDirection } from './ApiClient'
+export { nsToDate, dateToNs } from './utils'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,3 +114,14 @@ export function dateToNs(date: Date): Long {
 export function nsToDate(ns: Long): Date {
   return new Date(ns.divide(1_000_000).toNumber())
 }
+
+export const toNanoString = (d: Date | undefined): undefined | string => {
+  return d && dateToNs(d).toString()
+}
+
+export const fromNanoString = (s: string | undefined): undefined | Date => {
+  if (!s) {
+    return undefined
+  }
+  return nsToDate(Long.fromString(s))
+}


### PR DESCRIPTION
This PR unblocks a https://github.com/lensterxyz/lenster/pull/1047 where we use the lower-level `Client#listEnvelopes` to fetch _one_ most recent message for _all_ conversations. The timestamp associated with envelopes is in nanoseconds, I don't think the app-layer should have to `npm i long` in order to use that timestamp with higher precision since we already have it.