### PR TITLE
Serialization bug with exports

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -36,14 +36,14 @@ const { b64Decode } = fetcher
 type ConversationV1Export = {
   version: 'v1'
   peerAddress: string
-  createdAt: Date
+  createdAt: string
 }
 
 type ConversationV2Export = {
   version: 'v2'
   topic: string
   keyMaterial: string
-  createdAt: Date
+  createdAt: string
   peerAddress: string
   context: InvitationContext | undefined
 }
@@ -108,7 +108,7 @@ export class ConversationV1 {
     return {
       version: 'v1',
       peerAddress: this.peerAddress,
-      createdAt: this.createdAt,
+      createdAt: this.createdAt.toISOString(),
     }
   }
 
@@ -116,7 +116,11 @@ export class ConversationV1 {
     client: Client,
     data: ConversationV1Export
   ): ConversationV1 {
-    return new ConversationV1(client, data.peerAddress, data.createdAt)
+    return new ConversationV1(
+      client,
+      data.peerAddress,
+      new Date(data.createdAt)
+    )
   }
 
   async decodeMessage({
@@ -404,7 +408,7 @@ export class ConversationV2 {
       topic: this.topic,
       keyMaterial: Buffer.from(this.keyMaterial).toString('base64'),
       peerAddress: this.peerAddress,
-      createdAt: this.createdAt,
+      createdAt: this.createdAt.toISOString(),
       context: this.context,
     }
   }
@@ -418,7 +422,7 @@ export class ConversationV2 {
       data.topic,
       Buffer.from(data.keyMaterial, 'base64'),
       data.peerAddress,
-      data.createdAt,
+      new Date(data.createdAt),
       data.context
     )
   }

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -369,7 +369,7 @@ describe('conversation', () => {
       const exported = convo.export()
 
       expect(exported.peerAddress).toBe(bob.address)
-      expect(+exported.createdAt).toBe(+convo.createdAt)
+      expect(exported.createdAt).toBe(convo.createdAt.toISOString())
       expect(exported.version).toBe('v1')
     })
 
@@ -381,6 +381,7 @@ describe('conversation', () => {
         fail()
       }
       const imported = ConversationV1.fromExport(alice, exported)
+      expect(imported.createdAt).toEqual(convo.createdAt)
       await imported.send('hello')
       await sleep(50)
 
@@ -592,7 +593,7 @@ describe('conversation', () => {
         fail()
       }
       expect(exported.peerAddress).toBe(bob.address)
-      expect(+exported.createdAt).toBe(+convo.createdAt)
+      expect(exported.createdAt).toBe(convo.createdAt.toISOString())
       expect(exported.context?.conversationId).toBe(conversationId)
       expect(exported.keyMaterial).toBeTruthy()
       expect(exported.topic).toBe(convo.topic)
@@ -611,6 +612,7 @@ describe('conversation', () => {
       }
 
       const imported = ConversationV2.fromExport(alice, exported)
+      expect(imported.createdAt).toEqual(convo.createdAt)
       await imported.send('hello')
       await sleep(50)
 

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -394,7 +394,7 @@ describe('conversations', () => {
 
       const roundTripped = JSON.parse(JSON.stringify(exported))
       expect(roundTripped).toHaveLength(2)
-      expect(new Date(roundTripped[0].createdAt)).toEqual(exported[0].createdAt)
+      expect(roundTripped[0].createdAt).toEqual(exported[0].createdAt)
     })
 
     it('imports from export', async () => {


### PR DESCRIPTION
## Summary

There was a bug with conversation exports/imports where the `createdAt` field was not being deserialized back into a Date object, causing errors when importing conversations that had been run through `JSON.stringify(convoExport)`.

For clarity, I decided to change the export type to always represent dates as a string. This way the exported value will always be the same before/after a round trip through `JSON.stringify`.

Updated tests to match the updated code.