### PR TITLE
docs: Fix compression docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,10 @@ Message content can be optionally compressed using the `compression` option. The
 Content will be decompressed transparently on the receiving end. Note that `Client` enforces maximum content size. The default limit can be overridden through the `ClientOptions`. Consequently a message that would expand beyond that limit on the receiving end will fail to decode.
 
 ```ts
+import { Compression } from '@xmtp/xmtp-js'
+
 conversation.send('#'.repeat(1000), {
-  compression: 'deflate',
+  compression: Compression.COMPRESSION_DEFLATE
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Content will be decompressed transparently on the receiving end. Note that `Clie
 import { Compression } from '@xmtp/xmtp-js'
 
 conversation.send('#'.repeat(1000), {
-  compression: Compression.COMPRESSION_DEFLATE
+  compression: Compression.COMPRESSION_DEFLATE,
 })
 ```
 


### PR DESCRIPTION
Using a string errors in Typescript:

<img width="1377" alt="Screen Shot 2023-01-19 at 10 47 42 AM" src="https://user-images.githubusercontent.com/483/213538357-5be06f8e-2ada-44bb-9eed-0cdfba8494d9.png">
