### PR TITLE
WIP: POC that adds ability to cache wallet sig/private key in local storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,5 @@ export {
   toNanoString,
   mapPaginatedStream,
 } from './utils'
+
+export type { LocalKeyStorage } from './store/EncryptedStore'


### PR DESCRIPTION
**Note: This is not ready for merge, opening this for discussion purposes.**

This PR does two things:
1. Defines an interface for users of this library to implement to store/cache the wallet signature requested during `Client.create`
2. Short-circuits the wallet signature request process if that interface returns a value, preventing repeated wallet signature requests

🚨 Currently, this PR doesn't do anything to securely store that private key in local storage!! The user can do whatever they want with it. 🚨

A more production-ready approach would probably be to use something like Metamask's [keyring controller library](https://github.com/MetaMask/KeyringController).