### PR TITLE
Fix up exception tests

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -19,7 +19,27 @@ export const ApiUrls = {
   production: 'https://production.xmtp.network',
 } as const
 
-export type GrpcError = Error & { code?: number }
+export enum GrpcStatus {
+  OK = 0,
+  CANCELLED,
+  UNKNOWN,
+  INVALID_ARGUMENT,
+  DEADLINE_EXCEEDED,
+  NOT_FOUND,
+  ALREADY_EXISTS,
+  PERMISSION_DENIED,
+  RESOURCE_EXHAUSTED,
+  FAILED_PRECONDITION,
+  ABORTED,
+  OUT_OF_RANGE,
+  UNIMPLEMENTED,
+  INTERNAL,
+  UNAVAILABLE,
+  DATA_LOSS,
+  UNAUTHENTICATED,
+}
+
+export type GrpcError = Error & { code?: GrpcStatus }
 
 export type QueryParams = {
   startTime?: Date

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -1,5 +1,5 @@
 import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
-import ApiClient, { PublishParams } from '../src/ApiClient'
+import ApiClient, { GrpcStatus, PublishParams } from '../src/ApiClient'
 import { messageApi } from '@xmtp/proto'
 import { sleep } from './helpers'
 import { Authenticator } from '../src/authn'
@@ -187,7 +187,7 @@ describe('Publish', () => {
         message: Uint8Array.from([]),
       },
     ])
-    expect(promise).rejects.toBeInstanceOf(Error)
+    expect(promise).rejects.toThrow('Content topic cannot be empty string')
   })
 })
 
@@ -225,7 +225,7 @@ describe('Publish authn', () => {
     }
 
     const prom = publishClient.publish([msg])
-    expect(prom).rejects.toEqual({ code: 16 })
+    expect(prom).rejects.toEqual({ code: GrpcStatus.UNAUTHENTICATED })
     expect(publishMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -1,7 +1,6 @@
 import { NotifyStreamEntityArrival } from '@xmtp/proto/ts/dist/types/fetch.pb'
 import ApiClient, { PublishParams } from '../src/ApiClient'
 import { messageApi } from '@xmtp/proto'
-import Long from 'long'
 import { sleep } from './helpers'
 import { Authenticator } from '../src/authn'
 import { PrivateKey } from '../src'

--- a/test/ApiClientE2E.test.ts
+++ b/test/ApiClientE2E.test.ts
@@ -1,4 +1,4 @@
-import ApiClient, { ApiUrls, PublishParams } from '../src/ApiClient'
+import ApiClient, { ApiUrls, GrpcStatus, PublishParams } from '../src/ApiClient'
 import { newWallet, sleep } from './helpers'
 import { Authenticator } from '../src/authn'
 import { buildUserPrivateStoreTopic, dateToNs } from '../src/utils'
@@ -43,18 +43,21 @@ describe('e2e tests', () => {
         ).resolves
       })
 
-      it('publish restricted topic', async () => {
+      it('publish restricted topic', () => {
         expect(
-          async () =>
-            await client.publish([
-              {
-                contentTopic: buildUserPrivateStoreTopic(
-                  keys.getPublicKeyBundle().preKey.getEthereumAddress()
-                ),
-                message: new Uint8Array(5),
-              },
-            ])
-        ).toThrow('permission denied')
+          client.publish([
+            {
+              contentTopic: buildUserPrivateStoreTopic(
+                keys.getPublicKeyBundle().preKey.getEthereumAddress()
+              ),
+              message: new Uint8Array(5),
+            },
+          ])
+        ).rejects.toEqual({
+          code: GrpcStatus.PERMISSION_DENIED,
+          details: [],
+          message: 'publishing to restricted topic',
+        })
       })
     })
   })

