### PR TITLE
Friendlier log level when resubscribing

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -161,7 +161,7 @@ export default class ApiClient {
         if (isAbortError(err)) {
           return
         }
-        console.warn('Stream connection lost. Resubscribing', err)
+        console.info('Stream connection lost. Resubscribing', err)
         // If connection was initiated less than 1 second ago, sleep for a bit
         // TODO: exponential backoff + eventually giving up
         if (+new Date() - startTime < 1000) {


### PR DESCRIPTION
Reduce log level from `warn` to `info` to avoid the intimidating highlight + error expansion

![Screen Shot 2022-11-02 at 4 38 37 PM](https://user-images.githubusercontent.com/182290/199597850-670261ce-a9a9-4b41-b2ef-67c8bcd89cc5.png)
