### PR TITLE
fix: Fix deflate compression

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,6 @@
 
 If you're seeing this document, you are an early contributor to the development and success of XMTP. We welcome your questions, feedback, suggestions, and code contributions.
 
-> If you wish to contribute, please [apply for Early Access](https://xmtp.typeform.com/yojTJarb) so that we can provide you with access to our Discord.
-
 ## ❔ Questions
 
 Have a question? We welcome you to ask it in [Q&A discussions](https://github.com/orgs/xmtp/discussions/categories/q-a).
@@ -36,7 +34,7 @@ The table below shows example commits and the resulting release type:
 | `perf(pencil): remove graphiteWidth option`<br><br>`BREAKING CHANGE: The graphiteWidth option has been removed.`<br>`The default graphite width of 10mm is always used for performance reasons.` | ~~Major~~ Breaking Release <br /> (Note that the `BREAKING CHANGE:` token must be in the footer of the commit) |
 <!-- prettier-ignore-end -->
 
-This is currently configured to use the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format).
+This is currently configured to use the [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format). e.g. `feat: add message signing` would cause a minor release.
 
 ### Prerequisites
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -352,7 +352,7 @@ export default class Client {
     if (options?.contentFallback) {
       encoded.fallback = options.contentFallback
     }
-    if (options?.compression) {
+    if (typeof options?.compression === 'number') {
       encoded.compression = options.compression
     }
     await compress(encoded)

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -19,6 +19,7 @@ import {
   EncodedContent,
 } from './MessageContent'
 import { nsToDate } from './utils'
+import { decompress } from './Compression'
 
 const headerBytesAndCiphertext = (
   msg: proto.Message
@@ -333,7 +334,7 @@ export class DecodedMessage {
   }
 }
 
-export function decodeContent(contentBytes: Uint8Array, client: Client) {
+export async function decodeContent(contentBytes: Uint8Array, client: Client) {
   const encodedContent = protoContent.EncodedContent.decode(contentBytes)
 
   if (!encodedContent.type) {
@@ -343,6 +344,8 @@ export function decodeContent(contentBytes: Uint8Array, client: Client) {
   let content: any // eslint-disable-line @typescript-eslint/no-explicit-any
   let contentType = new ContentTypeId(encodedContent.type)
   let error: Error | undefined
+
+  await decompress(encodedContent, 1000)
 
   const codec = client.codecFor(contentType)
   if (codec) {

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -100,7 +100,7 @@ export class ConversationV1 {
       throw new Error('Headers do not match intended recipient')
     }
     const decrypted = await decoded.decrypt(this.client.legacyKeys)
-    const { content, contentType, error } = decodeContent(
+    const { content, contentType, error } = await decodeContent(
       decrypted,
       this.client
     )
@@ -333,7 +333,7 @@ export class ConversationV2 {
       throw new Error('invalid signature')
     }
     const messageV2 = await MessageV2.create(msg, header, signed, messageBytes)
-    const { content, contentType, error } = decodeContent(
+    const { content, contentType, error } = await decodeContent(
       signed.payload,
       this.client
     )

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -7,6 +7,8 @@ import {
 } from './helpers'
 import { buildUserContactTopic } from '../src/utils'
 import Client, { KeyStoreType, ClientOptions } from '../src/Client'
+import { Compression } from '../src'
+import { content as proto } from '@xmtp/proto'
 
 type TestCase = {
   name: string
@@ -69,6 +71,26 @@ describe('Client', () => {
         assert.equal(can_mesg_b, true)
       })
     })
+  })
+})
+
+describe('encodeContent', () => {
+  it('passes deflate compression option through properly', async function () {
+    const c = await newLocalHostClient()
+    const utf8Encode = new TextEncoder();
+    const uncompressed = utf8Encode.encode("hello world ".repeat(20));
+
+    const compressed = Uint8Array.from([
+      10, 18, 10, 8, 120, 109, 116, 112, 46, 111, 114, 103, 18, 4, 116, 101,
+      120, 116, 24, 1, 18, 17, 10, 8, 101, 110, 99, 111, 100, 105, 110, 103,
+      18, 5, 85, 84, 70, 45, 56, 40, 0, 34, 45, 120, 1, 51, 52, 48, 209, 49,
+      52, 48, 4, 98, 11, 8, 54, 52, 212, 49, 54, 2, 82, 150, 96, 166, 161,
+      161, 9, 84, 202, 0, 44, 60, 170, 122, 84, 245, 168, 106, 218, 171, 6,
+      0, 139, 43, 173, 229
+    ])
+
+    const payload = await c.encodeContent(uncompressed, { compression: Compression.COMPRESSION_DEFLATE })
+    assert.deepEqual(Uint8Array.from(payload), compressed)
   })
 })
 

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -77,19 +77,21 @@ describe('Client', () => {
 describe('encodeContent', () => {
   it('passes deflate compression option through properly', async function () {
     const c = await newLocalHostClient()
-    const utf8Encode = new TextEncoder();
-    const uncompressed = utf8Encode.encode("hello world ".repeat(20));
+    const utf8Encode = new TextEncoder()
+    const uncompressed = utf8Encode.encode('hello world '.repeat(20))
 
     const compressed = Uint8Array.from([
       10, 18, 10, 8, 120, 109, 116, 112, 46, 111, 114, 103, 18, 4, 116, 101,
-      120, 116, 24, 1, 18, 17, 10, 8, 101, 110, 99, 111, 100, 105, 110, 103,
-      18, 5, 85, 84, 70, 45, 56, 40, 0, 34, 45, 120, 1, 51, 52, 48, 209, 49,
-      52, 48, 4, 98, 11, 8, 54, 52, 212, 49, 54, 2, 82, 150, 96, 166, 161,
-      161, 9, 84, 202, 0, 44, 60, 170, 122, 84, 245, 168, 106, 218, 171, 6,
-      0, 139, 43, 173, 229
+      120, 116, 24, 1, 18, 17, 10, 8, 101, 110, 99, 111, 100, 105, 110, 103, 18,
+      5, 85, 84, 70, 45, 56, 40, 0, 34, 45, 120, 1, 51, 52, 48, 209, 49, 52, 48,
+      4, 98, 11, 8, 54, 52, 212, 49, 54, 2, 82, 150, 96, 166, 161, 161, 9, 84,
+      202, 0, 44, 60, 170, 122, 84, 245, 168, 106, 218, 171, 6, 0, 139, 43, 173,
+      229,
     ])
 
-    const payload = await c.encodeContent(uncompressed, { compression: Compression.COMPRESSION_DEFLATE })
+    const payload = await c.encodeContent(uncompressed, {
+      compression: Compression.COMPRESSION_DEFLATE,
+    })
     assert.deepEqual(Uint8Array.from(payload), compressed)
   })
 })

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -232,7 +232,7 @@ describe('conversation', () => {
       expect(twoToFourDaysAgo).toHaveLength(3)
     })
 
-    it('can send compressed messages', async () => {
+    it('can send compressed v1 messages', async () => {
       const convo = await alice.conversations.newConversation(bob.address)
       const content = 'A'.repeat(111)
       await convo.send(content, {
@@ -376,6 +376,23 @@ describe('conversation', () => {
 
       await bs.return()
       await as.return()
+    })
+
+    it('can send compressed v2 messages', async () => {
+      const convo = await alice.conversations.newConversation(bob.address, {
+        conversationId: 'example.com/compressedv2',
+        metadata: {},
+      })
+      const content = 'A'.repeat(111)
+      await convo.send(content, {
+        contentType: ContentTypeText,
+        compression: Compression.COMPRESSION_DEFLATE,
+      })
+      await sleep(100)
+      const results = await convo.messages()
+      expect(results).toHaveLength(1)
+      const msg = results[0]
+      expect(msg.content).toBe(content)
     })
 
     it('handles limiting page size', async () => {


### PR DESCRIPTION
Client.encodeContent was checking `options?.compression`, which in the case of `Compression.COMPRESSION_DEFLATE` equals `0`, which is falsey in JS.