--- a/test/ApiClientE2E.test.ts
+++ b/test/ApiClientE2E.test.ts
@@ -1,0 +1,61 @@
+import ApiClient, { ApiUrls, PublishParams } from '../src/ApiClient'
+import { newWallet, sleep } from './helpers'
+import { Authenticator } from '../src/authn'
+import { buildUserPrivateStoreTopic, dateToNs } from '../src/utils'
+import { Wallet } from 'ethers'
+import { PrivateKeyBundleV1 } from '../src/crypto'
+
+type TestCase = { name: string; api: string }
+
+describe('e2e tests', () => {
+  const tests: TestCase[] = [
+    {
+      name: 'local docker node',
+      api: ApiUrls.local,
+    },
+  ]
+  if (process.env.CI || process.env.TESTNET) {
+    tests.push({
+      name: 'dev',
+      api: ApiUrls.dev,
+    })
+  }
+  tests.forEach((testCase) => {
+    describe(testCase.name, () => {
+      let client: ApiClient
+      let wallet: Wallet
+      let keys: PrivateKeyBundleV1
+      beforeEach(async () => {
+        wallet = newWallet()
+        client = new ApiClient(testCase.api)
+        keys = await PrivateKeyBundleV1.generate(wallet)
+        client.setAuthenticator(new Authenticator(keys.identityKey))
+      })
+
+      it('publish success', async () => {
+        expect(
+          await client.publish([
+            {
+              contentTopic: buildUserPrivateStoreTopic(wallet.address),
+              message: new Uint8Array(5),
+            },
+          ])
+        ).resolves
+      })
+
+      it('publish restricted topic', async () => {
+        expect(
+          async () =>
+            await client.publish([
+              {
+                contentTopic: buildUserPrivateStoreTopic(
+                  keys.getPublicKeyBundle().preKey.getEthereumAddress()
+                ),
+                message: new Uint8Array(5),
+              },
+            ])
+        ).toThrow('permission denied')
+      })
+    })
+  })
+})

--- a/test/Compression.test.ts
+++ b/test/Compression.test.ts
@@ -17,10 +17,10 @@ describe('Compression', function () {
     assert.deepEqual(from, to.bytes)
   })
 
