### PR TITLE
RFC: Require an XMTP env when creating `Client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import { Wallet } from 'ethers'
 // You'll want to replace this with a wallet from your application
 const wallet = Wallet.createRandom()
 // Create the client with your wallet. This will connect to the XMTP development network by default
-const xmtp = await Client.create(wallet)
+const xmtp = await Client.create(wallet, 'dev')
 // Start a conversation with XMTP
 const conversation = await xmtp.conversations.newConversation(
   '0x3F11b27F323b62B159D2642964fa27C46C841897'
@@ -106,31 +106,30 @@ for await (const message of await conversation.streamMessages()) {
 
 ### Creating a Client
 
-A Client is created with `Client.create(wallet: ethers.Signer): Promise<Client>` that requires passing in a connected Wallet. The Client will request a wallet signature in 2 cases:
+A Client is created with `Client.create(wallet: ethers.Signer, env: "local" | "dev" | "production"): Promise<Client>` that requires passing in a connected Wallet and an XMTP environment. The Client will request a wallet signature in 2 cases:
 
 1. To sign the newly generated key bundle. This happens only the very first time when key bundle is not found in storage.
 2. To sign a random salt used to encrypt the key bundle in storage. This happens every time the Client is started (including the very first time).
 
-The Client will connect to the XMTP `dev` environment by default. ClientOptions can be used to override this and other parameters of the network connection.
+For important details about working with XMTP environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments). Additionally, ClientOptions can be used to override parameters of the network connection.
 
 ```ts
 import { Client } from '@xmtp/xmtp-js'
 // Create the client with an `ethers.Signer` from your application
-const xmtp = await Client.create(wallet)
+const xmtp = await Client.create(wallet, 'dev')
 ```
 
 #### Configuring the Client
 
 The client's network connection and key storage method can be configured with these optional parameters of `Client.create`:
 
-| Parameter      | Default               | Description                                                                                                                                                                                                                                                                |
-| -------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| env            | `dev`                 | Connect to the specified XMTP network environment. Valid values also include `production` and `local`. For important details about working with these environments, see [XMTP `production` and `dev` network environments](#xmtp-production-and-dev-network-environments). |
-| apiUrl         | `undefined`           | Manually specify an API URL to use. If specified, value of `env` will be ignored.                                                                                                                                                                                          |
+| Parameter      | Default               | Description                                                                                       |
+| -------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| apiUrl         | `undefined`           | Manually specify an API URL to use. If specified, value of `env` will be ignored.                 |
 |                |
-| keyStoreType   | `networkTopicStoreV1` | Persist the wallet's key bundle to the network, or use `static` to provide private keys manually.                                                                                                                                                                          |
-| codecs         | `[TextCodec]`         | Add codecs to support additional content types.                                                                                                                                                                                                                            |
-| maxContentSize | `100M`                | Maximum message content size in bytes.                                                                                                                                                                                                                                     |
+| keyStoreType   | `networkTopicStoreV1` | Persist the wallet's key bundle to the network, or use `static` to provide private keys manually. |
+| codecs         | `[TextCodec]`         | Add codecs to support additional content types.                                                   |
+| maxContentSize | `100M`                | Maximum message content size in bytes.                                                            |
 
 ### Conversations
 
@@ -139,7 +138,7 @@ Most of the time, when interacting with the network, you'll want to do it throug
 ```ts
 import { Client } from '@xmtp/xmtp-js'
 // Create the client with an `ethers.Signer` from your application
-const xmtp = await Client.create(wallet)
+const xmtp = await Client.create(wallet, 'dev')
 const conversations = xmtp.conversations
 ```
 
@@ -259,11 +258,12 @@ If you would like to check and see if a blockchain address is registered on the 
 import { Client } from '@xmtp/xmtp-js'
 
 const isOnDevNetwork = await Client.canMessage(
-  '0x3F11b27F323b62B159D2642964fa27C46C841897'
+  '0x3F11b27F323b62B159D2642964fa27C46C841897',
+  'dev'
 )
 const isOnProdNetwork = await Client.canMessage(
   '0x3F11b27F323b62B159D2642964fa27C46C841897',
-  { env: 'production' }
+  'production'
 )
 ```
 
@@ -336,7 +336,7 @@ Additional codecs can be configured through the `ClientOptions` parameter of `Cl
 ```ts
 // Adding support for `xmtp.org/composite` content type
 import { CompositeCodec } from '@xmtp/xmtp-js'
