### PR TITLE
Make newConversation cache-aware

### DIFF
--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -450,6 +450,8 @@ export default class Conversations {
       }
     )
 
+    // Keep the typechecker happy
+    // v2Convo should never actually be undefined. An error in the loader will bubble and halt execution
     if (!v2Convo) {
       throw new Error('Failed to create conversation')
     }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -413,7 +413,8 @@ export default class Conversations {
       isMatchingContext(context, convo.context ?? undefined)
 
     let v2Convo: Conversation | undefined
-    // Perform all future operations while holding the mutex
+
+    // Perform all read/write operations on the cache while holding the mutex
     await this.v2Cache.load(
       async ({ latestSeen, existing }): Promise<Conversation[]> => {
         // First check the cache without doing a network request

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -357,6 +357,23 @@ describe('conversations', () => {
       const bobInvites = await bob.listInvitations()
       expect(bobInvites).toHaveLength(2)
     })
+
+    it('handles races', async () => {
+      const ctx = {
+        conversationId: 'xmtp.org/foo',
+        metadata: {},
+      }
+      // Create three conversations in parallel
+      await Promise.all([
+        alice.conversations.newConversation(bob.address, ctx),
+        alice.conversations.newConversation(bob.address, ctx),
+        alice.conversations.newConversation(bob.address, ctx),
+      ])
+      await sleep(50)
+
+      const invites = await alice.listInvitations()
+      expect(invites).toHaveLength(1)
+    })
   })
 
   describe('export', () => {


### PR DESCRIPTION
## Summary

The `newConversation` method was not making use of the conversation caches. I've updated to use the existing `listV1Conversations()` and `listV2Conversations()` methods, in lieu of the lower level methods it was previously using.

The previous implementation skipped decrypting invitations for Conversations that did not match the intended recipient as a performance optimization. This method will load all new invitations, although it will use the cache to avoid decrypting any that have been seen before. This does make the worst-case performance worse (someone loads the SDK solely to create a new conversation), although the best-case performance should be better (creating a new conversation before or after running `conversations.list()`).

Both the old and new implementation will load/decrypt all V1 conversations on a cold start, although this implementation will only load/decrypt new introductions on all subsequent calls.

## Notes
In order to make the update transactional, I had to do a bit of a refactor to allow for `newConversation` to read from the cache, update it with items written since the last cache load, and potentially update with a newly created conversation before releasing the mutex.

I did that by breaking out the callback from `listV2Conversations` into a separate function that could be called from inside the cache loader, allowing for all logic to be executed before the mutex was released. This avoids race conditions where a second asynchronous process might create a conversation after the first releases the mutex.

Also worth noting that this will not prevent cases where a multiple client instances create a conversation with the same peer/conversationId at the same time.

## Resolves
Will resolve https://github.com/xmtp/example-chat-react/issues/168 (although we should also figure out why that hook is firing multiple times)