### PR TITLE
Keystore

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ for await (const message of await conversation.streamMessages()) {
 }
 ```
 
+Currently, network nodes are configured to rate limit high-volume publishing from Clients. A rate-limited Client can expect to receive a 429 status code response from a node. Rate limits can change at any time in the interest of maintaining network health.
+
 ### Creating a Client
 
 A Client is created with `Client.create(wallet: Signer): Promise<Client>` that requires passing in a connected Wallet that implements the [Signer](src/types/Signer.ts) interface. The Client will request a wallet signature in 2 cases:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.12.0",
+        "@xmtp/proto": "^3.13.0",
         "async-mutex": "^0.4.0",
         "ethers": "^5.5.3",
         "long": "^5.2.0"
@@ -3279,12 +3279,13 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.12.3.tgz",
-      "integrity": "sha512-uogSWSa90Mr6bH+BlmOCVXnRsnJozBHexpBM8GotpXgyqutmAgPniJKAntwyErjixpsh9NWkj9RAJKyYWb8Kew==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.13.0.tgz",
+      "integrity": "sha512-qzWEWt+S0CD3V6xzBaZmWvZqHNmthuy5pdmxO7qjxs+4jGn8IXQOapF5fPGuOboTgK/1IStj31vnkS1KNSf7CA==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
+        "rxjs": "^7.8.0",
         "undici": "^5.8.1"
       }
     },
@@ -12034,6 +12035,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -16201,12 +16215,13 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.12.3.tgz",
-      "integrity": "sha512-uogSWSa90Mr6bH+BlmOCVXnRsnJozBHexpBM8GotpXgyqutmAgPniJKAntwyErjixpsh9NWkj9RAJKyYWb8Kew==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.13.0.tgz",
+      "integrity": "sha512-qzWEWt+S0CD3V6xzBaZmWvZqHNmthuy5pdmxO7qjxs+4jGn8IXQOapF5fPGuOboTgK/1IStj31vnkS1KNSf7CA==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
+        "rxjs": "^7.8.0",
         "undici": "^5.8.1"
       },
       "dependencies": {
@@ -22664,6 +22679,21 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.12.0",
+    "@xmtp/proto": "^3.13.0",
     "async-mutex": "^0.4.0",
     "ethers": "^5.5.3",
     "long": "^5.2.0"

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -417,21 +417,33 @@ export default class Conversations {
     // Perform all read/write operations on the cache while holding the mutex
     await this.v2Cache.load(
       async ({ latestSeen, existing }): Promise<Conversation[]> => {
+        console.log(
+          'Loading conversations after',
+          latestSeen,
+          'looking for',
+          peerAddress,
+          'with context',
+          context
+        )
         // First check the cache without doing a network request
         const existingMatch = existing.find(matcherFn)
         if (existingMatch) {
+          console.log('Found an existing match')
           v2Convo = existingMatch
           return []
         }
 
         // Next try and load new items into the cache from the network
         const newItems = await this.v2ConversationLoader(latestSeen)
+        console.log(`Found ${newItems.length} new items`, newItems)
         const newItemMatch = newItems.find(matcherFn)
         // If one of those matches, return it to update the cache
         if (newItemMatch) {
           v2Convo = newItemMatch
           return newItems
         }
+
+        console.log('No new items matched')
 
         // If all else fails, create a new invite
         const invitation = InvitationV1.createRandom(context)
@@ -512,7 +524,11 @@ export default class Conversations {
     })
 
     const peerAddress = await recipient.walletSignatureAddress()
-
+    console.log(
+      'Sending invitation',
+      await recipient.walletSignatureAddress(),
+      invitation.context
+    )
     this.client.publishEnvelopes([
       {
         contentTopic: buildUserInviteTopic(peerAddress),

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -417,33 +417,21 @@ export default class Conversations {
     // Perform all read/write operations on the cache while holding the mutex
     await this.v2Cache.load(
       async ({ latestSeen, existing }): Promise<Conversation[]> => {
-        console.log(
-          'Loading conversations after',
-          latestSeen,
-          'looking for',
-          peerAddress,
-          'with context',
-          context
-        )
         // First check the cache without doing a network request
         const existingMatch = existing.find(matcherFn)
         if (existingMatch) {
-          console.log('Found an existing match')
           v2Convo = existingMatch
           return []
         }
 
         // Next try and load new items into the cache from the network
         const newItems = await this.v2ConversationLoader(latestSeen)
-        console.log(`Found ${newItems.length} new items`, newItems)
         const newItemMatch = newItems.find(matcherFn)
         // If one of those matches, return it to update the cache
         if (newItemMatch) {
           v2Convo = newItemMatch
           return newItems
         }
-
-        console.log('No new items matched')
 
         // If all else fails, create a new invite
         const invitation = InvitationV1.createRandom(context)

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -512,11 +512,6 @@ export default class Conversations {
     })
 
     const peerAddress = await recipient.walletSignatureAddress()
-    console.log(
-      'Sending invitation',
-      await recipient.walletSignatureAddress(),
-      invitation.context
-    )
     this.client.publishEnvelopes([
       {
         contentTopic: buildUserInviteTopic(peerAddress),

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -1,3 +1,4 @@
+import { ciphertext } from '@xmtp/proto'
 import Ciphertext, { AESGCMNonceSize, KDFSaltSize } from './Ciphertext'
 
 // crypto should provide access to standard Web Crypto API
@@ -44,7 +45,7 @@ export async function encrypt(
 
 // symmetric authenticated decryption of the encrypted ciphertext using the secret and additionalData
 export async function decrypt(
-  encrypted: Ciphertext,
+  encrypted: Ciphertext | ciphertext.Ciphertext,
   secret: Uint8Array,
   additionalData?: Uint8Array
 ): Promise<Uint8Array> {

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -10,11 +10,13 @@ import { UnsignedPublicKey, SignedPublicKey, PublicKey } from './PublicKey'
 import Signature, { WalletSigner } from './Signature'
 import * as utils from './utils'
 import { encrypt, decrypt } from './encryption'
+import Ciphertext from './Ciphertext'
 
 export {
   utils,
   encrypt,
   decrypt,
+  Ciphertext,
   UnsignedPublicKey,
   SignedPublicKey,
   SignedPublicKeyBundle,

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -88,9 +88,9 @@ export default class InMemoryKeystore implements Keystore {
           isSender
         )
 
-        return wrapResult({
+        return {
           decrypted,
-        })
+        }
       },
       keystore.ErrorCode.ERROR_CODE_UNSPECIFIED
     )
@@ -124,7 +124,7 @@ export default class InMemoryKeystore implements Keystore {
         }
         const decrypted = await decryptV2(payload, topicData.key, headerBytes)
 
-        return wrapResult({ decrypted })
+        return { decrypted }
       },
       ErrorCode.ERROR_CODE_UNSPECIFIED
     )
@@ -149,14 +149,14 @@ export default class InMemoryKeystore implements Keystore {
 
         const { recipient, payload, headerBytes } = req
 
-        return wrapResult({
+        return {
           encrypted: await encryptV1(
             this.v1Keys,
             toPublicKeyBundle(recipient),
             payload,
             headerBytes
           ),
-        })
+        }
       },
       ErrorCode.ERROR_CODE_UNSPECIFIED
     )
@@ -189,9 +189,9 @@ export default class InMemoryKeystore implements Keystore {
           )
         }
 
-        return wrapResult({
+        return {
           encrypted: await encryptV2(payload, topicData.key, headerBytes),
-        })
+        }
       },
       ErrorCode.ERROR_CODE_INVALID_INPUT
     )
@@ -216,12 +216,12 @@ export default class InMemoryKeystore implements Keystore {
 
         const invite = await sealed.v1.getInvitation(this.v2Keys)
 
-        return wrapResult({
+        return {
           conversation: this.addConversationFromV1Invite(
             invite,
             nsToDate(sealed.v1.header.createdNs)
           ),
-        })
+        }
       },
       ErrorCode.ERROR_CODE_INVALID_INPUT
     )

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -34,26 +34,6 @@ type TopicData = {
   createdAt: Date
 }
 
-export class TopicKeyManager {
-  private topicKeys: Map<string, TopicData>
-
-  constructor() {
-    this.topicKeys = new Map<string, TopicData>()
-  }
-
-  addTopicKey(topic: string, key: Uint8Array, context?: InvitationContext) {
-    this.topicKeys.set(topic, {
-      key,
-      context,
-      createdAt: new Date(),
-    })
-  }
-
-  getTopicKey(topic: string): TopicData | undefined {
-    return this.topicKeys.get(topic)
-  }
-}
-
 export default class InMemoryKeystore implements Keystore {
   private v1Keys: PrivateKeyBundleV1
   private v2Keys: PrivateKeyBundleV2 // Do I need this?

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -8,7 +8,7 @@ import {
   InvitationV1,
   SealedInvitation,
 } from './../Invitation'
-import { PublicKeyBundle, SignedPublicKeyBundle } from '../crypto'
+import { SignedPublicKeyBundle } from '../crypto'
 import {
   Keystore,
   DecryptV1Request,

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -1,0 +1,145 @@
+import { messageApi } from '@xmtp/proto'
+import {
+  PrivateKeyBundleV1,
+  PrivateKeyBundleV2,
+} from './../crypto/PrivateKeyBundle'
+import {
+  InvitationContext,
+  InvitationV1,
+  SealedInvitation,
+} from './../Invitation'
+import { SignedPublicKeyBundle } from '../crypto'
+import {
+  Keystore,
+  DecryptV1Request,
+  DecryptV2Request,
+  DecryptV1Response,
+  DecryptV2Response,
+  EncryptResponse,
+  EncryptV1Request,
+  EncryptV2Request,
+  CreateInviteRequest,
+  SealedInvitation as ISealedInvitation,
+  ResultOrError,
+  ConversationReference,
+} from './interfaces'
+import { decryptV1, encryptV1 } from './encryption'
+import { ErrorCode } from './errors'
+import { mapAndConvertErrors } from './utils'
+import { nsToDate } from '../utils'
+
+type TopicData = {
+  key: Uint8Array
+  context?: InvitationContext
+  createdAt: Date
+}
+
+export default class InMemoryKeystore implements Keystore {
+  private v1Keys: PrivateKeyBundleV1
+  private v2Keys: PrivateKeyBundleV2 // Do I need this?
+  private topicKeys: Map<string, TopicData>
+
+  constructor(keys: PrivateKeyBundleV1) {
+    this.v1Keys = keys
+    this.v2Keys = PrivateKeyBundleV2.fromLegacyBundle(keys)
+    this.topicKeys = new Map<string, TopicData>()
+  }
+
+  decryptV1(req: DecryptV1Request[]): Promise<DecryptV1Response[]> {
+    return mapAndConvertErrors(
+      req,
+      async ({ payload, contentTopic }) => {
+        const decrypted = await decryptV1(this.v1Keys, payload, contentTopic)
+        return {
+          decrypted,
+        }
+      },
+      ErrorCode.VALIDATION_FAILED
+    )
+  }
+
+  async decryptV2(req: DecryptV2Request[]): Promise<DecryptV2Response[]> {
+    throw new Error('unimplemented')
+  }
+
+  encryptV1(req: EncryptV1Request[]): Promise<EncryptResponse[]> {
+    return mapAndConvertErrors(
+      req,
+      async ({ recipient, message, headerBytes }) => {
+        return {
+          ciphertext: await encryptV1(
+            this.v1Keys,
+            recipient,
+            message,
+            headerBytes
+          ),
+        }
+      },
+      ErrorCode.VALIDATION_FAILED
+    )
+  }
+
+  async encryptV2(req: EncryptV2Request[]): Promise<EncryptResponse[]> {
+    throw new Error('unimplemented')
+  }
+
+  async saveInvites(
+    req: messageApi.Envelope[]
+  ): Promise<ResultOrError<ConversationReference>[]> {
+    return mapAndConvertErrors(
+      req,
+      async (envelope) => {
+        const sealedInvitation = await SealedInvitation.fromEnvelope(envelope)
+        const invite = await sealedInvitation.v1.getInvitation(this.v2Keys)
+        return this.addConversationFromV1Invite(
+          invite,
+          nsToDate(sealedInvitation.v1.header.createdNs)
+        )
+      },
+      ErrorCode.VALIDATION_FAILED
+    )
+  }
+
+  async createInvite(req: CreateInviteRequest): Promise<ISealedInvitation> {
+    throw new Error('unimplemented')
+  }
+
+  async getV2Conversations(): Promise<ConversationReference[]> {
+    const convos = Object.entries(this.topicKeys).map(
+      ([topic, data]): ConversationReference => ({
+        topic,
+        createdAt: data.createdAt,
+        context: data.context,
+      })
+    )
+
+    convos.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+
+    return convos
+  }
+
+  async getPublicKeyBundle(): Promise<SignedPublicKeyBundle> {
+    return this.v2Keys.getPublicKeyBundle()
+  }
+
+  async getWalletAddress(): Promise<string> {
+    return this.v2Keys.getPublicKeyBundle().walletSignatureAddress()
+  }
+
+  private addConversationFromV1Invite(
+    invite: InvitationV1,
+    createdAt: Date
+  ): ConversationReference {
+    this.topicKeys.set(invite.topic, {
+      key: invite.aes256GcmHkdfSha256.keyMaterial,
+      context: invite.context,
+      createdAt,
+    })
+
+    return {
+      topic: invite.topic,
+      createdAt,
+      context: invite.context,
+    }
+  }
+}

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -17,7 +17,6 @@ import {
   mapAndConvertErrors,
   toPublicKeyBundle,
   toSignedPublicKeyBundle,
-  wrapResult,
 } from './utils'
 import { dateToNs, nsToDate } from '../utils'
 const { ErrorCode } = keystore

--- a/src/keystore/encryption.ts
+++ b/src/keystore/encryption.ts
@@ -1,0 +1,47 @@
+import { MessageV1 } from '../Message'
+import { buildDirectMessageTopic } from '../utils'
+import { ErrorCode, KeystoreError } from './errors'
+import {
+  PublicKeyBundle,
+  encrypt,
+  PrivateKeyBundleV1,
+  Ciphertext,
+} from '../crypto'
+
+export async function decryptV1(
+  keys: PrivateKeyBundleV1,
+  payload: Uint8Array,
+  contentTopic: string
+): Promise<Uint8Array> {
+  const decoded = await MessageV1.fromBytes(payload)
+  const { senderAddress, recipientAddress } = decoded
+
+  // Filter for topics
+  if (
+    !senderAddress ||
+    !recipientAddress ||
+    !contentTopic ||
+    buildDirectMessageTopic(senderAddress, recipientAddress) !== contentTopic
+  ) {
+    throw new KeystoreError(
+      ErrorCode.VALIDATION_FAILED,
+      'Headers do not match intended recipient'
+    )
+  }
+  return decoded.decrypt(keys)
+}
+
+export async function encryptV1(
+  keys: PrivateKeyBundleV1,
+  recipient: PublicKeyBundle,
+  message: Uint8Array,
+  headerBytes: Uint8Array
+): Promise<Ciphertext> {
+  const secret = await keys.sharedSecret(
+    recipient,
+    keys.getCurrentPreKey().publicKey,
+    false // assumes that the sender is the party doing the encrypting
+  )
+
+  return encrypt(message, secret, headerBytes)
+}

--- a/src/keystore/encryption.ts
+++ b/src/keystore/encryption.ts
@@ -2,28 +2,22 @@ import {
   PublicKeyBundle,
   encrypt,
   PrivateKeyBundleV1,
-  Ciphertext,
   decrypt,
 } from '../crypto'
+import { ciphertext } from '@xmtp/proto'
 
 export const decryptV1 = async (
   myKeys: PrivateKeyBundleV1,
   peerKeys: PublicKeyBundle,
-  ciphertext: Ciphertext,
+  ciphertext: ciphertext.Ciphertext,
   headerBytes: Uint8Array,
   isSender: boolean
 ): Promise<Uint8Array> => {
-  const secret = isSender
-    ? await myKeys.sharedSecret(
-        peerKeys,
-        myKeys.getCurrentPreKey().publicKey, // assumes that the current preKey is what was used to encrypt
-        false
-      )
-    : await myKeys.sharedSecret(
-        myKeys.getPublicKeyBundle(),
-        peerKeys.preKey,
-        true
-      )
+  const secret = await myKeys.sharedSecret(
+    peerKeys,
+    myKeys.getCurrentPreKey().publicKey, // assumes that the current preKey is what was used to encrypt
+    !isSender
+  )
 
   return decrypt(ciphertext, secret, headerBytes)
 }
@@ -33,7 +27,7 @@ export const encryptV1 = async (
   recipient: PublicKeyBundle,
   message: Uint8Array,
   headerBytes: Uint8Array
-): Promise<Ciphertext> => {
+): Promise<ciphertext.Ciphertext> => {
   const secret = await keys.sharedSecret(
     recipient,
     keys.getCurrentPreKey().publicKey,
@@ -44,7 +38,7 @@ export const encryptV1 = async (
 }
 
 export const decryptV2 = (
-  ciphertext: Ciphertext,
+  ciphertext: ciphertext.Ciphertext,
   secret: Uint8Array,
   headerBytes: Uint8Array
 ) => decrypt(ciphertext, secret, headerBytes)

--- a/src/keystore/errors.ts
+++ b/src/keystore/errors.ts
@@ -1,0 +1,20 @@
+export enum ErrorCode {
+  KEYSTORE_UNAVAILABLE = 0, // maps to GRPC code 14 and HTTP code 503 (service unavailable)
+  UNAUTHENTICATED = 1, // maps to GRPC code 16 and HTTP code 401 (unauthorized)
+  UNAUTHORIZED = 2, // maps to GRPC code 7 and HTTP code 403 (forbidden)
+  INVALID_REQUEST = 3, // maps to GRPC code 3 and HTTP code 400 (bad request)
+  UNIMPLEMENTED = 4, // maps to GRPC code 12 and HTTP code 501 (not implemented)
+  INTERNAL_ERROR = 5, // maps to GRPC code 13 and HTTP code 500 (internal server error)
+  VALIDATION_FAILED = 6, // maps to GRPC code 3 and HTTP code 400 (bad request)
+}
+
+export class KeystoreError extends Error {
+  code: ErrorCode
+  error: string
+
+  constructor(code: ErrorCode, message: string) {
+    super(message)
+    this.error = message
+    this.code = code
+  }
+}

--- a/src/keystore/errors.ts
+++ b/src/keystore/errors.ts
@@ -1,21 +1,10 @@
-export enum ErrorCode {
-  KEYSTORE_UNAVAILABLE = 0, // maps to GRPC code 14 and HTTP code 503 (service unavailable)
-  UNAUTHENTICATED = 1, // maps to GRPC code 16 and HTTP code 401 (unauthorized)
-  UNAUTHORIZED = 2, // maps to GRPC code 7 and HTTP code 403 (forbidden)
-  INVALID_REQUEST = 3, // maps to GRPC code 3 and HTTP code 400 (bad request)
-  UNIMPLEMENTED = 4, // maps to GRPC code 12 and HTTP code 501 (not implemented)
-  INTERNAL_ERROR = 5, // maps to GRPC code 13 and HTTP code 500 (internal server error)
-  VALIDATION_FAILED = 6, // maps to GRPC code 3 and HTTP code 400 (bad request)
-  NOT_FOUND = 7, // maps to GRPC code 5 and HTTP code 404 (not found)
-}
+import { keystore } from '@xmtp/proto'
 
-export class KeystoreError extends Error {
-  code: ErrorCode
-  error: string
+export class KeystoreError extends Error implements keystore.KeystoreError {
+  code: keystore.ErrorCode
 
-  constructor(code: ErrorCode, message: string) {
+  constructor(code: keystore.ErrorCode, message: string) {
     super(message)
-    this.error = message
     this.code = code
   }
 }

--- a/src/keystore/errors.ts
+++ b/src/keystore/errors.ts
@@ -6,6 +6,7 @@ export enum ErrorCode {
   UNIMPLEMENTED = 4, // maps to GRPC code 12 and HTTP code 501 (not implemented)
   INTERNAL_ERROR = 5, // maps to GRPC code 13 and HTTP code 500 (internal server error)
   VALIDATION_FAILED = 6, // maps to GRPC code 3 and HTTP code 400 (bad request)
+  NOT_FOUND = 7, // maps to GRPC code 5 and HTTP code 404 (not found)
 }
 
 export class KeystoreError extends Error {

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,0 +1,3 @@
+export { default as InMemoryKeystore } from './InMemoryKeystore'
+export { decryptV1, decryptV2, encryptV1, encryptV2 } from './encryption'
+export { KeystoreError, ErrorCode } from './errors'

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,3 +1,4 @@
 export { default as InMemoryKeystore } from './InMemoryKeystore'
-export { decryptV1, decryptV2, encryptV1, encryptV2 } from './encryption'
-export { KeystoreError, ErrorCode } from './errors'
+export * from './encryption'
+export * from './errors'
+export * from './interfaces'

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -21,31 +21,30 @@ export type ConversationReference = {
 }
 
 export type DecryptV1Request = {
-  // Full message bytes, including header
-  payload: Uint8Array
-  contentTopic: string
+  payload: Ciphertext
+  peerKeys: PublicKeyBundle
+  headerBytes: Uint8Array
+  isSender: boolean
 }
 
 export type DecryptV1Response = ResultOrError<{
-  // Right now, I am leaving out header extraction. Maybe we want that included too, IDK
-  // Header does need to be parsed as part of decryption to verify, but maybe we want to parse that on both sides
   decrypted: Uint8Array
 }>
 
 export type DecryptV2Request = {
-  payload: Uint8Array
+  payload: Ciphertext
+  headerBytes: Uint8Array
   // Need to include contentTopic for the Keystore to know what topic key to use
   contentTopic: string
 }
 
 export type DecryptV2Response = ResultOrError<{
-  // Either decrypted or error will be present
   decrypted: Uint8Array
 }>
 
 export type EncryptV1Request = {
   recipient: PublicKeyBundle
-  message: Uint8Array
+  payload: Uint8Array
   headerBytes: Uint8Array
 }
 
@@ -65,7 +64,7 @@ export type CreateInviteRequest = {
   context: InvitationContext
 }
 
-export type SealedInvitation = {
+export type CreateInviteResponse = {
   conversation: ConversationReference
   // The full bytes of the sealed invitation, which can then be published to the API
   payload: Uint8Array
@@ -85,7 +84,7 @@ export interface Keystore {
     req: messageApi.Envelope[]
   ): Promise<ResultOrError<ConversationReference>[]>
   // Create the sealed invite and store the Topic keys in the Keystore for later use
-  createInvite(req: CreateInviteRequest): Promise<SealedInvitation>
+  createInvite(req: CreateInviteRequest): Promise<CreateInviteResponse>
   // Get V2 conversations
   getV2Conversations(): Promise<ConversationReference[]>
   // Used for publishing the contact

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -1,87 +1,23 @@
-import { messageApi, ciphertext, publicKey } from '@xmtp/proto'
-import { InvitationContext } from '../Invitation'
-import { ErrorCode } from './errors'
-
-type KeystoreError = {
-  error: string
-  code: ErrorCode
-}
-
-export type ResultOrError<T> = T | KeystoreError
-
-export type ConversationReference = {
-  topic: string
-  createdAt: Date
-  context?: InvitationContext
-}
-
-export type DecryptV1Request = {
-  payload: ciphertext.Ciphertext
-  peerKeys: publicKey.PublicKeyBundle
-  headerBytes: Uint8Array
-  isSender: boolean
-}
-
-export type DecryptV1Response = ResultOrError<{
-  decrypted: Uint8Array
-}>
-
-export type DecryptV2Request = {
-  payload: ciphertext.Ciphertext
-  headerBytes: Uint8Array
-  // Need to include contentTopic for the Keystore to know what topic key to use
-  contentTopic: string
-}
-
-export type DecryptV2Response = ResultOrError<{
-  decrypted: Uint8Array
-}>
-
-export type EncryptV1Request = {
-  recipient: publicKey.PublicKeyBundle
-  payload: Uint8Array
-  headerBytes: Uint8Array
-}
-
-export type EncryptResponse = ResultOrError<{
-  ciphertext: ciphertext.Ciphertext
-}>
-
-export type EncryptV2Request = {
-  contentTopic: string
-  message: Uint8Array
-  headerBytes: Uint8Array
-}
-
-export type CreateInviteRequest = {
-  recipient: publicKey.SignedPublicKeyBundle
-  createdAt: Date
-  context?: InvitationContext
-}
-
-export type CreateInviteResponse = {
-  conversation: ConversationReference
-  // The full bytes of the sealed invitation, which can then be published to the API
-  payload: Uint8Array
-}
-
+import { keystore, publicKey } from '@xmtp/proto'
 export interface Keystore {
   // Decrypt a batch of V1 messages
-  decryptV1(req: DecryptV1Request[]): Promise<DecryptV1Response[]>
+  decryptV1(req: keystore.DecryptV1Request): Promise<keystore.DecryptResponse>
   // Decrypt a batch of V2 messages
-  decryptV2(req: DecryptV2Request[]): Promise<DecryptV2Response[]>
+  decryptV2(req: keystore.DecryptV2Request): Promise<keystore.DecryptResponse>
   // Encrypt a batch of V1 messages
-  encryptV1(req: EncryptV1Request[]): Promise<EncryptResponse[]>
+  encryptV1(req: keystore.EncryptV1Request): Promise<keystore.EncryptResponse>
   // Encrypt a batch of V2 messages
-  encryptV2(req: EncryptV2Request[]): Promise<EncryptResponse[]>
+  encryptV2(req: keystore.EncryptV2Request): Promise<keystore.EncryptResponse>
   // Decrypt and save a batch of invite for later use in decrypting messages on the invite topic
   saveInvites(
-    req: messageApi.Envelope[]
-  ): Promise<ResultOrError<ConversationReference>[]>
+    req: keystore.SaveInvitesRequest
+  ): Promise<keystore.SaveInvitesResponse>
   // Create the sealed invite and store the Topic keys in the Keystore for later use
-  createInvite(req: CreateInviteRequest): Promise<CreateInviteResponse>
+  createInvite(
+    req: keystore.CreateInviteRequest
+  ): Promise<keystore.CreateInviteResponse>
   // Get V2 conversations
-  getV2Conversations(): Promise<ConversationReference[]>
+  getV2Conversations(): Promise<keystore.ConversationReference[]>
   // Used for publishing the contact
   getPublicKeyBundle(): Promise<publicKey.SignedPublicKeyBundle>
   // Technically duplicative of `getPublicKeyBundle`, but nice for ergonomics

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -1,0 +1,95 @@
+import { messageApi } from '@xmtp/proto'
+import Ciphertext from '../crypto/Ciphertext'
+import {
+  SignedPublicKeyBundle,
+  PublicKeyBundle,
+} from '../crypto/PublicKeyBundle'
+import { InvitationContext } from '../Invitation'
+import { ErrorCode } from './errors'
+
+type KeystoreError = {
+  error: string
+  code: ErrorCode
+}
+
+export type ResultOrError<T> = T | KeystoreError
+
+export type ConversationReference = {
+  topic: string
+  createdAt: Date
+  context?: InvitationContext
+}
+
+export type DecryptV1Request = {
+  // Full message bytes, including header
+  payload: Uint8Array
+  contentTopic: string
+}
+
+export type DecryptV1Response = ResultOrError<{
+  // Right now, I am leaving out header extraction. Maybe we want that included too, IDK
+  // Header does need to be parsed as part of decryption to verify, but maybe we want to parse that on both sides
+  decrypted: Uint8Array
+}>
+
+export type DecryptV2Request = {
+  payload: Uint8Array
+  // Need to include contentTopic for the Keystore to know what topic key to use
+  contentTopic: string
+}
+
+export type DecryptV2Response = ResultOrError<{
+  // Either decrypted or error will be present
+  decrypted: Uint8Array
+}>
+
+export type EncryptV1Request = {
+  recipient: PublicKeyBundle
+  message: Uint8Array
+  headerBytes: Uint8Array
+}
+
+export type EncryptResponse = ResultOrError<{
+  ciphertext: Ciphertext
+}>
+
+export type EncryptV2Request = {
+  contentTopic: string
+  message: Uint8Array
+  headerBytes: Uint8Array
+}
+
+export type CreateInviteRequest = {
+  recipient: SignedPublicKeyBundle
+  createdAt: Date
+  context: InvitationContext
+}
+
+export type SealedInvitation = {
+  conversation: ConversationReference
+  // The full bytes of the sealed invitation, which can then be published to the API
+  payload: Uint8Array
+}
+
+export interface Keystore {
+  // Decrypt a batch of V1 messages
+  decryptV1(req: DecryptV1Request[]): Promise<DecryptV1Response[]>
+  // Decrypt a batch of V2 messages
+  decryptV2(req: DecryptV2Request[]): Promise<DecryptV2Response[]>
+  // Encrypt a batch of V1 messages
+  encryptV1(req: EncryptV1Request[]): Promise<EncryptResponse[]>
+  // Encrypt a batch of V2 messages
+  encryptV2(req: EncryptV2Request[]): Promise<EncryptResponse[]>
+  // Decrypt and save a batch of invite for later use in decrypting messages on the invite topic
+  saveInvites(
+    req: messageApi.Envelope[]
+  ): Promise<ResultOrError<ConversationReference>[]>
+  // Create the sealed invite and store the Topic keys in the Keystore for later use
+  createInvite(req: CreateInviteRequest): Promise<SealedInvitation>
+  // Get V2 conversations
+  getV2Conversations(): Promise<ConversationReference[]>
+  // Used for publishing the contact
+  getPublicKeyBundle(): Promise<SignedPublicKeyBundle>
+  // Technically duplicative of `getPublicKeyBundle`, but nice for ergonomics
+  getWalletAddress(): Promise<string>
+}

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -21,5 +21,5 @@ export interface Keystore {
   // Used for publishing the contact
   getPublicKeyBundle(): Promise<publicKey.SignedPublicKeyBundle>
   // Technically duplicative of `getPublicKeyBundle`, but nice for ergonomics
-  getWalletAddress(): Promise<string>
+  getAccountAddress(): Promise<string>
 }

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -1,9 +1,4 @@
-import { messageApi } from '@xmtp/proto'
-import Ciphertext from '../crypto/Ciphertext'
-import {
-  SignedPublicKeyBundle,
-  PublicKeyBundle,
-} from '../crypto/PublicKeyBundle'
+import { messageApi, ciphertext, publicKey } from '@xmtp/proto'
 import { InvitationContext } from '../Invitation'
 import { ErrorCode } from './errors'
 
@@ -21,8 +16,8 @@ export type ConversationReference = {
 }
 
 export type DecryptV1Request = {
-  payload: Ciphertext
-  peerKeys: PublicKeyBundle
+  payload: ciphertext.Ciphertext
+  peerKeys: publicKey.PublicKeyBundle
   headerBytes: Uint8Array
   isSender: boolean
 }
@@ -32,7 +27,7 @@ export type DecryptV1Response = ResultOrError<{
 }>
 
 export type DecryptV2Request = {
-  payload: Ciphertext
+  payload: ciphertext.Ciphertext
   headerBytes: Uint8Array
   // Need to include contentTopic for the Keystore to know what topic key to use
   contentTopic: string
@@ -43,13 +38,13 @@ export type DecryptV2Response = ResultOrError<{
 }>
 
 export type EncryptV1Request = {
-  recipient: PublicKeyBundle
+  recipient: publicKey.PublicKeyBundle
   payload: Uint8Array
   headerBytes: Uint8Array
 }
 
 export type EncryptResponse = ResultOrError<{
-  ciphertext: Ciphertext
+  ciphertext: ciphertext.Ciphertext
 }>
 
 export type EncryptV2Request = {
@@ -59,9 +54,9 @@ export type EncryptV2Request = {
 }
 
 export type CreateInviteRequest = {
-  recipient: SignedPublicKeyBundle
+  recipient: publicKey.SignedPublicKeyBundle
   createdAt: Date
-  context: InvitationContext
+  context?: InvitationContext
 }
 
 export type CreateInviteResponse = {
@@ -88,7 +83,7 @@ export interface Keystore {
   // Get V2 conversations
   getV2Conversations(): Promise<ConversationReference[]>
   // Used for publishing the contact
-  getPublicKeyBundle(): Promise<SignedPublicKeyBundle>
+  getPublicKeyBundle(): Promise<publicKey.SignedPublicKeyBundle>
   // Technically duplicative of `getPublicKeyBundle`, but nice for ergonomics
   getWalletAddress(): Promise<string>
 }

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -14,7 +14,9 @@ export const convertError = (
   return new KeystoreError(errorCode, e.message)
 }
 
-type ResultOrError<T> = T | { error: KeystoreError }
+export const wrapResult = <T>(result: T): { result: T } => ({ result })
+
+type ResultOrError<T> = { result: T } | { error: KeystoreError }
 
 // Map an array of items to an array of results or errors
 // Transform any errors thrown into `KeystoreError`s
@@ -28,7 +30,7 @@ export const mapAndConvertErrors = <Input, Output>(
     input.map(async (item: Input) => {
       try {
         // Be sure to await mapper result to catch errors
-        return await mapper(item)
+        return wrapResult(await mapper(item))
       } catch (e) {
         return { error: convertError(e as Error, errorCode) }
       }
@@ -55,5 +57,3 @@ export const toSignedPublicKeyBundle = (
 
   return new SignedPublicKeyBundle(bundle)
 }
-
-export const wrapResult = <T>(result: T): { result: T } => ({ result })

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -1,12 +1,11 @@
-import { publicKey } from '@xmtp/proto'
+import { publicKey, keystore } from '@xmtp/proto'
 import { PublicKeyBundle, SignedPublicKeyBundle } from '../crypto'
-import { ErrorCode, KeystoreError } from './errors'
-import { ResultOrError } from './interfaces'
+import { KeystoreError } from './errors'
 
 export const convertError = (
   e: Error,
   // Default error code to apply to errors that don't have one
-  errorCode: ErrorCode
+  errorCode: keystore.ErrorCode
 ) => {
   if (e instanceof KeystoreError) {
     return e
@@ -15,13 +14,15 @@ export const convertError = (
   return new KeystoreError(errorCode, e.message)
 }
 
+type ResultOrError<T> = T | { error: KeystoreError }
+
 // Map an array of items to an array of results or errors
 // Transform any errors thrown into `KeystoreError`s
 export const mapAndConvertErrors = <Input, Output>(
   input: Input[],
   mapper: (input: Input) => Promise<Output> | Output,
   // Default error code to apply to errors that don't have one
-  errorCode: ErrorCode
+  errorCode: keystore.ErrorCode
 ): Promise<ResultOrError<Output>[]> => {
   return Promise.all(
     input.map(async (item: Input) => {
@@ -29,7 +30,7 @@ export const mapAndConvertErrors = <Input, Output>(
         // Be sure to await mapper result to catch errors
         return await mapper(item)
       } catch (e) {
-        return convertError(e as Error, errorCode)
+        return { error: convertError(e as Error, errorCode) }
       }
     })
   )
@@ -54,3 +55,5 @@ export const toSignedPublicKeyBundle = (
 
   return new SignedPublicKeyBundle(bundle)
 }
+
+export const wrapResult = <T>(result: T): { result: T } => ({ result })

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -1,15 +1,32 @@
+import { publicKey } from '@xmtp/proto'
+import { PublicKeyBundle, SignedPublicKeyBundle } from '../crypto'
 import { ErrorCode, KeystoreError } from './errors'
 import { ResultOrError } from './interfaces'
 
-export function mapAndConvertErrors<Input, Output>(
+export const convertError = (
+  e: Error,
+  // Default error code to apply to errors that don't have one
+  errorCode: ErrorCode
+) => {
+  if (e instanceof KeystoreError) {
+    return e
+  }
+
+  return new KeystoreError(errorCode, e.message)
+}
+
+// Map an array of items to an array of results or errors
+// Transform any errors thrown into `KeystoreError`s
+export const mapAndConvertErrors = <Input, Output>(
   input: Input[],
   mapper: (input: Input) => Promise<Output> | Output,
   // Default error code to apply to errors that don't have one
   errorCode: ErrorCode
-): Promise<ResultOrError<Output>[]> {
+): Promise<ResultOrError<Output>[]> => {
   return Promise.all(
     input.map(async (item: Input) => {
       try {
+        // Be sure to await mapper result to catch errors
         return await mapper(item)
       } catch (e) {
         return convertError(e as Error, errorCode)
@@ -18,14 +35,22 @@ export function mapAndConvertErrors<Input, Output>(
   )
 }
 
-export function convertError(
-  e: Error,
-  // Default error code to apply to errors that don't have one
-  errorCode: ErrorCode
-) {
-  if (e instanceof KeystoreError) {
-    return e
+// Wrap the bundle in our class if not already wrapped
+export const toPublicKeyBundle = (bundle: publicKey.PublicKeyBundle) => {
+  if (bundle instanceof PublicKeyBundle) {
+    return bundle
   }
 
-  return new KeystoreError(errorCode, e.message)
+  return new PublicKeyBundle(bundle)
+}
+
+// Wrap the bundle in our class if not already wrapped
+export const toSignedPublicKeyBundle = (
+  bundle: publicKey.SignedPublicKeyBundle
+) => {
+  if (bundle instanceof SignedPublicKeyBundle) {
+    return bundle
+  }
+
+  return new SignedPublicKeyBundle(bundle)
 }

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -1,0 +1,31 @@
+import { ErrorCode, KeystoreError } from './errors'
+import { ResultOrError } from './interfaces'
+
+export function mapAndConvertErrors<Input, Output>(
+  input: Input[],
+  mapper: (input: Input) => Promise<Output> | Output,
+  // Default error code to apply to errors that don't have one
+  errorCode: ErrorCode
+): Promise<ResultOrError<Output>[]> {
+  return Promise.all(
+    input.map(async (item: Input) => {
+      try {
+        return await mapper(item)
+      } catch (e) {
+        return convertError(e as Error, errorCode)
+      }
+    })
+  )
+}
+
+export function convertError(
+  e: Error,
+  // Default error code to apply to errors that don't have one
+  errorCode: ErrorCode
+) {
+  if (e instanceof KeystoreError) {
+    return e
+  }
+
+  return new KeystoreError(errorCode, e.message)
+}

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -3,7 +3,7 @@ import {
   ConversationV2,
 } from './../../src/conversations/Conversation'
 import { ConversationCache } from '../../src/conversations/Conversations'
-import { newLocalHostClient, waitForUserContact } from './../helpers'
+import { newLocalHostClient, newWallet, waitForUserContact } from './../helpers'
 import { Client } from '../../src'
 import {
   buildDirectMessageTopic,
@@ -398,7 +398,7 @@ describe('conversations', () => {
     })
 
     it('imports from export', async () => {
-      const wallet = Wallet.createRandom()
+      const wallet = newWallet()
       const clientA = await Client.create(wallet, { env: 'local' })
       await Promise.all([
         clientA.conversations

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,4 @@
-import { toNanoString } from './../src/utils'
+import { dateToNs, toNanoString } from './../src/utils'
 import { Wallet } from 'ethers'
 import {
   PrivateKey,
@@ -164,5 +164,17 @@ export const buildEnvelope = (
     contentTopic,
     timestampNs: toNanoString(created),
     message: b64Encode(message, 0, message.length) as unknown as Uint8Array,
+  }
+}
+
+export const buildProtoEnvelope = (
+  payload: Uint8Array,
+  contentTopic: string,
+  timestamp: Date
+) => {
+  return {
+    contentTopic,
+    timestampNs: dateToNs(timestamp),
+    payload,
   }
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -166,10 +166,3 @@ export const buildEnvelope = (
     message: b64Encode(message, 0, message.length) as unknown as Uint8Array,
   }
 }
-
-export const shuffleArray = (array: any[]) => {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[array[i], array[j]] = [array[j], array[i]]
-  }
-}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,3 +1,4 @@
+import { toNanoString } from './../src/utils'
 import { Wallet } from 'ethers'
 import {
   PrivateKey,
@@ -12,6 +13,9 @@ import Stream from '../src/Stream'
 import { promiseWithTimeout } from '../src/utils'
 import assert from 'assert'
 import { PublicKeyBundle, SignedPublicKeyBundle } from '../src/crypto'
+import { messageApi, fetcher } from '@xmtp/proto'
+
+const { b64Encode } = fetcher
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
@@ -150,3 +154,22 @@ export const newDevClient = (opts?: Partial<ClientOptions>): Promise<Client> =>
     env: 'dev',
     ...opts,
   })
+
+export const buildEnvelope = (
+  message: Uint8Array,
+  contentTopic: string,
+  created: Date
+): messageApi.Envelope => {
+  return {
+    contentTopic,
+    timestampNs: toNanoString(created),
+    message: b64Encode(message, 0, message.length) as unknown as Uint8Array,
+  }
+}
+
+export const shuffleArray = (array: any[]) => {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[array[i], array[j]] = [array[j], array[i]]
+  }
+}

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -1,12 +1,8 @@
-import { shuffleArray } from './../helpers'
 import { InvitationContext } from './../../src/Invitation'
-import { toNanoString } from './../../src/utils'
 import { DecryptV1Request } from './../../src/keystore/interfaces'
 import { MessageV1 } from './../../src/Message'
-import { Wallet } from 'ethers'
 import {
   PrivateKeyBundleV1,
-  PublicKeyBundle,
   SignedPublicKeyBundle,
   PrivateKeyBundleV2,
 } from '../../src/crypto'

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -10,11 +10,8 @@ import { KeystoreError } from '../../src/keystore/errors'
 import InMemoryKeystore from '../../src/keystore/InMemoryKeystore'
 import { equalBytes } from '../../src/crypto/utils'
 import { InvitationV1, SealedInvitation } from '../../src/Invitation'
-import { fetcher } from '@xmtp/proto'
 import { buildProtoEnvelope, newWallet } from '../helpers'
 import { dateToNs, nsToDate } from '../../src/utils/date'
-
-const { b64Encode } = fetcher
 
 describe('InMemoryKeystore', () => {
   let aliceKeys: PrivateKeyBundleV1
@@ -423,12 +420,12 @@ describe('InMemoryKeystore', () => {
     })
   })
 
-  describe('getWalletAddress', () => {
+  describe('getAccountAddress', () => {
     it('returns the wallet address', async () => {
       const aliceAddress = aliceKeys
         .getPublicKeyBundle()
         .walletSignatureAddress()
-      const returnedAddress = await aliceKeystore.getWalletAddress()
+      const returnedAddress = await aliceKeystore.getAccountAddress()
 
       expect(aliceAddress).toEqual(returnedAddress)
     })

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -1,0 +1,406 @@
+import { shuffleArray } from './../helpers'
+import { InvitationContext } from './../../src/Invitation'
+import { toNanoString } from './../../src/utils'
+import { DecryptV1Request } from './../../src/keystore/interfaces'
+import { MessageV1 } from './../../src/Message'
+import { Wallet } from 'ethers'
+import {
+  PrivateKeyBundleV1,
+  PublicKeyBundle,
+  SignedPublicKeyBundle,
+  PrivateKeyBundleV2,
+} from '../../src/crypto'
+import { decryptV1 } from '../../src/keystore/encryption'
+import { KeystoreError } from '../../src/keystore/errors'
+import InMemoryKeystore from '../../src/keystore/InMemoryKeystore'
+import { equalBytes } from '../../src/crypto/utils'
+import { InvitationV1, SealedInvitation } from '../../src/Invitation'
+import { fetcher } from '@xmtp/proto'
+import { buildEnvelope, newWallet } from '../helpers'
+
+const { b64Encode } = fetcher
+
+describe('InMemoryKeystore', () => {
+  let aliceKeys: PrivateKeyBundleV1
+  let aliceKeystore: InMemoryKeystore
+  let bobKeys: PrivateKeyBundleV1
+  let bobKeystore: InMemoryKeystore
+
+  beforeEach(async () => {
+    aliceKeys = await PrivateKeyBundleV1.generate(newWallet())
+    aliceKeystore = new InMemoryKeystore(aliceKeys)
+    bobKeys = await PrivateKeyBundleV1.generate(newWallet())
+    bobKeystore = new InMemoryKeystore(bobKeys)
+  })
+
+  const buildInvite = async (context?: InvitationContext) => {
+    const invite = InvitationV1.createRandom(context)
+    const created = new Date()
+    const sealed = await SealedInvitation.createV1({
+      sender: PrivateKeyBundleV2.fromLegacyBundle(aliceKeys),
+      recipient: SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      ),
+      invitation: invite,
+      created,
+    })
+
+    return { invite, created, sealed }
+  }
+
+  describe('encryptV1', () => {
+    it('can encrypt a batch of valid messages', async () => {
+      const messages = Array.from({ length: 10 }, (v: unknown, i: number) =>
+        new TextEncoder().encode(`message ${i}`)
+      )
+
+      const headerBytes = new Uint8Array(10)
+
+      const req = messages.map((msg) => ({
+        recipient: bobKeys.getPublicKeyBundle(),
+        payload: msg,
+        headerBytes,
+      }))
+
+      const res = await aliceKeystore.encryptV1(req)
+      expect(res).toHaveLength(req.length)
+      for (const item of res) {
+        if ('error' in item) {
+          throw new Error(item.error)
+        }
+        expect(item).toHaveProperty('ciphertext')
+        expect(item.ciphertext.aes256GcmHkdfSha256?.gcmNonce).toBeTruthy()
+        expect(item.ciphertext.aes256GcmHkdfSha256?.hkdfSalt).toBeTruthy()
+        expect(item.ciphertext.aes256GcmHkdfSha256?.payload).toBeTruthy()
+
+        // Ensure decryption doesn't throw
+        await decryptV1(
+          aliceKeys,
+          bobKeys.getPublicKeyBundle(),
+          item.ciphertext,
+          headerBytes,
+          true
+        )
+      }
+    })
+
+    it('fails to encrypt with invalid params', async () => {
+      const req = [
+        {
+          recipient: {},
+          payload: new Uint8Array(10),
+          headerBytes: new Uint8Array(10),
+        },
+      ]
+
+      // @ts-expect-error
+      const res = await aliceKeystore.encryptV1(req)
+
+      expect(res).toHaveLength(req.length)
+      expect(res[0]).toHaveProperty('error')
+      expect(res[0]).toHaveProperty('code')
+      expect(res[0]).toBeInstanceOf(KeystoreError)
+    })
+  })
+
+  describe('decryptV1', () => {
+    it('can decrypt a valid message', async () => {
+      const msg = new TextEncoder().encode('Hello, world!')
+      const peerKeys = bobKeys.getPublicKeyBundle()
+      const message = await MessageV1.encode(
+        aliceKeys,
+        peerKeys,
+        msg,
+        new Date()
+      )
+
+      const req: DecryptV1Request[] = [
+        {
+          payload: message.ciphertext,
+          peerKeys,
+          headerBytes: message.headerBytes,
+          isSender: true,
+        },
+      ]
+
+      const res = await aliceKeystore.decryptV1(req)
+
+      expect(res).toHaveLength(req.length)
+      if ('error' in res[0]) {
+        throw res[0]
+      }
+      expect(equalBytes(res[0].decrypted, msg)).toBe(true)
+    })
+
+    it('fails to decrypt an invalid message', async () => {
+      const msg = new TextEncoder().encode('Hello, world!')
+      const charlieKeys = await PrivateKeyBundleV1.generate(newWallet())
+      const message = await MessageV1.encode(
+        aliceKeys,
+        charlieKeys.getPublicKeyBundle(),
+        msg,
+        new Date()
+      )
+
+      const req: DecryptV1Request[] = [
+        {
+          payload: message.ciphertext,
+          peerKeys: bobKeys.getPublicKeyBundle(),
+          headerBytes: message.headerBytes,
+          isSender: true,
+        },
+      ]
+
+      const res = await aliceKeystore.decryptV1(req)
+
+      expect(res).toHaveLength(req.length)
+
+      if (!('error' in res[0])) {
+        throw new Error('should have errored')
+      }
+      expect(res[0]).toHaveProperty('error')
+    })
+  })
+
+  describe('createInvite', () => {
+    it('creates a valid invite with no context', async () => {
+      const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      )
+      const createdAt = new Date()
+      const response = await aliceKeystore.createInvite({
+        recipient,
+        createdAt,
+      })
+
+      expect(response.conversation.topic).toBeTruthy()
+      expect(response.conversation.context).toBeUndefined()
+      expect(response.conversation.createdAt.getTime()).toEqual(
+        createdAt.getTime()
+      )
+      expect(response.payload).toBeInstanceOf(Uint8Array)
+    })
+
+    it('creates a valid invite with context', async () => {
+      const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      )
+      const createdAt = new Date()
+      const context = { conversationId: 'xmtp.org/foo', metadata: {} }
+      const response = await aliceKeystore.createInvite({
+        recipient,
+        createdAt,
+        context,
+      })
+
+      expect(response.conversation.topic).toBeTruthy()
+      expect(response.conversation.context).toEqual(context)
+    })
+
+    it('throws if an invalid recipient is included', async () => {
+      const createdAt = new Date()
+      expect(async () => {
+        await aliceKeystore.createInvite({
+          recipient: {} as any,
+          createdAt,
+        })
+      }).rejects.toThrow(KeystoreError)
+    })
+  })
+
+  describe('saveInvites', () => {
+    it('can save a batch of valid envelopes', async () => {
+      const { invite, created, sealed } = await buildInvite()
+
+      const sealedBytes = sealed.toBytes()
+      const envelope = buildEnvelope(sealedBytes, 'foo', created)
+      const response = await bobKeystore.saveInvites([envelope])
+
+      expect(response).toHaveLength(1)
+      const firstResult = response[0]
+      if ('error' in firstResult) {
+        throw firstResult
+      }
+      expect(firstResult.createdAt.getTime()).toEqual(created.getTime())
+      expect(firstResult.topic).toEqual(invite.topic)
+      expect(firstResult.context).toBeUndefined()
+
+      const conversations = await bobKeystore.getV2Conversations()
+      expect(conversations).toHaveLength(1)
+      expect(conversations[0].topic).toBe(invite.topic)
+    })
+
+    it('can save received invites', async () => {
+      const { invite, created, sealed } = await buildInvite()
+
+      const sealedBytes = sealed.toBytes()
+      const envelope = buildEnvelope(sealedBytes, 'foo', created)
+
+      const [aliceResponse] = await aliceKeystore.saveInvites([envelope])
+      if ('error' in aliceResponse) {
+        throw aliceResponse
+      }
+
+      const aliceConversations = await aliceKeystore.getV2Conversations()
+      expect(aliceConversations).toHaveLength(1)
+
+      const [bobResponse] = await bobKeystore.saveInvites([envelope])
+      if ('error' in bobResponse) {
+        throw bobResponse
+      }
+
+      const bobConversations = await bobKeystore.getV2Conversations()
+      expect(bobConversations).toHaveLength(1)
+    })
+
+    it('ignores bad envelopes', async () => {
+      const conversationId = 'xmtp.org/foo'
+      const { invite, created, sealed } = await buildInvite({
+        conversationId,
+        metadata: {},
+      })
+      const envelopes = [
+        buildEnvelope(new Uint8Array(10), 'bar', new Date()),
+        buildEnvelope(sealed.toBytes(), 'foo', created),
+      ]
+
+      const response = await bobKeystore.saveInvites(envelopes)
+      expect(response).toHaveLength(2)
+
+      const [firstResult, secondResult] = response
+      if (!('error' in firstResult)) {
+        fail('should have errored')
+      }
+      expect(firstResult).toBeInstanceOf(KeystoreError)
+
+      if ('error' in secondResult) {
+        fail('should not have errored')
+      }
+      expect(secondResult.createdAt.getTime()).toEqual(created.getTime())
+      expect(secondResult.topic).toEqual(invite.topic)
+      expect(secondResult.context?.conversationId).toEqual(conversationId)
+    })
+  })
+
+  describe('encryptV2/decryptV2', () => {
+    it('encrypts using a saved envelope', async () => {
+      const { invite, created, sealed } = await buildInvite()
+
+      const sealedBytes = sealed.toBytes()
+      const envelope = buildEnvelope(sealedBytes, 'foo', created)
+      await aliceKeystore.saveInvites([envelope])
+
+      const message = new TextEncoder().encode('Hello, world!')
+      const headerBytes = new Uint8Array(10)
+
+      const [encrypted] = await aliceKeystore.encryptV2([
+        {
+          contentTopic: invite.topic,
+          message,
+          headerBytes,
+        },
+      ])
+
+      if ('error' in encrypted) {
+        throw encrypted
+      }
+
+      expect(encrypted.ciphertext).toBeTruthy()
+    })
+
+    it('round trips using a created invite', async () => {
+      const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      )
+      const createdAt = new Date()
+      const response = await aliceKeystore.createInvite({
+        recipient,
+        createdAt,
+      })
+
+      const message = new TextEncoder().encode('Hello, world!')
+      const headerBytes = new Uint8Array(10)
+
+      const [encrypted] = await aliceKeystore.encryptV2([
+        {
+          contentTopic: response.conversation.topic,
+          message,
+          headerBytes,
+        },
+      ])
+
+      if ('error' in encrypted) {
+        throw encrypted
+      }
+
+      expect(encrypted.ciphertext).toBeTruthy()
+
+      const [decrypted] = await aliceKeystore.decryptV2([
+        {
+          payload: encrypted.ciphertext,
+          headerBytes,
+          contentTopic: response.conversation.topic,
+        },
+      ])
+
+      if ('error' in decrypted) {
+        throw decrypted
+      }
+
+      expect(equalBytes(message, decrypted.decrypted)).toBeTruthy()
+    })
+  })
+
+  describe('getV2Conversations', () => {
+    it('correctly sorts conversations', async () => {
+      const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      )
+      const baseTime = new Date()
+      const timestamps = Array.from(
+        { length: 25 },
+        (_, i) => new Date(baseTime.getTime() + i)
+      )
+
+      // Shuffle the order they go into the store
+      const shuffled = [...timestamps].sort(() => Math.random() - 0.5)
+
+      const invites = Promise.all(
+        shuffled.map((createdAt) => {
+          return aliceKeystore.createInvite({
+            recipient,
+            createdAt,
+          })
+        })
+      )
+
+      const convos = await aliceKeystore.getV2Conversations()
+      for (let i = 0; i < convos.length; i++) {
+        expect(convos[i].createdAt.getTime()).toEqual(timestamps[i].getTime())
+      }
+    })
+  })
+
+  describe('getPublicKeyBundle', () => {
+    it('can retrieve a valid bundle', async () => {
+      const bundle = await aliceKeystore.getPublicKeyBundle()
+      const wrappedBundle = new SignedPublicKeyBundle(bundle)
+      expect(
+        wrappedBundle.equals(
+          SignedPublicKeyBundle.fromLegacyBundle(aliceKeys.getPublicKeyBundle())
+        )
+      )
+    })
+  })
+
+  describe('getWalletAddress', () => {
+    it('returns the wallet address', async () => {
+      const aliceAddress = aliceKeys
+        .getPublicKeyBundle()
+        .walletSignatureAddress()
+      const returnedAddress = await aliceKeystore.getWalletAddress()
+
+      expect(aliceAddress).toEqual(returnedAddress)
+    })
+  })
+})

--- a/test/keystore/encryption.test.ts
+++ b/test/keystore/encryption.test.ts
@@ -1,0 +1,44 @@
+import { buildDirectMessageTopic } from './../../src/utils/topic'
+import { PrivateKeyBundleV1 } from './../../src/crypto/PrivateKeyBundle'
+import { decryptV1 } from '../../src/keystore/encryption'
+import { MessageV1 } from '../../src/Message'
+import { Wallet } from 'ethers'
+import { equalBytes } from '../../src/crypto/utils'
+
+describe('encryption primitives', () => {
+  let aliceKeys: PrivateKeyBundleV1
+  let aliceWallet: Wallet
+  let bobKeys: PrivateKeyBundleV1
+  let bobWallet: Wallet
+
+  beforeEach(async () => {
+    aliceWallet = Wallet.createRandom()
+    aliceKeys = await PrivateKeyBundleV1.generate(aliceWallet)
+    bobWallet = Wallet.createRandom()
+    bobKeys = await PrivateKeyBundleV1.generate(bobWallet)
+  })
+
+  describe('decryptV1', () => {
+    it('should decrypt a valid payload', async () => {
+      const message = new TextEncoder().encode('Hello world')
+      const topic = buildDirectMessageTopic(
+        aliceWallet.address,
+        bobWallet.address
+      )
+      const encryptedPayload = (
+        await MessageV1.encode(
+          aliceKeys,
+          bobKeys.getPublicKeyBundle(),
+          message,
+          new Date()
+        )
+      ).toBytes()
+
+      const aliceDecrypted = await decryptV1(aliceKeys, encryptedPayload, topic)
+      expect(equalBytes(aliceDecrypted, message)).toBeTruthy()
+
+      const bobDecrypted = await decryptV1(bobKeys, encryptedPayload, topic)
+      expect(equalBytes(bobDecrypted, message)).toBeTruthy()
+    })
+  })
+})

--- a/test/keystore/encryption.test.ts
+++ b/test/keystore/encryption.test.ts
@@ -21,24 +21,30 @@ describe('encryption primitives', () => {
   describe('decryptV1', () => {
     it('should decrypt a valid payload', async () => {
       const message = new TextEncoder().encode('Hello world')
-      const topic = buildDirectMessageTopic(
-        aliceWallet.address,
-        bobWallet.address
+      const payload = await MessageV1.encode(
+        aliceKeys,
+        bobKeys.getPublicKeyBundle(),
+        message,
+        new Date()
       )
-      const encryptedPayload = (
-        await MessageV1.encode(
-          aliceKeys,
-          bobKeys.getPublicKeyBundle(),
-          message,
-          new Date()
-        )
-      ).toBytes()
 
-      const aliceDecrypted = await decryptV1(aliceKeys, encryptedPayload, topic)
-      expect(equalBytes(aliceDecrypted, message)).toBeTruthy()
+      const aliceDecrypted = await decryptV1(
+        aliceKeys,
+        bobKeys.getPublicKeyBundle(),
+        payload.ciphertext,
+        payload.headerBytes,
+        true
+      )
 
-      const bobDecrypted = await decryptV1(bobKeys, encryptedPayload, topic)
-      expect(equalBytes(bobDecrypted, message)).toBeTruthy()
+      const bobDecrypted = await decryptV1(
+        bobKeys,
+        aliceKeys.getPublicKeyBundle(),
+        payload.ciphertext,
+        payload.headerBytes,
+        false
+      )
+
+      expect(equalBytes(aliceDecrypted, bobDecrypted)).toBeTruthy()
     })
   })
 })

--- a/test/keystore/encryption.test.ts
+++ b/test/keystore/encryption.test.ts
@@ -1,9 +1,10 @@
-import { buildDirectMessageTopic } from './../../src/utils/topic'
+import { Ciphertext } from '../../src/crypto'
 import { PrivateKeyBundleV1 } from './../../src/crypto/PrivateKeyBundle'
-import { decryptV1 } from '../../src/keystore/encryption'
+import { decryptV1, encryptV1 } from '../../src/keystore/encryption'
 import { MessageV1 } from '../../src/Message'
 import { Wallet } from 'ethers'
 import { equalBytes } from '../../src/crypto/utils'
+import { newWallet } from '../helpers'
 
 describe('encryption primitives', () => {
   let aliceKeys: PrivateKeyBundleV1
@@ -12,15 +13,16 @@ describe('encryption primitives', () => {
   let bobWallet: Wallet
 
   beforeEach(async () => {
-    aliceWallet = Wallet.createRandom()
+    aliceWallet = newWallet()
     aliceKeys = await PrivateKeyBundleV1.generate(aliceWallet)
-    bobWallet = Wallet.createRandom()
+    bobWallet = newWallet()
     bobKeys = await PrivateKeyBundleV1.generate(bobWallet)
   })
 
   describe('decryptV1', () => {
     it('should decrypt a valid payload', async () => {
-      const message = new TextEncoder().encode('Hello world')
+      const messageText = 'Hello, world!'
+      const message = new TextEncoder().encode(messageText)
       const payload = await MessageV1.encode(
         aliceKeys,
         bobKeys.getPublicKeyBundle(),
@@ -35,6 +37,7 @@ describe('encryption primitives', () => {
         payload.headerBytes,
         true
       )
+      expect(new TextDecoder().decode(aliceDecrypted)).toEqual(messageText)
 
       const bobDecrypted = await decryptV1(
         bobKeys,
@@ -43,8 +46,57 @@ describe('encryption primitives', () => {
         payload.headerBytes,
         false
       )
+      expect(new TextDecoder().decode(bobDecrypted)).toEqual(messageText)
 
       expect(equalBytes(aliceDecrypted, bobDecrypted)).toBeTruthy()
+    })
+
+    it('fails to decrypt when wrong keys are used', async () => {
+      const message = new TextEncoder().encode('should fail')
+      const payload = await MessageV1.encode(
+        aliceKeys,
+        bobKeys.getPublicKeyBundle(),
+        message,
+        new Date()
+      )
+      const charlieKeys = await PrivateKeyBundleV1.generate(
+        Wallet.createRandom()
+      )
+
+      expect(async () => {
+        await decryptV1(
+          charlieKeys,
+          bobKeys.getPublicKeyBundle(),
+          payload.ciphertext,
+          payload.headerBytes,
+          true
+        )
+      }).rejects.toThrow()
+    })
+  })
+
+  describe('encryptV1', () => {
+    it('should round trip a valid payload', async () => {
+      const messageText = 'Hello, world!'
+      const message = new TextEncoder().encode(messageText)
+      const headerBytes = new Uint8Array(5)
+
+      const ciphertext = await encryptV1(
+        aliceKeys,
+        bobKeys.getPublicKeyBundle(),
+        message,
+        headerBytes
+      )
+      expect(ciphertext).toBeInstanceOf(Ciphertext)
+
+      const decrypted = await decryptV1(
+        aliceKeys,
+        bobKeys.getPublicKeyBundle(),
+        ciphertext,
+        headerBytes,
+        true
+      )
+      expect(equalBytes(message, decrypted)).toBeTruthy()
     })
   })
 })

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from 'ethers'
 
-import { newWallet, sleep } from '../helpers'
+import { newWallet, pollFor, sleep } from '../helpers'
 import { PrivateTopicStore } from '../../src/store'
 import ApiClient, { ApiUrls } from '../../src/ApiClient'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
@@ -43,8 +43,17 @@ describe('PrivateTopicStore', () => {
         expect(empty).toBeNull()
 
         await store.set(key, Buffer.from(value))
-        await sleep(100)
-        const full = await store.get(key)
+        const full = await pollFor(
+          async () => {
+            const full = await store.get(key)
+            if (!full) {
+              throw new Error('not found')
+            }
+            return full
+          },
+          500,
+          50
+        )
 
         expect(full).toBeDefined()
         expect(full).toEqual(Buffer.from(value))

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -1,6 +1,6 @@
 import { Wallet } from 'ethers'
 
-import { newWallet, pollFor, sleep } from '../helpers'
+import { newWallet, pollFor } from '../helpers'
 import { PrivateTopicStore } from '../../src/store'
 import ApiClient, { ApiUrls } from '../../src/ApiClient'
 import { PrivateKeyBundleV1 } from '../../src/crypto'


### PR DESCRIPTION
## Summary
- Creates Typescript interfaces for Keystore API
- Initial implementation of InMemoryKeystore
- Wrote a bunch of tests for the InMemoryKeystore
- Initial version of `KeystoreError` type
- Uses the new Protobuf Keystore request/response types

## Notes
- One of the things I want to do here is wrap all errors in a `KeystoreError` which always includes an error code. This way we can normalize errors coming from "over the wire" sources like the MM Snap and errors coming from the same process. Over time my goal is to refactor the code to throw `KeystoreError`s directly
- This will likely be the last PR against `main` on the Keystore project until V8.0. The next steps involve breaking changes.

WDYT protopod?

## Next steps
- Start replacing usage of `PrivateKeyBundle` in the SDK with calls to `InMemoryKeystore`