### PR TITLE
feat: export KeyStoreType for client configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { default as Stream } from './Stream'
 export {
   default as Client,
   ClientOptions,
+  KeyStoreType,
   ListMessagesOptions,
   SendOptions,
   Compression,


### PR DESCRIPTION
This PR exports the KeyStoreType enum, so it is available to client applications which are using the static key store option in ClientOptions. 