### PR TITLE
feat: add canMessage multiple powered by batch query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.9.0",
+        "@xmtp/proto": "^3.12.0",
         "async-mutex": "^0.4.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0"
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.9.0.tgz",
-      "integrity": "sha512-FhS2+PPoS3zR8KLCXcttonE8dsiigqIfHzxTD47nndoYk1crhK0IcygVQJN/9aL5K5/KXx/A2USzy/74cMfW9g==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.12.3.tgz",
+      "integrity": "sha512-uogSWSa90Mr6bH+BlmOCVXnRsnJozBHexpBM8GotpXgyqutmAgPniJKAntwyErjixpsh9NWkj9RAJKyYWb8Kew==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16201,9 +16201,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.9.0.tgz",
-      "integrity": "sha512-FhS2+PPoS3zR8KLCXcttonE8dsiigqIfHzxTD47nndoYk1crhK0IcygVQJN/9aL5K5/KXx/A2USzy/74cMfW9g==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.12.3.tgz",
+      "integrity": "sha512-uogSWSa90Mr6bH+BlmOCVXnRsnJozBHexpBM8GotpXgyqutmAgPniJKAntwyErjixpsh9NWkj9RAJKyYWb8Kew==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.9.0",
+    "@xmtp/proto": "^3.12.0",
     "async-mutex": "^0.4.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0"

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -283,7 +283,7 @@ export default class Client {
     )
     // The logic here is tricky because we need to do a batch query for any uncached bundles,
     // then interleave back into an ordered array. So we create a map<string, keybundle|undefined>
-    // and fill it with cached values, then take any undefined entries and form a BatchQuery from there.
+    // and fill it with cached values, then take any undefined entries and form a BatchQuery from those.
     const addressToBundle = new Map<
       string,
       PublicKeyBundle | SignedPublicKeyBundle | undefined

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -308,7 +308,12 @@ export default class Client {
     // Now merge the newBundles into the addressToBundle map
     for (let i = 0; i < newBundles.length; i++) {
       const address = uncachedAddresses[i]
-      addressToBundle.set(address, newBundles[i])
+      const bundle = newBundles[i]
+      addressToBundle.set(address, bundle)
+      // If the bundle is not undefined, cache it
+      if (bundle) {
+        this.knownPublicKeyBundles.set(address, bundle)
+      }
     }
 
     // Finally return the bundles in the same order as the input addresses

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -147,40 +147,42 @@ describe('canMessageBatch', () => {
     )
 
     const canMessageUnregisteredClient = await Client.canMessage(
-      newWallet().address,
+      [newWallet().address],
       { env: 'local' }
     )
-    expect(canMessageUnregisteredClient).toBeFalsy()
+    expect(canMessageUnregisteredClient).toEqual([false])
   })
 })
 
-describe('canMessageBatch75', () => {
+describe('canMessageMultipleBatches', () => {
   it('can confirm many multiple users are on the network statically', async () => {
-    // Create 10 registered clients
     const registeredClients = await Promise.all(
-      Array.from({ length: 75 }, () => newLocalHostClient())
+      Array.from({ length: 10 }, () => newLocalHostClient())
     )
     // Wait for all clients to be registered
     await Promise.all(
       registeredClients.map((client) => waitForUserContact(client, client))
     )
+    // Repeat registeredClients 8 times to arrive at 80 addresses
+    const initialPeerAddresses = registeredClients.map(
+      (client) => client.address
+    )
+    const repeatedPeerAddresses: string[] = []
+    for (let i = 0; i < 8; i++) {
+      repeatedPeerAddresses.push(...initialPeerAddresses)
+    }
+
     // Now call canMessage with all of the peerAddresses
     const canMessageRegisteredClients = await Client.canMessage(
-      [...registeredClients.map((client) => client.address)],
+      repeatedPeerAddresses,
       {
         env: 'local',
       }
     )
     // Expect all of the clients to be registered, so response should be all True
     expect(canMessageRegisteredClients).toEqual(
-      registeredClients.map(() => true)
+      repeatedPeerAddresses.map(() => true)
     )
-
-    const canMessageUnregisteredClient = await Client.canMessage(
-      newWallet().address,
-      { env: 'local' }
-    )
-    expect(canMessageUnregisteredClient).toBeFalsy()
   })
 })
 

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -124,6 +124,66 @@ describe('canMessage', () => {
   })
 })
 
