### PR TITLE
Loudly log when connected to the `dev` network

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -4,6 +4,7 @@ import { retry, sleep, toNanoString } from './utils'
 import AuthCache from './authn/AuthCache'
 import { Authenticator } from './authn'
 import { version } from '../package.json'
+import { XMTP_DEV_WARNING } from './constants'
 export const { MessageApi, SortDirection } = messageApi
 
 const RETRY_SLEEP_TIME = 100
@@ -11,6 +12,12 @@ const ERR_CODE_UNAUTHENTICATED = 16
 
 const clientVersionHeaderKey = 'X-Client-Version'
 const appVersionHeaderKey = 'X-App-Version'
+
+export const ApiUrls = {
+  local: 'http://localhost:5555',
+  dev: 'https://dev.xmtp.network',
+  production: 'https://production.xmtp.network',
+} as const
 
 export type GrpcError = Error & { code?: number }
 
@@ -85,6 +92,10 @@ export default class ApiClient {
     this.maxRetries = opts?.maxRetries || 5
     this.appVersion = opts?.appVersion
     this.version = 'xmtp-js/' + version
+
+    if (pathPrefix === ApiUrls.dev) {
+      console.info(XMTP_DEV_WARNING)
+    }
   }
 
   // Raw method for querying the API

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -23,7 +23,7 @@ import { ContentTypeId, ContentCodec } from './MessageContent'
 import { compress } from './Compression'
 import { xmtpEnvelope, messageApi, fetcher } from '@xmtp/proto'
 import { decodeContactBundle, encodeContactBundle } from './ContactBundle'
-import ApiClient, { PublishParams, SortDirection } from './ApiClient'
+import ApiClient, { ApiUrls, PublishParams, SortDirection } from './ApiClient'
 import { Authenticator } from './authn'
 import { SealedInvitation } from './Invitation'
 const { Compression } = xmtpEnvelope
@@ -34,12 +34,6 @@ const { b64Decode } = fetcher
 
 // Default maximum allowed content size
 const MaxContentSize = 100 * 1024 * 1024 // 100M
-
-export const ApiUrls = {
-  local: 'http://localhost:5555',
-  dev: 'https://dev.xmtp.network',
-  production: 'https://production.xmtp.network',
-} as const
 
 // Parameters for the listMessages functions
 export type ListMessagesOptions = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-useless-escape */
 export const XMTP_DEV_WARNING = `
 XX    XX MM    MM TTTTTTT PPPPPP   DDDDD   EEEEEEE VV     VV 
  XX  XX  MMM  MMM   TTT   PP   PP  DD  DD  EE      VV     VV 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-useless-escape */
+export const XMTP_DEV_WARNING = `
+XX    XX MM    MM TTTTTTT PPPPPP   DDDDD   EEEEEEE VV     VV 
+ XX  XX  MMM  MMM   TTT   PP   PP  DD  DD  EE      VV     VV 
+  XXXX   MM MM MM   TTT   PPPPPP   DD   DD EEEEE    VV   VV  
+ XX  XX  MM    MM   TTT   PP       DD   DD EE        VV VV   
+XX    XX MM    MM   TTT   PP       DDDDDD  EEEEEEE    VVV    
+
+Connected to the XMTP 'dev' network. Use 'production' for production messages.
+https://github.com/xmtp/xmtp-js#xmtp-production-and-dev-network-environments
+`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,9 @@
 export const XMTP_DEV_WARNING = `
-XX    XX MM    MM TTTTTTT PPPPPP   DDDDD   EEEEEEE VV     VV 
- XX  XX  MMM  MMM   TTT   PP   PP  DD  DD  EE      VV     VV 
-  XXXX   MM MM MM   TTT   PPPPPP   DD   DD EEEEE    VV   VV  
- XX  XX  MM    MM   TTT   PP       DD   DD EE        VV VV   
-XX    XX MM    MM   TTT   PP       DDDDDD  EEEEEEE    VVV    
+XX    XX MM    MM TTTTTT PPPPPP   DDDDD   EEEEEEE VV     VV 
+ XX  XX  MMM  MMM   TT   PP   PP  DD  DD  EE      VV     VV 
+  XXXX   MM MM MM   TT   PPPPPP   DD   DD EEEEE    VV   VV  
+ XX  XX  MM    MM   TT   PP       DD   DD EE        VV VV   
+XX    XX MM    MM   TT   PP       DDDDDD  EEEEEEE    VVV    
 
 Connected to the XMTP 'dev' network. Use 'production' for production messages.
 https://github.com/xmtp/xmtp-js#xmtp-production-and-dev-network-environments

--- a/test/Keygen.test.ts
+++ b/test/Keygen.test.ts
@@ -1,10 +1,6 @@
-import { ApiUrls } from './../src/Client'
+import { ApiUrls } from './../src/ApiClient'
 import { newWallet, sleep } from './helpers'
-import Client, {
-  ClientOptions,
-  defaultOptions,
-  KeyStoreType,
-} from '../src/Client'
+import Client, { defaultOptions } from '../src/Client'
 import { Signer } from 'ethers'
 import {
   EncryptedKeyStore,

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -12,8 +12,7 @@ import {
 } from '../../src/store'
 import { hexToBytes } from '../../src/crypto/utils'
 import { newWallet, sleep } from '../helpers'
-import { ApiUrls } from '../../src/Client'
-import ApiClient from '../../src/ApiClient'
+import ApiClient, { ApiUrls } from '../../src/ApiClient'
 
 describe('Crypto', function () {
   describe('PrivateKeyBundle', function () {

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -2,8 +2,7 @@ import { Wallet } from 'ethers'
 
 import { newWallet, sleep } from '../helpers'
 import { PrivateTopicStore } from '../../src/store'
-import ApiClient from '../../src/ApiClient'
-import { ApiUrls } from '../../src/Client'
+import ApiClient, { ApiUrls } from '../../src/ApiClient'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
 import Authenticator from '../../src/authn/Authenticator'
 

--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -3,8 +3,7 @@ import { EncryptedKeyStore, PrivateTopicStore } from '../../src/store'
 import assert from 'assert'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
 import { newWallet, sleep } from '../helpers'
-import ApiClient from '../../src/ApiClient'
-import { ApiUrls } from '../../src/Client'
+import ApiClient, { ApiUrls } from '../../src/ApiClient'
 
 describe('EncryptedKeyStore', () => {
   let wallet: Wallet


### PR DESCRIPTION
Instead of requiring an environment be passed in to every `Client` instance as originally proposed in this [RFC](https://github.com/xmtp/xmtp-js/pull/215), we determined it would be best to still default to `dev` but loudly log to the console when using dev.

This PR adds an ASCII art info log when creating a new `ApiClient` which is called from all `Client.canMessage()`, `Client.getKeys` and `Client.create()` methods. I also moved the ApiUrls to live inside `ApiClient` instead of having a circular dependency back to `Client` to read them.

<img width="562" alt="Screen Shot 2022-11-10 at 4 39 33 PM" src="https://user-images.githubusercontent.com/556051/201213567-e23342ca-044e-4a3f-8d04-fb3b03de4e7d.png">
