### PR TITLE
fix: update for proto@v3.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.4.0",
+        "@xmtp/proto": "^3.9.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0"
       },
@@ -3278,9 +3278,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.4.0.tgz",
-      "integrity": "sha512-DIXgEVTDV9nctUhxLqMzdInmIqShKaTNa0wv61qFvaH8SRN5o3gq9uIuQLFGwxWZLK75GAFa+0orsX1T4eAXiw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.9.0.tgz",
+      "integrity": "sha512-FhS2+PPoS3zR8KLCXcttonE8dsiigqIfHzxTD47nndoYk1crhK0IcygVQJN/9aL5K5/KXx/A2USzy/74cMfW9g==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16187,9 +16187,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.4.0.tgz",
-      "integrity": "sha512-DIXgEVTDV9nctUhxLqMzdInmIqShKaTNa0wv61qFvaH8SRN5o3gq9uIuQLFGwxWZLK75GAFa+0orsX1T4eAXiw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.9.0.tgz",
+      "integrity": "sha512-FhS2+PPoS3zR8KLCXcttonE8dsiigqIfHzxTD47nndoYk1crhK0IcygVQJN/9aL5K5/KXx/A2USzy/74cMfW9g==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.4.0",
+    "@xmtp/proto": "^3.9.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0"
   },

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -21,12 +21,12 @@ import { Conversations } from './conversations'
 import { ContentTypeText, TextCodec } from './codecs/Text'
 import { ContentTypeId, ContentCodec } from './MessageContent'
 import { compress } from './Compression'
-import { xmtpEnvelope, messageApi, fetcher } from '@xmtp/proto'
+import { content as proto, messageApi, fetcher } from '@xmtp/proto'
 import { decodeContactBundle, encodeContactBundle } from './ContactBundle'
 import ApiClient, { ApiUrls, PublishParams, SortDirection } from './ApiClient'
 import { Authenticator } from './authn'
 import { SealedInvitation } from './Invitation'
-const { Compression } = xmtpEnvelope
+const { Compression } = proto
 const { b64Decode } = fetcher
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types
@@ -61,7 +61,7 @@ export { Compression }
 export type SendOptions = {
   contentType?: ContentTypeId
   contentFallback?: string
-  compression?: xmtpEnvelope.Compression
+  compression?: proto.Compression
   timestamp?: Date
 }
 
@@ -355,7 +355,7 @@ export default class Client {
       encoded.compression = options.compression
     }
     await compress(encoded)
-    return xmtpEnvelope.EncodedContent.encode(encoded).finish()
+    return proto.EncodedContent.encode(encoded).finish()
   }
 
   listInvitations(opts?: ListMessagesOptions): Promise<SealedInvitation[]> {

--- a/src/Compression.ts
+++ b/src/Compression.ts
@@ -1,5 +1,5 @@
 // This import has to come first so that the polyfills are registered before the stream polyfills
-import { xmtpEnvelope as proto } from '@xmtp/proto'
+import { content as proto } from '@xmtp/proto'
 import './polyfills/stream'
 
 //

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -1,6 +1,6 @@
 import type { Conversation } from './conversations/Conversation'
 import type Client from './Client'
-import { xmtpEnvelope as proto, xmtpEnvelope } from '@xmtp/proto'
+import { message as proto, content as protoContent } from '@xmtp/proto'
 import Long from 'long'
 import Ciphertext from './crypto/Ciphertext'
 import {
@@ -203,14 +203,14 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
 export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
   private header: proto.MessageHeaderV2 // eslint-disable-line camelcase
-  private signed?: proto.SignedContent
+  private signed?: protoContent.SignedContent
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    signed: proto.SignedContent,
+    signed: protoContent.SignedContent,
     // wallet address derived from the signature of the message sender
     senderAddress: string
   ) {
@@ -223,7 +223,7 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
   static async create(
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    signed: proto.SignedContent,
+    signed: protoContent.SignedContent,
     bytes: Uint8Array
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
@@ -334,7 +334,7 @@ export class DecodedMessage {
 }
 
 export function decodeContent(contentBytes: Uint8Array, client: Client) {
-  const encodedContent = xmtpEnvelope.EncodedContent.decode(contentBytes)
+  const encodedContent = protoContent.EncodedContent.decode(contentBytes)
 
   if (!encodedContent.type) {
     throw new Error('missing content type')

--- a/src/MessageContent.ts
+++ b/src/MessageContent.ts
@@ -1,4 +1,4 @@
-import { xmtpEnvelope as proto } from '@xmtp/proto'
+import { content as proto } from '@xmtp/proto'
 
 // Represents proto.ContentTypeId
 export class ContentTypeId {

--- a/test/Compression.test.ts
+++ b/test/Compression.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { xmtpEnvelope as proto } from '@xmtp/proto'
+import { content as proto } from '@xmtp/proto'
 import {
   compress,
   decompress,


### PR DESCRIPTION
Follow up for https://github.com/xmtp/proto/pull/24.

Any `xmtpEnvelope` imports from `@xtmp/proto` now need to be changed to be either `message` or `content` accordingly.
