### PR TITLE
Jazzz/memo integration

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -421,7 +421,7 @@ export default class Client {
   }
 
   async signBytes(bytes: Uint8Array): Promise<Signature> {
-    return await this.keys.identityKey.sign(bytes)
+    return this.keys.identityKey.sign(bytes)
   }
 }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -3,6 +3,7 @@ import {
   SignedPublicKeyBundle,
   PrivateKeyBundleV1,
   PrivateKeyBundleV2,
+  Signature,
 } from './crypto'
 import {
   buildUserContactTopic,
@@ -417,6 +418,10 @@ export default class Client {
       ),
       mapper
     )
+  }
+
+  async signBytes(bytes: Uint8Array): Promise<Signature> {
+    return await this.keys.identityKey.sign(bytes)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Message, DecodedMessage } from './Message'
+export { Message, DecodedMessage, decodeContent } from './Message'
 export {
   PublicKey,
   PublicKeyBundle,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export {
   CompositeCodec,
   ContentTypeComposite,
 } from './codecs/Composite'
-export { SortDirection } from './ApiClient'
+export { ApiUrls, SortDirection } from './ApiClient'
 export {
   nsToDate,
   dateToNs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,11 @@ export { Message, DecodedMessage } from './Message'
 export {
   PublicKey,
   PublicKeyBundle,
+  SignedPublicKey,
   SignedPublicKeyBundle,
   PrivateKey,
   PrivateKeyBundle,
+  Signature,
 } from './crypto'
 export { default as Stream } from './Stream'
 export {
@@ -28,4 +30,10 @@ export {
   ContentTypeComposite,
 } from './codecs/Composite'
 export { SortDirection } from './ApiClient'
-export { nsToDate, dateToNs, fromNanoString, toNanoString } from './utils'
+export {
+  nsToDate,
+  dateToNs,
+  fromNanoString,
+  toNanoString,
+  mapPaginatedStream,
+} from './utils'


### PR DESCRIPTION
This PR contains the changes required for PreReg messaging. 

- Enables an external signing interface. This allows external applications to be able to sign messages using the IdentityKeys without having to export and manually manage them.
- Exports additional types and functions.
