### PR TITLE
Add v2 conversation cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^3.9.0",
+        "async-mutex": "^0.4.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0"
       },
@@ -3575,6 +3576,19 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/async-mutex/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -16419,6 +16433,21 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        }
+      }
     },
     "asynckit": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^3.9.0",
+    "async-mutex": "^0.4.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0"
   },

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -22,7 +22,7 @@ type CacheLoader = (args: {
   latestSeen: Date | undefined
 }) => Promise<Conversation[]>
 
-class ConversationCache {
+export class ConversationCache {
   private conversations: Conversation[]
   private mutex: Mutex
   private latestSeen?: Date
@@ -108,6 +108,7 @@ export default class Conversations {
           console.warn('Error decrypting invitation', e)
         }
       }
+
       return newConvos
     })
   }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -56,11 +56,11 @@ class ConversationsCache {
  */
 export default class Conversations {
   private client: Client
-  private inviteCache: ConversationsCache
+  private v2Cache: ConversationsCache
 
   constructor(client: Client) {
     this.client = client
-    this.inviteCache = new ConversationsCache()
+    this.v2Cache = new ConversationsCache()
   }
 
   /**
@@ -86,8 +86,7 @@ export default class Conversations {
   }
 
   private async listV2Conversations(): Promise<Conversation[]> {
-    const { latestSeen, release, addConvos } =
-      await this.inviteCache.getAndLock()
+    const { latestSeen, release, addConvos } = await this.v2Cache.getAndLock()
     try {
       const newConvos: Conversation[] = []
       const invites = await this.client.listInvitations({

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -47,6 +47,7 @@ class ConversationCache {
           }
         }
       }
+      // No catch block so that errors still bubble
     } finally {
       release()
     }

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -97,6 +97,25 @@ describe('conversations', () => {
         })
       ).rejects.toThrow('test')
     })
+
+    it('waits for one request to finish before the second one starts', async () => {
+      const cache = new ConversationCache()
+      const convoDate = new Date()
+      const firstConvo = new ConversationV1(alice, bob.address, convoDate)
+      const promise1 = cache.load(async ({ latestSeen }) => {
+        expect(latestSeen).toBeUndefined()
+        return [firstConvo]
+      })
+
+      const promise2 = cache.load(async ({ latestSeen }) => {
+        expect(latestSeen).toBe(convoDate)
+        return []
+      })
+
+      const [result1, result2] = await Promise.all([promise1, promise2])
+      expect(result1).toHaveLength(1)
+      expect(result2).toHaveLength(1)
+    })
   })
 
   it('streams conversations', async () => {

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -56,6 +56,7 @@ describe('conversations', () => {
         conversationId: 'foo',
         metadata: {},
       })
+      await sleep(100)
       const aliceConversations2 = await alice.conversations.list()
       expect(aliceConversations2).toHaveLength(1)
 
@@ -63,6 +64,7 @@ describe('conversations', () => {
         conversationId: 'bar',
         metadata: {},
       })
+      await sleep(100)
       const aliceConversations3 = await alice.conversations.list()
       expect(aliceConversations3).toHaveLength(2)
     })

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -30,21 +30,42 @@ describe('conversations', () => {
     if (charlie) await charlie.close()
   })
 
-  it('lists all conversations', async () => {
-    const aliceConversations = await alice.conversations.list()
-    expect(aliceConversations).toHaveLength(0)
+  describe('listConversations', () => {
+    it('lists all conversations', async () => {
+      const aliceConversations = await alice.conversations.list()
+      expect(aliceConversations).toHaveLength(0)
 
-    const aliceToBob = await alice.conversations.newConversation(bob.address)
-    await aliceToBob.send('gm')
-    await sleep(100)
+      const aliceToBob = await alice.conversations.newConversation(bob.address)
+      await aliceToBob.send('gm')
+      await sleep(100)
 
-    const aliceConversationsAfterMessage = await alice.conversations.list()
-    expect(aliceConversationsAfterMessage).toHaveLength(1)
-    expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
+      const aliceConversationsAfterMessage = await alice.conversations.list()
+      expect(aliceConversationsAfterMessage).toHaveLength(1)
+      expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
 
-    const bobConversations = await bob.conversations.list()
-    expect(bobConversations).toHaveLength(1)
-    expect(bobConversations[0].peerAddress).toBe(alice.address)
+      const bobConversations = await bob.conversations.list()
+      expect(bobConversations).toHaveLength(1)
+      expect(bobConversations[0].peerAddress).toBe(alice.address)
+    })
+
+    it('resumes list with cache after new conversation is created', async () => {
+      const aliceConversations1 = await alice.conversations.list()
+      expect(aliceConversations1).toHaveLength(0)
+
+      await alice.conversations.newConversation(bob.address, {
+        conversationId: 'foo',
+        metadata: {},
+      })
+      const aliceConversations2 = await alice.conversations.list()
+      expect(aliceConversations2).toHaveLength(1)
+
+      await alice.conversations.newConversation(bob.address, {
+        conversationId: 'bar',
+        metadata: {},
+      })
+      const aliceConversations3 = await alice.conversations.list()
+      expect(aliceConversations3).toHaveLength(2)
+    })
   })
 
   it('streams conversations', async () => {


### PR DESCRIPTION
## Summary

We are seeing performance degradations for users attempting to load a large number of conversations. Decrypting an invitation takes approximately 15ms on a M1 mac, so decrypting 100 can easily take multiple seconds depending on the device.

This is particularly noticeable when there are multiple code paths calling `conversations.list()`. A common case is the use of `conversations.streamAllMessages()`, which has a call to `conversations.list()` in its startup but does not remove the need to list all conversations. Applications that were offline for a period of time may also wish to call `conversations.list()` to get their internal store of conversations current with the network.

I implemented this using a cache and a mutex. The mutex is required to ensure that a second request to list conversations is not fired before the first completes. The cache keeps track of the most recently seen conversation so that subsequent calls can use that date as a `startTime` and only fetch/decrypt invites since the last query.

## Further improvements

- Applications with access to persistent storage could take an export of the cache and load it on startup. To do this, Conversations would need to be serializable. 