-  it('will not write beyond limit', async () => {
+  it('will not write beyond limit', () => {
     let from = new Uint8Array(111).fill(42)
     let to = { bytes: new Uint8Array(10) }
-    await expect(
+    expect(
       readStreamFromBytes(from, 23).pipeTo(writeStreamToBytes(to, 100))
     ).rejects.toThrow('maximum output size exceeded')
   })

--- a/test/Invitation.test.ts
+++ b/test/Invitation.test.ts
@@ -9,6 +9,7 @@ import { newWallet } from './helpers'
 import { crypto } from '../src/crypto/encryption'
 import Long from 'long'
 import Ciphertext from '../src/crypto/Ciphertext'
+import { NoMatchingPreKeyError } from '../src/crypto/errors'
 
 const createInvitation = (): InvitationV1 => {
   return new InvitationV1({
@@ -73,7 +74,7 @@ describe('Invitations', () => {
       })
       expect(
         sealedInvitationWithWrongSender.v1.getInvitation(alice)
-      ).rejects.toThrow()
+      ).rejects.toThrow(NoMatchingPreKeyError)
 
       expect(() => {
         const sealedInvite = new SealedInvitation({

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -52,7 +52,7 @@ describe('Message', function () {
       new Date()
     )
     assert.ok(!msg.error)
-    await expect(msg.decrypt(eve)).rejects.toThrow(NoMatchingPreKeyError)
+    expect(msg.decrypt(eve)).rejects.toThrow(NoMatchingPreKeyError)
   })
 
   it('Message create throws error for sender without wallet', async () => {

--- a/test/codecs/Composite.test.ts
+++ b/test/codecs/Composite.test.ts
@@ -61,6 +61,6 @@ describe('CompositeType', () => {
   it('definitely not a composite', () => {
     const codec = codecs.codecFor(ContentTypeComposite)
     assert(codec)
-    expect(() => codec.encode('definitely not a composite', codecs)).rejects
+    expect(() => codec.encode('definitely not a composite', codecs)).toThrow()
   })
 })

--- a/test/codecs/Text.test.ts
+++ b/test/codecs/Text.test.ts
@@ -27,16 +27,22 @@ describe('ContentTypeText', () => {
   })
 
   it('throws on non-string', () => {
-    expect(codec.encode(7, codecs)).rejects
+    expect(() =>
+      new TextEncoder().encode({
+        toString() {
+          throw new Error('GM!')
+        },
+      } as any)
+    ).toThrow('GM!')
   })
 
-  it('throws on invalid utf8', () => {
+  it('throws on invalid input', () => {
     const ec = {
       type: ContentTypeText,
       parameters: {},
-      content: new Uint8Array([0xe2, 0x28, 0x81]),
+      content: {} as Uint8Array,
     }
-    expect(() => codec.decode(ec, codecs)).rejects
+    expect(() => codec.decode(ec, codecs)).toThrow()
   })
 
   it('throws on unknown encoding', () => {

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -246,10 +246,10 @@ describe('conversation', () => {
       expect(msg.content).toBe(content)
     })
 
-    it('throws when opening a conversation with an unknown address', async () => {
-      return expect(
-        alice.conversations.newConversation('0xfoo')
-      ).rejects.toThrow('Recipient 0xfoo is not on the XMTP network')
+    it('throws when opening a conversation with an unknown address', () => {
+      expect(alice.conversations.newConversation('0xfoo')).rejects.toThrow(
+        'Recipient 0xfoo is not on the XMTP network'
+      )
     })
 
     it('filters out spoofed messages', async () => {
@@ -324,9 +324,9 @@ describe('conversation', () => {
         ...ContentTypeTestKey,
         versionMajor: 2,
       })
-      await expect(
-        aliceConvo.send(key, { contentType: type2 })
-      ).rejects.toThrow('unknown content type xmtp.test/public-key:2.0')
+      expect(aliceConvo.send(key, { contentType: type2 })).rejects.toThrow(
+        'unknown content type xmtp.test/public-key:2.0'
+      )
 
       await bobStream.return()
       await aliceStream.return()
@@ -472,7 +472,7 @@ describe('conversation', () => {
       const key = PrivateKey.generate().publicKey
 
       // alice doesn't recognize the type
-      await expect(
+      expect(
         aliceConvo.send(key, {
           contentType: ContentTypeTestKey,
         })
@@ -515,9 +515,9 @@ describe('conversation', () => {
         ...ContentTypeTestKey,
         versionMajor: 2,
       })
-      await expect(
-        aliceConvo.send(key, { contentType: type2 })
-      ).rejects.toThrow('unknown content type xmtp.test/public-key:2.0')
+      expect(aliceConvo.send(key, { contentType: type2 })).rejects.toThrow(
+        'unknown content type xmtp.test/public-key:2.0'
+      )
 
       await bobStream.return()
       await aliceStream.return()

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -45,23 +45,6 @@ describe('PrivateTopicStore', () => {
         expect(full).toBeDefined()
         expect(full).toEqual(Buffer.from(value))
       })
-
-      it('distinct topics', async () => {
-        const valueA = Buffer.from(new TextEncoder().encode('helloA'))
-        const valueB = Buffer.from(new TextEncoder().encode('helloB'))
-        const keyA = wallet.address + 'A'
-        const keyB = wallet.address + 'B'
-
-        store.set(keyA, valueA)
-        store.set(keyB, valueB)
-        await sleep(100)
-        const responseA = await store.get(keyA)
-        const responseB = await store.get(keyB)
-
-        expect(responseA).toEqual(valueA)
-        expect(responseB).toEqual(valueB)
-        expect(responseA).not.toEqual(responseB)
-      })
     })
   })
 })


### PR DESCRIPTION
* added E2E ApiTests to confirm that GRPC errors are propagated as expected.
* fixing up synchronous toThrow cases
* fixing up async rejects cases to use uniform style
* dropped NetworkStore>distinct topics test case, it is not workable with the restricted topics checks in place

Fixes #226 