-const xmtp = Client.create(wallet, { codecs: [new CompositeCodec()] })
+const xmtp = Client.create(wallet, 'dev', { codecs: [new CompositeCodec()] })
 ```
 
 #### Compression
@@ -360,9 +360,9 @@ You can export the unencrypted key bundle using the static method `Client.getKey
 ```ts
 import { Client } from '@xmtp/xmtp-js'
 // Get the keys using a valid ethers.Signer. Save them somewhere secure.
-const keys = await Client.getKeys(wallet)
+const keys = await Client.getKeys(wallet, 'dev')
 // Create a client using keys returned from getKeys
-const client = await Client.create(null, { privateKeyOverride: keys })
+const client = await Client.create(null, 'dev', { privateKeyOverride: keys })
 ```
 
 The keys returned by `getKeys` should be treated with the utmost care as compromise of these keys will allow an attacker to impersonate the user on the XMTP network. Ensure these keys are stored somewhere secure and encrypted.

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -78,15 +78,13 @@ describe('canMessage', () => {
     await waitForUserContact(registeredClient, registeredClient)
     const canMessageRegisteredClient = await Client.canMessage(
       registeredClient.address,
-      {
-        env: 'local',
-      }
+      'local'
     )
     expect(canMessageRegisteredClient).toBeTruthy()
 
     const canMessageUnregisteredClient = await Client.canMessage(
       newWallet().address,
-      { env: 'local' }
+      'local'
     )
     expect(canMessageUnregisteredClient).toBeFalsy()
   })

--- a/test/Keygen.test.ts
+++ b/test/Keygen.test.ts
@@ -20,12 +20,9 @@ describe('Key Generation', () => {
   })
 
   test('Network store', async () => {
-    const opts = {
-      env: 'local' as keyof typeof ApiUrls,
-    }
-    const keys = await Client.getKeys(wallet, opts)
-    const client = await Client.create(null, {
-      ...opts,
+    const env = 'local' as keyof typeof ApiUrls
+    const keys = await Client.getKeys(wallet, env)
+    const client = await Client.create(null, env, {
       privateKeyOverride: keys,
     })
     expect(client.legacyKeys.encode()).toEqual(keys)
@@ -33,13 +30,11 @@ describe('Key Generation', () => {
 
   // Make sure that the keys are being saved to the network upon generation
   test('Ensure persistence', async () => {
-    const opts = defaultOptions({
-      env: 'local' as keyof typeof ApiUrls,
-    })
-    const keys = await Client.getKeys(wallet, opts)
+    const env = 'local' as keyof typeof ApiUrls
+    const keys = await Client.getKeys(wallet, env)
     const staticStore = new StaticKeyStore(keys)
     const bundle = await staticStore.loadPrivateKeyBundle()
-    const apiClient = new ApiClient(ApiUrls[opts.env])
+    const apiClient = new ApiClient(ApiUrls[env])
     const store = new EncryptedKeyStore(
       wallet,
       new PrivateTopicStore(apiClient)

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -113,11 +113,10 @@ export class CodecRegistry {
 export const newLocalHostClient = (
   opts?: Partial<ClientOptions>
 ): Promise<Client> =>
-  Client.create(newWallet(), {
-    env: 'local',
+  Client.create(newWallet(), 'local', {
     ...opts,
   })
 
 // client running against the dev cluster in AWS
 export const newDevClient = (): Promise<Client> =>
-  Client.create(newWallet(), { env: 'dev' })
+  Client.create(newWallet(), 'dev')


### PR DESCRIPTION
Opening this up as an RFC because this would be a **BREAKING CHANGE** for everyone.

## Context

In the past few weeks, we've seen confusion around which environment we are pointing to causing bugs (and missing messages) internally and externally. Even us employees at XMTP Labs sometimes forget to set the `production` env when calling `Client.canMessage()` or `Clinet.getKeys()` since it is optional right now. We saw this with Lenster and have heard this is a friction point from developers in Discord and at Hackathons.

## Goal

I think requiring `env` when creating a Client or using any of the static methods on Client will push developers to consider the env and likely make a constant for it to be used everywhere. This is what we did for Lenster [here](https://github.com/lensterxyz/lenster/blob/fe30651fe0b56706f7b07b896027b6ac5c679b8c/src/constants.ts#L25). I think this is an instance where a little bit of friction will help with education and best practices and hopefully make it like bowling with gutter guards to do the right thing.

Ideally, we will see less valuable messages on the dev network that want to get ported over to production as well as fewer `No matching pre-key` errors with people accidentally using dev keys on the production env via `Client.getKeys()`.