### PR TITLE
test: clean unit test console warnings

### DIFF
--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -104,6 +104,9 @@ describe('conversation', () => {
     })
 
     it('ignores failed decoding of messages', async () => {
+      const consoleWarn = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
       const aliceConversation = await alice.conversations.newConversation(
         bob.address
       )
@@ -124,6 +127,8 @@ describe('conversation', () => {
         numMessages += page.length
       }
       expect(numMessages).toBe(1)
+      expect(consoleWarn).toBeCalledTimes(1)
+      consoleWarn.mockRestore()
     })
 
     it('works for messaging yourself', async () => {
@@ -275,6 +280,9 @@ describe('conversation', () => {
     })
 
     it('filters out spoofed messages', async () => {
+      const consoleWarn = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
       const aliceConvo = await alice.conversations.newConversation(bob.address)
       const bobConvo = await bob.conversations.newConversation(alice.address)
       const stream = await bobConvo.streamMessages()
@@ -293,6 +301,8 @@ describe('conversation', () => {
       expect(msg.senderAddress).toBe(alice.address)
       expect(msg.content).toBe('Hello from Alice')
       await stream.return()
+      expect(consoleWarn).toBeCalledTimes(1)
+      consoleWarn.mockRestore()
     })
 
     it('can send custom content type', async () => {


### PR DESCRIPTION
The unit tests are spitting out console warnings that look like errors:

![Screen Shot 2022-12-22 at 10 44 36 AM](https://user-images.githubusercontent.com/696206/209403095-2f91e3b9-2df0-405b-afcf-112429a2ede4.png)

I'm a bit worried that this noise can cause us to overlook true errors, as well as this generally being confusing for newbies. As these logs are expected given the unit tests are validating failure cases, I added a change to have the unit tests explicitly verify that these logs are being emitted, but swallow them so that we don't have to see them.

There is still some console output left over after this fix - an import error, and some connection info logs, these can be addressed separately.
