### PR TITLE
fix: allow backwards compatibility with ledger enableidentity signatures

### DIFF
--- a/test/store/store.test.ts
+++ b/test/store/store.test.ts
@@ -2,7 +2,7 @@ import { Wallet } from 'ethers'
 import { EncryptedKeyStore, PrivateTopicStore } from '../../src/store'
 import assert from 'assert'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
-import { newWallet, sleep } from '../helpers'
+import { newWallet, sleep, wrapAsLedgerWallet } from '../helpers'
 import ApiClient, { ApiUrls } from '../../src/ApiClient'
 
 describe('EncryptedKeyStore', () => {
@@ -21,6 +21,52 @@ describe('EncryptedKeyStore', () => {
     await secureStore.storePrivateKeyBundle(originalBundle)
     await sleep(100)
     const returnedBundle = await secureStore.loadPrivateKeyBundle()
+
+    assert.ok(returnedBundle)
+    assert.deepEqual(
+      originalBundle.identityKey.toBytes(),
+      returnedBundle.identityKey.toBytes()
+    )
+    assert.equal(originalBundle.preKeys.length, returnedBundle.preKeys.length)
+    assert.deepEqual(
+      originalBundle.preKeys[0].toBytes(),
+      returnedBundle.preKeys[0].toBytes()
+    )
+  })
+
+  it('can encrypt with Ledger and decrypt with Metamask', async () => {
+    const wallet = newWallet()
+    const ledgerLikeWallet = wrapAsLedgerWallet(wallet)
+    const secureLedgerStore = new EncryptedKeyStore(ledgerLikeWallet, store)
+    const secureNormalStore = new EncryptedKeyStore(wallet, store)
+    const originalBundle = await PrivateKeyBundleV1.generate(ledgerLikeWallet)
+
+    await secureLedgerStore.storePrivateKeyBundle(originalBundle)
+    await sleep(100)
+    const returnedBundle = await secureNormalStore.loadPrivateKeyBundle()
+
+    assert.ok(returnedBundle)
+    assert.deepEqual(
+      originalBundle.identityKey.toBytes(),
+      returnedBundle.identityKey.toBytes()
+    )
+    assert.equal(originalBundle.preKeys.length, returnedBundle.preKeys.length)
+    assert.deepEqual(
+      originalBundle.preKeys[0].toBytes(),
+      returnedBundle.preKeys[0].toBytes()
+    )
+  })
+
+  it('can encrypt with Metamask and decrypt with Ledger', async () => {
+    const wallet = newWallet()
+    const ledgerLikeWallet = wrapAsLedgerWallet(wallet)
+    const secureLedgerStore = new EncryptedKeyStore(ledgerLikeWallet, store)
+    const secureNormalStore = new EncryptedKeyStore(wallet, store)
+    const originalBundle = await PrivateKeyBundleV1.generate(wallet)
+
+    await secureNormalStore.storePrivateKeyBundle(originalBundle)
+    await sleep(100)
+    const returnedBundle = await secureLedgerStore.loadPrivateKeyBundle()
 
     assert.ok(returnedBundle)
     assert.deepEqual(


### PR DESCRIPTION
References: https://github.com/xmtp-labs/hq/issues/834

**Background**

XMTP uses a specific signature as secret material to protect the encrypted store. The signature is a `secp256k1` ECDSA signature, with `r,s` encoded into 64 bytes (32 each). There is a 65th byte though, which is the "recovery id". This allows verifiers to recover the public key unambiguously from the signature and the signed message.

Unfortunately, it's [documented](https://ethereum.stackexchange.com/questions/111610/how-do-ledger-hardware-wallet-signatures-differ-from-web3-eth-personal-sign) that Ledger in personal signatures uses a canonical version of the recovery id which starts at `v=0`. Whereas Metamask normally uses `v+27` as the recovery id.

**Problem**

If a user creates and encrypts their identity bundle with one format (Ledger canonical) and then attempts to use XMTP with another wallet provider, the encryption key will not be a match.

Example signatures:
```
Ledger: 192deeb77a01e8a9daaa41f4ac603b1e434121fd69a4f51317a0e8513b23799555aa94c3375a1cd8b4579d14a1b20f91c20f5385217de7c502b7803528c3c38c01

Metamask: 192deeb77a01e8a9daaa41f4ac603b1e434121fd69a4f51317a0e8513b23799555aa94c3375a1cd8b4579d14a1b20f91c20f5385217de7c502b7803528c3c38c1c
```

**Solution**

Luckily there are only two cases we need to consider, canonical and not. We can try both during decryption.

**Test Cases**
- Added a new unit test case
- If I remove the new code, the test case fails

