### PR TITLE
docs: Add rate limit info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ for await (const message of await conversation.streamMessages()) {
 }
 ```
 
+Currently, network nodes are configured to rate limit high-volume publishing from Clients. A rate-limited Client can expect to receive a 429 status code response from a node. Rate limits can change at any time in the interest of maintaining network health.
+
 ### Creating a Client
 
 A Client is created with `Client.create(wallet: ethers.Signer): Promise<Client>` that requires passing in a connected Wallet. The Client will request a wallet signature in 2 cases:


### PR DESCRIPTION
- Add rate limit info to the README. 
- This text has already been approved and published to the documentation. Adding to the README to bring it in line with the documentation.
