### PR TITLE
fix: maintain pre-existing legacy conversation

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -123,12 +123,12 @@ export class ConversationV1 {
     options?: SendOptions
   ): Promise<DecodedMessage> {
     let topics: string[]
-    const recipient = await this.client.getUserContact(this.peerAddress)
+    let recipient = await this.client.getUserContact(this.peerAddress)
     if (!recipient) {
       throw new Error(`recipient ${this.peerAddress} is not registered`)
     }
     if (!(recipient instanceof PublicKeyBundle)) {
-      throw new Error(`recipient bundle is not legacy bundle`)
+      recipient = recipient.toLegacyBundle()
     }
 
     if (!this.client.contacts.has(this.peerAddress)) {

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -285,7 +285,21 @@ export default class Conversations {
       const intros = await this.getIntroductionPeers()
       const introSentTime = intros.get(peerAddress)
       // If intro already exists, return V1 conversation
+      // if both peers have V1 compatible key bundles
       if (introSentTime) {
+        if (!this.client.keys.getPublicKeyBundle().isFromLegacyBundle()) {
+          throw new Error(
+            'cannot resume pre-existing V1 conversation; client keys not compatible'
+          )
+        }
+        if (
+          !(contact instanceof PublicKeyBundle) &&
+          !contact.isFromLegacyBundle()
+        ) {
+          throw new Error(
+            'cannot resume pre-existing V1 conversation; peer keys not compatible'
+          )
+        }
         return new ConversationV1(this.client, peerAddress, introSentTime)
       }
     }

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -13,6 +13,7 @@ export class PrivateKeyBundleV2 implements proto.PrivateKeyBundleV2 {
   identityKey: SignedPrivateKey
   preKeys: SignedPrivateKey[]
   version = 2
+  private _publicKeyBundle?: SignedPublicKeyBundle
 
   constructor(bundle: proto.PrivateKeyBundleV2) {
     if (!bundle.identityKey) {
@@ -58,10 +59,13 @@ export class PrivateKeyBundleV2 implements proto.PrivateKeyBundleV2 {
 
   // Return a key bundle with the current pre-key.
   getPublicKeyBundle(): SignedPublicKeyBundle {
-    return new SignedPublicKeyBundle({
-      identityKey: this.identityKey.publicKey,
-      preKey: this.getCurrentPreKey().publicKey,
-    })
+    if (!this._publicKeyBundle) {
+      this._publicKeyBundle = new SignedPublicKeyBundle({
+        identityKey: this.identityKey.publicKey,
+        preKey: this.getCurrentPreKey().publicKey,
+      })
+    }
+    return this._publicKeyBundle
   }
 
   // sharedSecret derives a secret from peer's key bundles using a variation of X3DH protocol
@@ -134,6 +138,7 @@ export class PrivateKeyBundleV1 implements proto.PrivateKeyBundleV1 {
   identityKey: PrivateKey
   preKeys: PrivateKey[]
   version = 1
+  private _publicKeyBundle?: PublicKeyBundle
 
   constructor(bundle: proto.PrivateKeyBundleV1) {
     if (!bundle.identityKey) {
@@ -181,10 +186,13 @@ export class PrivateKeyBundleV1 implements proto.PrivateKeyBundleV1 {
 
   // Return a key bundle with the current pre-key.
   getPublicKeyBundle(): PublicKeyBundle {
-    return new PublicKeyBundle({
-      identityKey: this.identityKey.publicKey,
-      preKey: this.getCurrentPreKey().publicKey,
-    })
+    if (!this._publicKeyBundle) {
+      this._publicKeyBundle = new PublicKeyBundle({
+        identityKey: this.identityKey.publicKey,
+        preKey: this.getCurrentPreKey().publicKey,
+      })
+    }
+    return this._publicKeyBundle
   }
 
   // sharedSecret derives a secret from peer's key bundles using a variation of X3DH protocol

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -53,6 +53,7 @@ export class PrivateKeyBundleV2 implements proto.PrivateKeyBundleV2 {
 
   // Generate a new pre-key to be used as the current pre-key.
   async addPreKey(): Promise<void> {
+    this._publicKeyBundle = undefined
     const preKey = await SignedPrivateKey.generate(this.identityKey)
     this.preKeys.unshift(preKey)
   }
@@ -179,6 +180,7 @@ export class PrivateKeyBundleV1 implements proto.PrivateKeyBundleV1 {
 
   // Generate a new pre-key to be used as the current pre-key.
   async addPreKey(): Promise<void> {
+    this._publicKeyBundle = undefined
     const preKey = PrivateKey.generate()
     await this.identityKey.signKey(preKey.publicKey)
     this.preKeys.unshift(preKey)

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -47,12 +47,14 @@ export class UnsignedPublicKey implements publicKey.UnsignedPublicKey {
     return new Date(this.timestamp.toNumber())
   }
 
+  isFromLegacyKey(): boolean {
+    return this.createdNs.lessThan(MS_NS_TIMESTAMP_THRESHOLD)
+  }
+
   // creation time in milliseconds
   get timestamp(): Long {
     return (
-      this.createdNs < MS_NS_TIMESTAMP_THRESHOLD
-        ? this.createdNs
-        : this.createdNs.div(1000000)
+      this.isFromLegacyKey() ? this.createdNs : this.createdNs.div(1000000)
     ).toUnsigned()
   }
 
@@ -169,6 +171,23 @@ export class SignedPublicKey
   // Decode signed key from bytes.
   static fromBytes(bytes: Uint8Array): SignedPublicKey {
     return new SignedPublicKey(publicKey.SignedPublicKey.decode(bytes))
+  }
+
+  toLegacyKey(): PublicKey {
+    if (!this.isFromLegacyKey()) {
+      throw new Error('cannot be converted to legacy key')
+    }
+    let signature = this.signature
+    if (signature.walletEcdsaCompact) {
+      signature = new Signature({
+        ecdsaCompact: signature.walletEcdsaCompact,
+      })
+    }
+    return new PublicKey({
+      timestamp: this.timestamp,
+      secp256k1Uncompressed: this.secp256k1Uncompressed,
+      signature,
+    })
   }
 
   static fromLegacyKey(

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -34,6 +34,17 @@ export class SignedPublicKeyBundle implements publicKey.SignedPublicKeyBundle {
     return publicKey.SignedPublicKeyBundle.encode(this).finish()
   }
 
+  isFromLegacyBundle(): boolean {
+    return this.identityKey.isFromLegacyKey() && this.preKey.isFromLegacyKey()
+  }
+
+  toLegacyBundle(): PublicKeyBundle {
+    return new PublicKeyBundle({
+      identityKey: this.identityKey.toLegacyKey(),
+      preKey: this.preKey.toLegacyKey(),
+    })
+  }
+
   static fromBytes(bytes: Uint8Array): SignedPublicKeyBundle {
     const decoded = publicKey.SignedPublicKeyBundle.decode(bytes)
     return new SignedPublicKeyBundle(decoded)

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -176,6 +176,15 @@ describe('conversations', () => {
 
       const aliceConvo2 = await alice.conversations.newConversation(bob.address)
       expect(aliceConvo2 instanceof ConversationV1).toBeTruthy()
+      await aliceConvo2.send('hi')
+
+      await sleep(100)
+      const bobConvo = await bob.conversations.newConversation(alice.address)
+      expect(bobConvo instanceof ConversationV1).toBeTruthy()
+      const messages = await bobConvo.messages()
+      expect(messages.length).toBe(2)
+      expect(messages[0].content).toBe('gm')
+      expect(messages[1].content).toBe('hi')
     })
 
     it('creates a new V2 conversation when no existing convo and V2 bundle', async () => {

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -4,6 +4,7 @@ import {
   PrivateKey,
   PrivateKeyBundleV1,
   PrivateKeyBundleV2,
+  SignedPublicKeyBundle,
 } from '../../src/crypto'
 import {
   EncryptedKeyStore,
@@ -86,6 +87,20 @@ describe('Crypto', function () {
         'XMTP : Enable Identity\nf51bd1da9ec2239723ae2cf6a9f8d0ac37546b27e634002c653d23bacfcc67ad\n\nFor more info: https://xmtp.org/signatures/'
       assert.equal(actual, expected)
       assert.ok(true)
+    })
+  })
+  describe('SignedPublicKeyBundle', () => {
+    it('legacy roundtrip', async function () {
+      const wallet = newWallet()
+      const pri = await PrivateKeyBundleV1.generate(wallet)
+      const pub = SignedPublicKeyBundle.fromLegacyBundle(
+        pri.getPublicKeyBundle()
+      )
+      expect(pub.isFromLegacyBundle()).toBeTruthy()
+      const leg = pub.toLegacyBundle()
+      const pub2 = SignedPublicKeyBundle.fromLegacyBundle(leg)
+      expect(pub.equals(pub2)).toBeTruthy()
+      expect(pub2.identityKey.verifyKey(pub2.preKey)).toBeTruthy()
     })
   })
 })

--- a/test/crypto/PublicKey.test.ts
+++ b/test/crypto/PublicKey.test.ts
@@ -36,6 +36,34 @@ describe('Crypto', function () {
       const idPri2 = SignedPrivateKey.fromBytes(bytes)
       assert.ok(idPri.equals(idPri2))
     })
+    it('legacy conversation fails for ns creation timestamps', async function () {
+      const wallet = newWallet()
+      const keySigner = new WalletSigner(wallet)
+      const idPri = await SignedPrivateKey.generate(keySigner)
+      expect(idPri.publicKey.isFromLegacyKey()).toBeFalsy()
+      expect(() => idPri.publicKey.toLegacyKey()).toThrow(
+        'cannot be converted to legacy key'
+      )
+    })
+    it('public key legacy roundtrip', async function () {
+      const wallet = newWallet()
+      const idPri = PrivateKey.generate()
+      await idPri.publicKey.signWithWallet(wallet)
+      const idPub = SignedPublicKey.fromLegacyKey(idPri.publicKey, true)
+      expect(idPub.isFromLegacyKey()).toBeTruthy()
+      const idPubLeg = idPub.toLegacyKey()
+      const idPub2 = SignedPublicKey.fromLegacyKey(idPubLeg, true)
+      assert.ok(idPub.equals(idPub2))
+
+      const prePri = PrivateKey.generate()
+      await idPri.signKey(prePri.publicKey)
+      const prePub = SignedPublicKey.fromLegacyKey(prePri.publicKey, false)
+      expect(prePub.isFromLegacyKey()).toBeTruthy()
+      const prePubLeg = prePub.toLegacyKey()
+      const prePub2 = SignedPublicKey.fromLegacyKey(prePubLeg, false)
+      assert.ok(prePub.equals(prePub2))
+      assert.ok(idPub2.verifyKey(prePub2))
+    })
   })
   describe('PublicKey', function () {
     it('derives address from public key', function () {


### PR DESCRIPTION
Fixes error: `recipient bundle is not legacy bundle`

This turned out to be a bit messier than I thought. The issue was clear, `ConversationV1.send()` explicitly checked that the recipient's contact is a V1 bundle, if not it threw this error. So when we started publishing V2 contacts, users that had pre-existing V1 conversations started tripping over this check. The obvious solution is to convert V2 contacts back to V1 contacts for V1 conversations, which is largely what this PR does.

However this conversion is not always possible. This is due to the precision change of creation time between V1 and V2 keys. We moved from millisecond precision to nanosecond precision, which caused trouble from the beginning, but we worked around it by allowing V2 keys converted from V1 keys to stick with ms precision in order to be able to transplant the key signature during the conversion. This enabled V1->V2 conversion, but the inverse is only possible if the V2 key uses the ms precision, i.e. it was converted from V1 to begin with.

This is sufficient for us today, all the keys out there, including new ones being created, are generated as V1 keys and converted to V2. However, we will have to be careful when we start generating native V2 key bundles. Users with native V2 bundles will not be able to participate in V1 conversations. This should be OK as long as we can expect that

1. all users out there to have V2 contacts at that point AND that
2. the user with native V2 keys does not have any pre-existing V1 conversations with anyone.

That means we MUST NOT create V2 keys until we deprecate pre-v7.1 SDK, and ensure that all users have a V2 contact published.
