### PR TITLE
feat: enforce 2party dh

### DIFF
--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -84,9 +84,10 @@ describe('Message', function () {
 
   it('id returns bytes as hex string of sha256 hash', async () => {
     const alice = await PrivateKeyBundleV1.generate(newWallet())
+    const bob = await PrivateKeyBundleV1.generate(newWallet())
     const msg = await MessageV1.encode(
       alice,
-      alice.getPublicKeyBundle(),
+      bob.getPublicKeyBundle(),
       new TextEncoder().encode('hi'),
       new Date()
     )

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -131,15 +131,11 @@ describe('conversation', () => {
       consoleWarn.mockRestore()
     })
 
-    it('works for messaging yourself', async () => {
+    it('cannot message yourself', async () => {
       const convo = await alice.conversations.newConversation(alice.address)
-      await convo.send('hey me')
-
-      const messages = await convo.messages()
-      expect(messages).toHaveLength(1)
-      expect(messages[0].content).toBe('hey me')
-      expect(messages[0].senderAddress).toBe(alice.address)
-      expect(messages[0].recipientAddress).toBe(alice.address)
+      expect(convo.send('hey me')).rejects.toThrowError(
+        'Cannot derive sharedsecret using keys from the same keypair'
+      )
     })
 
     it('allows for sorted listing', async () => {

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -87,6 +87,20 @@ describe('Crypto', function () {
       assert.equal(actual, expected)
       assert.ok(true)
     })
+
+    it('1Party SharedKey derivation', async function () {
+      const pri = PrivateKey.fromBytes(
+        hexToBytes(
+          '08aaa9dad3ed2f12220a206fd789a6ee2376bb6595b4ebace57c7a79e6e4f1f12c8416d611399eda6c74cb1a4c08aaa9dad3ed2f1a430a4104e208133ea0973a9968fe5362e5ac0a8bbbe2aa16d796add31f3d027a1b894389873d7f282163bceb1fc3ca60d589d1e667956c40fed4cdaa7edc1392d2100b8a'
+        )
+      )
+
+      expect(() => {
+        pri.sharedSecret(pri.publicKey)
+      }).toThrowError(
+        'Cannot derive sharedsecret using keys from the same keypair'
+      )
+    })
   })
   describe('SignedPublicKeyBundle', () => {
     it('legacy roundtrip', async function () {


### PR DESCRIPTION
## Problem: 
Deriving shared keys for a conversation with "yourself" can lead to weak keys ought not be allowed in the SDK.

## Solution:
SDK ought to throw an error when attempting to derive keys using the public and private keys from the same keypair. 

## Notes:
This is a breaking change. Applications which allowed users to send messages to themself will no longer be able to derive keys to decrypt those messages. This behavior is explicitly banned in the XMTP Example apps however may exist in other implementations. 



