### PR TITLE
fix: grammar in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-If you're seeing this document, you an early contributor to the development and success of XMTP. We welcome your questions, feedback, suggestions, and code contributions.
+If you're seeing this document, you are an early contributor to the development and success of XMTP. We welcome your questions, feedback, suggestions, and code contributions.
 
 > If you wish to contribute, please [apply for Early Access](https://xmtp.typeform.com/yojTJarb) so that we can provide you with access to our Discord.
 


### PR DESCRIPTION
Added a missing "are" in the first paragraph of the contributing guidelines.