+describe('canMessageBatch', () => {
+  it('can confirm multiple users are on the network statically', async () => {
+    // Create 10 registered clients
+    const registeredClients = await Promise.all(
+      Array.from({ length: 10 }, () => newLocalHostClient())
+    )
+    // Wait for all clients to be registered
+    await Promise.all(
+      registeredClients.map((client) => waitForUserContact(client, client))
+    )
+    // Now call canMessage with all of the peerAddresses
+    const canMessageRegisteredClients = await Client.canMessage(
+      [...registeredClients.map((client) => client.address)],
+      {
+        env: 'local',
+      }
+    )
+    // Expect all of the clients to be registered, so response should be all True
+    expect(canMessageRegisteredClients).toEqual(
+      registeredClients.map(() => true)
+    )
+
+    const canMessageUnregisteredClient = await Client.canMessage(
+      newWallet().address,
+      { env: 'local' }
+    )
+    expect(canMessageUnregisteredClient).toBeFalsy()
+  })
+})
+
+describe('canMessageBatch75', () => {
+  it('can confirm many multiple users are on the network statically', async () => {
+    // Create 10 registered clients
+    const registeredClients = await Promise.all(
+      Array.from({ length: 75 }, () => newLocalHostClient())
+    )
+    // Wait for all clients to be registered
+    await Promise.all(
+      registeredClients.map((client) => waitForUserContact(client, client))
+    )
+    // Now call canMessage with all of the peerAddresses
+    const canMessageRegisteredClients = await Client.canMessage(
+      [...registeredClients.map((client) => client.address)],
+      {
+        env: 'local',
+      }
+    )
+    // Expect all of the clients to be registered, so response should be all True
+    expect(canMessageRegisteredClients).toEqual(
+      registeredClients.map(() => true)
+    )
+
+    const canMessageUnregisteredClient = await Client.canMessage(
+      newWallet().address,
+      { env: 'local' }
+    )
+    expect(canMessageUnregisteredClient).toBeFalsy()
+  })
+})
+
 describe('ClientOptions', () => {
   const tests = [
     {

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -136,7 +136,7 @@ describe('canMessageBatch', () => {
     )
     // Now call canMessage with all of the peerAddresses
     const canMessageRegisteredClients = await Client.canMessage(
-      [...registeredClients.map((client) => client.address)],
+      registeredClients.map((client) => client.address),
       {
         env: 'local',
       }
@@ -171,6 +171,13 @@ describe('canMessageMultipleBatches', () => {
     for (let i = 0; i < 8; i++) {
       repeatedPeerAddresses.push(...initialPeerAddresses)
     }
+    // Add 5 fake addresses
+    repeatedPeerAddresses.push(
+      ...Array.from(
+        { length: 5 },
+        () => '0x0000000000000000000000000000000000000000'
+      )
+    )
 
     // Now call canMessage with all of the peerAddresses
     const canMessageRegisteredClients = await Client.canMessage(
@@ -179,9 +186,11 @@ describe('canMessageMultipleBatches', () => {
         env: 'local',
       }
     )
-    // Expect all of the clients to be registered, so response should be all True
+    // Expect 80 True and 5 False
     expect(canMessageRegisteredClients).toEqual(
-      repeatedPeerAddresses.map(() => true)
+      Array.from({ length: 80 }, () => true).concat(
+        Array.from({ length: 5 }, () => false)
+      )
     )
   })
 })


### PR DESCRIPTION
**Goal**

Now that we BatchQueries in [node API](https://github.com/xmtp/xmtp-node-go/pull/202) we can begin to use the capability in the xmtp-js SDK. This first change will create a method overload for `canMessage` which takes multiple addresses and executes them via batch queries, returning a list of booleans as a Promise.

**Changes**
- Implement BatchQuery in apiClient.ts
- Implement BatchQuery in Client.ts
- Add `getUserContactsFromNetwork` (plural)
- Add overloaded type signatures for `canMessage`

**Testing**
- Unit tests


**Outdated Notes**

My question: `canMessage` isn't really used in a multiple address case by apps today right? I'm looking at ListConversations as the biggest bottleneck that could benefit from batch querying. If I use "Fast 3G" with 1000 convos, the network stalling can be 6+ seconds. On 500Mb/s network, the decryption of envelopes takes enough time that network stall is < 1 second.

Turns out folks want the use case of being able to see what addresses they can message from some set (e.g. these addresses own this NFT) 