### PR TITLE
Add client app version on api requests

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -79,6 +79,8 @@ type NetworkOptions = {
   env: keyof typeof ApiUrls
   // apiUrl can be used to override the default URL for the env
   apiUrl: string | undefined
+  // app identifier included with client version header
+  appVersion?: string
 }
 
 type ContentOptions = {
@@ -266,7 +268,7 @@ export default class Client {
   ): Promise<boolean> {
     const apiUrl = opts?.apiUrl || ApiUrls[opts?.env || 'dev']
     const keyBundle = await getUserContactFromNetwork(
-      new ApiClient(apiUrl),
+      new ApiClient(apiUrl, { appVersion: opts?.appVersion }),
       peerAddress
     )
     return keyBundle !== undefined
@@ -465,7 +467,7 @@ async function loadOrCreateKeysFromOptions(
 
 function createApiClientFromOptions(options: ClientOptions): ApiClient {
   const apiUrl = options.apiUrl || ApiUrls[options.env]
-  return new ApiClient(apiUrl)
+  return new ApiClient(apiUrl, { appVersion: options.appVersion })
 }
 
 // retrieve a key bundle from given user's contact topic

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -145,7 +145,7 @@ describe('Publish', () => {
 
   beforeEach(() => {
     publishMock.mockClear()
-    publishClient = new ApiClient(PATH_PREFIX)
+    publishClient = new ApiClient(PATH_PREFIX, { appVersion: 'test/0.0.0' })
   })
 
   it('publishes valid messages', async () => {
@@ -176,6 +176,7 @@ describe('Publish', () => {
       headers: new Headers({
         Authorization: `Bearer ${AUTH_TOKEN}`,
         'X-Client-Version': 'xmtp-js/' + version,
+        'X-App-Version': 'test/0.0.0',
       }),
     })
   })


### PR DESCRIPTION
Adds optional client app version identifier that's included with API requests.

https://github.com/xmtp/xmtp-js/issues/202