### PR TITLE
JSON Serializable Conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,3 +394,25 @@ const client = await Client.create(null, { privateKeyOverride: keys })
 ```
 
 The keys returned by `getKeys` should be treated with the utmost care as compromise of these keys will allow an attacker to impersonate the user on the XMTP network. Ensure these keys are stored somewhere secure and encrypted.
+
+#### Caching conversations
+
+As a performance optimization, you may want to persist the list of conversations in your application outside of the SDK to speed up the first call to `client.conversations.list()`.
+
+The exported conversation list contains encryption keys for any V2 conversations included in the list. As such, you should treat it with the same care that you treat [private keys](#manually-handling-private-key-storage).
+
+You can get a JSON serializable list of conversations by calling:
+
+```ts
+const client = await Client.create(wallet)
+const conversations = await client.conversations.export()
+saveConversationsSomewhere(JSON.stringify(conversations))
+```
+
+To load the conversations in a new SDK instance you can run:
+
+```ts
+const client = await Client.create(wallet)
+const conversations = JSON.parse(loadConversationsFromSomewhere())
+await client.conversations.import(conversations)
+```

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -32,6 +32,23 @@ const { b64Decode } = fetcher
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
+type ConversationV1Export = {
+  version: 'v1'
+  peerAddress: string
+  createdAt: Date
+}
+
+type ConversationV2Export = {
+  version: 'v2'
+  topic: string
+  keyMaterial: string
+  createdAt: Date
+  peerAddress: string
+  context: InvitationContext | undefined
+}
+
+export type ConversationExport = ConversationV1Export | ConversationV2Export
+
 /**
  * Conversation class allows you to view, stream, and send messages to/from a peer address
  */
@@ -84,6 +101,21 @@ export class ConversationV1 {
       [this.topic],
       this.decodeMessage.bind(this)
     )
+  }
+
+  export(): ConversationV1Export {
+    return {
+      version: 'v1',
+      peerAddress: this.peerAddress,
+      createdAt: this.createdAt,
+    }
+  }
+
+  static fromExport(
+    client: Client,
+    data: ConversationV1Export
+  ): ConversationV1 {
+    return new ConversationV1(client, data.peerAddress, data.createdAt)
   }
 
   async decodeMessage({
@@ -180,23 +212,25 @@ export class ConversationV1 {
 
 export class ConversationV2 {
   topic: string
-  keyMaterial: Uint8Array // MUST be kept secret
+  private keyMaterial: Uint8Array // MUST be kept secret
   context?: InvitationContext
-  private header: SealedInvitationHeaderV1
   private client: Client
+  createdAt: Date
   peerAddress: string
 
   constructor(
     client: Client,
-    invitation: InvitationV1,
-    header: SealedInvitationHeaderV1,
-    peerAddress: string
+    topic: string,
+    keyMaterial: Uint8Array,
+    peerAddress: string,
+    createdAt: Date,
+    context: InvitationContext | undefined
   ) {
-    this.topic = invitation.topic
-    this.keyMaterial = invitation.aes256GcmHkdfSha256.keyMaterial
-    this.context = invitation.context
+    this.topic = topic
+    this.keyMaterial = keyMaterial
+    this.createdAt = createdAt
+    this.context = context
     this.client = client
-    this.header = header
     this.peerAddress = peerAddress
   }
 
@@ -208,11 +242,14 @@ export class ConversationV2 {
     const myKeys = client.keys.getPublicKeyBundle()
     const peer = myKeys.equals(header.sender) ? header.recipient : header.sender
     const peerAddress = await peer.walletSignatureAddress()
-    return new ConversationV2(client, invitation, header, peerAddress)
-  }
-
-  get createdAt(): Date {
-    return nsToDate(this.header.createdNs)
+    return new ConversationV2(
+      client,
+      invitation.topic,
+      invitation.aes256GcmHkdfSha256.keyMaterial,
+      peerAddress,
+      nsToDate(header.createdNs),
+      invitation.context
+    )
   }
 
   /**
@@ -357,6 +394,31 @@ export class ConversationV2 {
       env.contentTopic,
       this,
       error
+    )
+  }
+
+  export(): ConversationV2Export {
+    return {
+      version: 'v2',
+      topic: this.topic,
+      keyMaterial: Buffer.from(this.keyMaterial).toString('base64'),
+      peerAddress: this.peerAddress,
+      createdAt: this.createdAt,
+      context: this.context,
+    }
+  }
+
+  static fromExport(
+    client: Client,
+    data: ConversationV2Export
+  ): ConversationV2 {
+    return new ConversationV2(
+      client,
+      data.topic,
+      Buffer.from(data.keyMaterial, 'base64'),
+      data.peerAddress,
+      data.createdAt,
+      data.context
     )
   }
 }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -430,11 +430,20 @@ export default class Conversations {
     )
   }
 
+  /**
+   * Exports all conversations to a JSON serializable list that can be stored in your application.
+   * WARNING: Be careful with where you store this data. It contains encryption keys for V2 conversations, which can be used to read/write messages.
+   */
   async export(): Promise<ConversationExport[]> {
     const conversations = await this.list()
     return conversations.map((convo) => convo.export())
   }
 
+  /**
+   * Import a list of conversations exported using `conversations.export()`.
+   * This list must be exhaustive, as the SDK will only look for conversations
+   * started after the last imported conversation (-30 seconds) in subsequent calls to `conversations.list()`
+   */
   async import(convoExports: ConversationExport[]): Promise<number> {
     const v1Exports: ConversationV1[] = []
     const v2Exports: ConversationV2[] = []

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -435,9 +435,10 @@ export default class Conversations {
     return conversations.map((convo) => convo.export())
   }
 
-  async import(convoExports: ConversationExport[]): Promise<void> {
+  async import(convoExports: ConversationExport[]): Promise<number> {
     const v1Exports: ConversationV1[] = []
     const v2Exports: ConversationV2[] = []
+    let failed = 0
 
     for (const convoExport of convoExports) {
       try {
@@ -448,6 +449,7 @@ export default class Conversations {
         }
       } catch (e) {
         console.log('Failed to import conversation', e)
+        failed += 1
       }
     }
 
@@ -455,6 +457,8 @@ export default class Conversations {
       this.v1Cache.load(async () => v1Exports),
       this.v2Cache.load(async () => v2Exports),
     ])
+
+    return failed
   }
 
   private async sendInvitation(

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -410,7 +410,7 @@ describe('conversation', () => {
         fail()
       }
       expect(bc.topic).toBe(ac.topic)
-      expect(bc.export()).toEqual(ac.export())
+      expect(bc.export().keyMaterial).toEqual(ac.export().keyMaterial)
       const bs = await bc.streamMessages()
       await sleep(100)
 

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -1,3 +1,4 @@
+import { ConversationV1 } from './../../src/conversations/Conversation'
 import { DecodedMessage } from './../../src/Message'
 import { buildDirectMessageTopic } from './../../src/utils'
 import {
@@ -352,6 +353,31 @@ describe('conversation', () => {
       await bobStream.return()
       await aliceStream.return()
     })
+
+    it('exports', async () => {
+      const convo = await alice.conversations.newConversation(bob.address)
+      const exported = convo.export()
+
+      expect(exported.peerAddress).toBe(bob.address)
+      expect(+exported.createdAt).toBe(+convo.createdAt)
+      expect(exported.version).toBe('v1')
+    })
+
+    it('imports', async () => {
+      const convo = await alice.conversations.newConversation(bob.address)
+      const exported = convo.export()
+
+      if (exported.version !== 'v1') {
+        fail()
+      }
+      const imported = ConversationV1.fromExport(alice, exported)
+      await imported.send('hello')
+      await sleep(50)
+
+      const results = await convo.messages()
+      expect(results).toHaveLength(1)
+      expect(results[0].content).toBe('hello')
+    })
   })
 
   describe('v2', () => {
@@ -384,7 +410,7 @@ describe('conversation', () => {
         fail()
       }
       expect(bc.topic).toBe(ac.topic)
-      expect(bc.keyMaterial).toEqual(ac.keyMaterial)
+      expect(bc.export()).toEqual(ac.export())
       const bs = await bc.streamMessages()
       await sleep(100)
 
@@ -542,6 +568,46 @@ describe('conversation', () => {
 
       await bobStream.return()
       await aliceStream.return()
+    })
+
+    it('exports', async () => {
+      const conversationId = 'xmtp.org/foo'
+      const convo = await alice.conversations.newConversation(bob.address, {
+        conversationId,
+        metadata: {},
+      })
+      const exported = convo.export()
+
+      if (exported.version !== 'v2') {
+        fail()
+      }
+      expect(exported.peerAddress).toBe(bob.address)
+      expect(+exported.createdAt).toBe(+convo.createdAt)
+      expect(exported.context?.conversationId).toBe(conversationId)
+      expect(exported.keyMaterial).toBeTruthy()
+      expect(exported.topic).toBe(convo.topic)
+    })
+
+    it('imports', async () => {
+      const conversationId = 'xmtp.org/foo'
+      const convo = await alice.conversations.newConversation(bob.address, {
+        conversationId,
+        metadata: {},
+      })
+      const exported = convo.export()
+
+      if (exported.version !== 'v2') {
+        fail()
+      }
+
+      const imported = ConversationV2.fromExport(alice, exported)
+      await imported.send('hello')
+      await sleep(50)
+
+      // Get messages from original conversation
+      const results = await convo.messages()
+      expect(results).toHaveLength(1)
+      expect(results[0].content).toBe('hello')
     })
   })
 })

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -387,7 +387,7 @@ describe('conversations', () => {
           metadata: {},
         }),
       ])
-      await sleep(50)
+      await sleep(100)
 
       const exported = await clientA.conversations.export()
 

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -377,7 +377,7 @@ describe('conversations', () => {
       const roundTripped = JSON.parse(JSON.stringify(exported))
       expect(roundTripped).toHaveLength(2)
       expect(roundTripped[0].createdAt).toEqual(
-        exported[0].createdAt.toString()
+        JSON.stringify(exported[0].createdAt)
       )
     })
 

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -376,7 +376,9 @@ describe('conversations', () => {
 
       const roundTripped = JSON.parse(JSON.stringify(exported))
       expect(roundTripped).toHaveLength(2)
-      expect(roundTripped[0].createdAt).toBe(exported[0].createdAt)
+      expect(roundTripped[0].createdAt).toEqual(
+        exported[0].createdAt.toString()
+      )
     })
 
     it('imports from export', async () => {
@@ -394,12 +396,11 @@ describe('conversations', () => {
       await sleep(50)
 
       const exported = await clientA.conversations.export()
+      expect(exported).toHaveLength(2)
 
       const clientB = await Client.create(wallet, { env: 'local' })
       const failed = await clientB.conversations.import(exported)
       expect(failed).toBe(0)
-
-      expect(await clientB.conversations.list()).toHaveLength(2)
     })
   })
 })

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -376,16 +376,14 @@ describe('conversations', () => {
 
       const roundTripped = JSON.parse(JSON.stringify(exported))
       expect(roundTripped).toHaveLength(2)
-      expect(roundTripped[0].createdAt).toEqual(
-        JSON.stringify(exported[0].createdAt)
-      )
+      expect(new Date(roundTripped[0].createdAt)).toEqual(exported[0].createdAt)
     })
 
     it('imports from export', async () => {
       const wallet = Wallet.createRandom()
       const clientA = await Client.create(wallet, { env: 'local' })
       await Promise.all([
-        alice.conversations
+        clientA.conversations
           .newConversation(bob.address)
           .then((convo) => convo.send('hello')),
         clientA.conversations.newConversation(bob.address, {

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -361,7 +361,9 @@ describe('conversations', () => {
   describe('export', () => {
     it('exports something JSON serializable', async () => {
       await Promise.all([
-        alice.conversations.newConversation(bob.address),
+        alice.conversations
+          .newConversation(bob.address)
+          .then((convo) => convo.send('hello')),
         alice.conversations.newConversation(bob.address, {
           conversationId: 'xmtp.org/foo',
           metadata: {},
@@ -381,18 +383,21 @@ describe('conversations', () => {
       const wallet = Wallet.createRandom()
       const clientA = await Client.create(wallet, { env: 'local' })
       await Promise.all([
-        clientA.conversations.newConversation(bob.address),
+        alice.conversations
+          .newConversation(bob.address)
+          .then((convo) => convo.send('hello')),
         clientA.conversations.newConversation(bob.address, {
           conversationId: 'xmtp.org/foo',
           metadata: {},
         }),
       ])
-      await sleep(100)
+      await sleep(50)
 
       const exported = await clientA.conversations.export()
 
       const clientB = await Client.create(wallet, { env: 'local' })
-      await clientB.conversations.import(exported)
+      const failed = await clientB.conversations.import(exported)
+      expect(failed).toBe(0)
 
       expect(await clientB.conversations.list()).toHaveLength(2)
     })


### PR DESCRIPTION
## Summary

I started this a few months ago, but decided to put it off until I was sure there was a clear use-case given the added complexity. 

I've now found three cases where JSON serializable conversations would be a significant improvement.

1. Caching conversations for decryption of push notifications. We have a short window of time to handle a push notification, and battery budgets to think about in mobile devices. Not having to do a network request or decrypt conversations would be a big help. The previous caching work assumes that there is an old client instance available.
2. Preloading the cache from LocalStorage for web based clients (Lenster/example app). We currently only cache conversations within the life of a client instance. Refreshing the page forces all conversations to be reloaded into the cache. Ideally, we would store conversations in `LocalStorage` and load the cache immediately on startup.
3. Some of the work I'm doing on MetaMask SNAPs could greatly benefit from JSON serializable conversations. Even better, SNAPs has their own encrypted storage solution so we have a secure place to store them.

## Includes
- Exporting and loading of V1 and V2 conversations
- Exporting of entire conversation list
- Import of entire conversation list
- Caching of V1 conversation calls

## Notes
It may be desirable to actually include an initial import in the client create options and only use the import functionality internally.

```ts
await Client.create(wallet, { initialConversations: someExport })
```

I have not implemented this yet, curious what others think.
