### PR TITLE
test: add db-reader flag and platform: linux/amd64 to docker-compose.yml

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,12 +1,14 @@
 services:
   waku-node:
     image: xmtp/node-go:latest
+    platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67
     command:
       - --ws
       - --store
       - --message-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      - --message-db-reader-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --lightpush
       - --filter
       - --ws-port=9001


### PR DESCRIPTION
# Background

For the new [db cleaner](https://github.com/xmtp/xmtp-node-go/pull/208/files#diff-71d92c070793d886ac0d3b56c477078f018800dc6167bb8065c2f221b9879e84R10) + read replica change, we need to add a `--message-db-reader-connection-string=` in the docker-compose.yml file.

Similarly we stopped building `arm64` platform images for `xmtp/node-go` since they take forever in CI. Seems like we need to specify `- platform: linux/amd64` now in docker-compose.yml. This is in addition to specifying platform when pulling the latest image `docker pull xmtp/node-go:latest --platform linux/amd64`

# Tests

This allows `npm test` to pass when the local cluster is started

# Notes

I started messing with this when realizing that my local tests failed due to not being able to reach :5555 in the local node-go container after `./dev/up`. Somehow, restarting my computer (and Docker as a result) fixed what seemed like a networking issue where localhost:5555 was bound to node-go:5555 but somehow requests were receiving empty replies.