### PR TITLE
fix: unsubscribe in ApiClient tests to avoid leaking subscription loops

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -196,6 +196,7 @@ export default class ApiClient {
           if (new Date().getTime() - startTime < 1000) {
             await sleep(1000)
           }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           if (isAbortError(err) || abortController.signal.aborted) {
             return

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -242,7 +242,7 @@ describe('Subscribe', () => {
       numEnvelopes++
     }
     const req = { contentTopics: [CONTENT_TOPIC] }
-    client.subscribe(req, cb)
+    const unsubscribeFn = client.subscribe(req, cb)
     await sleep(10)
     expect(numEnvelopes).toBe(2)
     expect(subscribeMock).toBeCalledWith(req, cb, {
@@ -253,6 +253,7 @@ describe('Subscribe', () => {
         'X-Client-Version': 'xmtp-js/' + version,
       }),
     })
+    await unsubscribeFn()
   })
 
   it('should resubscribe on error', async () => {
@@ -280,7 +281,7 @@ describe('Subscribe', () => {
       numEnvelopes++
     }
     const req = { contentTopics: [CONTENT_TOPIC] }
-    client.subscribe(req, cb)
+    const unsubscribeFn = client.subscribe(req, cb)
     await sleep(1200)
     expect(numEnvelopes).toBe(2)
     expect(subscribeMock).toBeCalledWith(req, cb, {
@@ -291,6 +292,7 @@ describe('Subscribe', () => {
         'X-Client-Version': 'xmtp-js/' + version,
       }),
     })
+    await unsubscribeFn()
   })
 
   it('should resubscribe on completion', async () => {
@@ -318,7 +320,7 @@ describe('Subscribe', () => {
       numEnvelopes++
     }
     const req = { contentTopics: [CONTENT_TOPIC] }
-    client.subscribe(req, cb)
+    const unsubscribeFn = client.subscribe(req, cb)
     await sleep(1200)
     expect(numEnvelopes).toBe(2)
     expect(subscribeMock).toBeCalledWith(req, cb, {
@@ -329,6 +331,7 @@ describe('Subscribe', () => {
         'X-Client-Version': 'xmtp-js/' + version,
       }),
     })
+    await unsubscribeFn()
   })
 
   it('throws when no content topics returned', async () => {

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -130,6 +130,7 @@ describe('conversations', () => {
       break
     }
     expect(numConversations).toBe(1)
+    await stream.return()
   })
 
   it('streams all conversation messages from empty state', async () => {


### PR DESCRIPTION
# Summary

Running unit tests would result in repeated warnings of the form (below). I believe this is caused by not unsubscribing during tests in ApiClient.test.ts

## Changes
- Explicitly invoke unsubscribe function (returned by `subscribe`) in ApiClient unit tests
- Add what appears to be a missing `await stream.return()` in a conversation unit test
- Add eslint suppression for an `any` typed catch error

Warnings seen before:
```  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Stream connection closed. Resubscribing TypeError: fetchImpl.apply is not a function".

      201 |             return
      202 |           }
    > 203 |           console.info(
          |                   ^
      204 |             'Stream connection closed. Resubscribing',
      205 |             err.toString()
      206 |           )

      at console.info (node_modules/@jest/console/build/BufferedConsole.js:195:10)
      at ApiClient.<anonymous> (src/ApiClient.ts:203:19)
          at Generator.throw (<anonymous>)
      at rejected (src/ApiClient.ts:6:65)
```

## Test Plan

Observe no more warnings of the above form during testing

note: there are still open handle warnings that I may investigate further. After running with `--detectOpenHandles` looks like the complains lead back to `query` in ApiClient
