### PR TITLE
WIP: feat: decouple encode/decode from conversation

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -1,13 +1,20 @@
 import {
-  buildUserIntroTopic,
   buildDirectMessageTopic,
+  buildUserIntroTopic,
   dateToNs,
   nsToDate,
 } from '../utils'
 import { utils } from 'ethers'
-import { DecodedMessage } from './../Message'
+import {
+  decodeContent,
+  DecodedMessage,
+  DecodedMessageExport,
+  MessageV1,
+  MessageV2,
+} from '../Message'
 import Stream from '../Stream'
 import Client, {
+  encodeContent,
   ListMessagesOptions,
   ListMessagesPaginatedOptions,
   SendOptions,
@@ -17,18 +24,28 @@ import {
   InvitationV1,
   SealedInvitationHeaderV1,
 } from '../Invitation'
-import { MessageV1, MessageV2, decodeContent } from '../Message'
-import { messageApi, message, content as proto, fetcher } from '@xmtp/proto'
 import {
-  encrypt,
+  content as proto,
+  fetcher,
+  message,
+  messageApi,
+  privateKey as privateKeyProto,
+  publicKey,
+} from '@xmtp/proto'
+import {
   decrypt,
-  SignedPublicKey,
-  Signature,
+  encrypt,
+  PrivateKeyBundleV1,
+  PrivateKeyBundleV2,
   PublicKeyBundle,
+  Signature,
+  SignedPublicKey,
 } from '../crypto'
 import Ciphertext from '../crypto/Ciphertext'
 import { sha256 } from '../crypto/encryption'
 import { ContentTypeText } from '../codecs/Text'
+import { CodecRegistry } from '../MessageContent'
+
 const { b64Decode } = fetcher
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
@@ -37,6 +54,7 @@ type ConversationV1Export = {
   version: 'v1'
   peerAddress: string
   createdAt: string
+  topic: string
 }
 
 type ConversationV2Export = {
@@ -58,11 +76,17 @@ export class ConversationV1 {
   createdAt: Date
   context = null
   private client: Client
+  readonly topic: string
 
   constructor(client: Client, address: string, createdAt: Date) {
     this.peerAddress = utils.getAddress(address)
     this.client = client
     this.createdAt = createdAt
+    this.topic = buildDirectMessageTopic(this.peerAddress, this.client.address)
+  }
+
+  getClient(): Client {
+    return this.client
   }
 
   /**
@@ -77,10 +101,6 @@ export class ConversationV1 {
       this.decodeMessage.bind(this),
       opts
     )
-  }
-
-  get topic(): string {
-    return buildDirectMessageTopic(this.peerAddress, this.client.address)
   }
 
   messagesPaginated(
@@ -109,6 +129,7 @@ export class ConversationV1 {
       version: 'v1',
       peerAddress: this.peerAddress,
       createdAt: this.createdAt.toISOString(),
+      topic: this.topic,
     }
   }
 
@@ -123,37 +144,14 @@ export class ConversationV1 {
     )
   }
 
-  async decodeMessage({
-    message,
-    contentTopic,
-  }: messageApi.Envelope): Promise<DecodedMessage> {
-    const messageBytes = fetcher.b64Decode(message as unknown as string)
-    const decoded = await MessageV1.fromBytes(messageBytes)
-    const { senderAddress, recipientAddress } = decoded
-
-    // Filter for topics
-    if (
-      !senderAddress ||
-      !recipientAddress ||
-      !contentTopic ||
-      buildDirectMessageTopic(senderAddress, recipientAddress) !== this.topic
-    ) {
-      throw new Error('Headers do not match intended recipient')
-    }
-    const decrypted = await decoded.decrypt(this.client.legacyKeys)
-    const { content, contentType, error } = await decodeContent(
-      decrypted,
-      this.client
+  async decodeMessage(envelope: messageApi.Envelope): Promise<DecodedMessage> {
+    const dme = await decodeMessageV1(
+      envelope,
+      this.export(),
+      this.client,
+      this.client.legacyKeys
     )
-
-    return DecodedMessage.fromV1Message(
-      decoded,
-      content,
-      contentType,
-      contentTopic,
-      this,
-      error
-    )
+    return DecodedMessage.fromExport(dme, this)
   }
 
   /**
@@ -184,13 +182,12 @@ export class ConversationV1 {
     }
 
     const contentType = options?.contentType || ContentTypeText
-    const timestamp = options?.timestamp || new Date()
-    const payload = await this.client.encodeContent(content, options)
-    const msg = await MessageV1.encode(
+    const msg = await encodeMessageV1(
+      content,
       this.client.legacyKeys,
       recipient,
-      payload,
-      timestamp
+      this.client,
+      options
     )
 
     await this.client.publishEnvelopes(
@@ -237,6 +234,10 @@ export class ConversationV2 {
     this.context = context
     this.client = client
     this.peerAddress = peerAddress
+  }
+
+  getClient(): Client {
+    return this.client
   }
 
   static async create(
@@ -324,82 +325,18 @@ export class ConversationV2 {
     content: any,
     options?: SendOptions
   ): Promise<MessageV2> {
-    const payload = await this.client.encodeContent(content, options)
-    const header: message.MessageHeaderV2 = {
-      topic: this.topic,
-      createdNs: dateToNs(options?.timestamp || new Date()),
-    }
-    const headerBytes = message.MessageHeaderV2.encode(header).finish()
-    const digest = await sha256(concat(headerBytes, payload))
-    const signed = {
-      payload,
-      sender: this.client.keys.getPublicKeyBundle(),
-      signature: await this.client.keys.getCurrentPreKey().sign(digest),
-    }
-    const signedBytes = proto.SignedContent.encode(signed).finish()
-    const ciphertext = await encrypt(signedBytes, this.keyMaterial, headerBytes)
-    const protoMsg = {
-      v1: undefined,
-      v2: { headerBytes, ciphertext },
-    }
-    const bytes = message.Message.encode(protoMsg).finish()
-    return MessageV2.create(protoMsg, header, signed, bytes)
+    return encodeMessageV2(
+      content,
+      this.export(),
+      this.client.keys,
+      this.client,
+      options
+    )
   }
 
   async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage> {
-    if (!env.message || !env.contentTopic) {
-      throw new Error('empty envelope')
-    }
-    const messageBytes = b64Decode(env.message.toString())
-    const msg = message.Message.decode(messageBytes)
-    if (!msg.v2) {
-      throw new Error('unknown message version')
-    }
-    const msgv2 = msg.v2
-    const header = message.MessageHeaderV2.decode(msgv2.headerBytes)
-    if (header.topic !== this.topic) {
-      throw new Error('topic mismatch')
-    }
-    if (!msgv2.ciphertext) {
-      throw new Error('missing ciphertext')
-    }
-    const decrypted = await decrypt(
-      new Ciphertext(msgv2.ciphertext),
-      this.keyMaterial,
-      msgv2.headerBytes
-    )
-    const signed = proto.SignedContent.decode(decrypted)
-    if (
-      !signed.sender?.identityKey ||
-      !signed.sender?.preKey ||
-      !signed.signature
-    ) {
-      throw new Error('incomplete signed content')
-    }
-
-    const digest = await sha256(concat(msgv2.headerBytes, signed.payload))
-    if (
-      !new SignedPublicKey(signed.sender?.preKey).verify(
-        new Signature(signed.signature),
-        digest
-      )
-    ) {
-      throw new Error('invalid signature')
-    }
-    const messageV2 = await MessageV2.create(msg, header, signed, messageBytes)
-    const { content, contentType, error } = await decodeContent(
-      signed.payload,
-      this.client
-    )
-
-    return DecodedMessage.fromV2Message(
-      messageV2,
-      content,
-      contentType,
-      env.contentTopic,
-      this,
-      error
-    )
+    const dme = await decodeMessageV2(env, this.export(), this.client)
+    return DecodedMessage.fromExport(dme, this)
   }
 
   export(): ConversationV2Export {
@@ -430,9 +367,171 @@ export class ConversationV2 {
 
 export type Conversation = ConversationV1 | ConversationV2
 
+export const conversationFromExport = (
+  data: ConversationExport,
+  client: Client
+): Conversation => {
+  switch (data.version) {
+    case 'v1':
+      return ConversationV1.fromExport(client, data)
+    case 'v2':
+      return ConversationV2.fromExport(client, data)
+    default:
+      throw new Error('unknown conversation version')
+  }
+}
+
 function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
   const ab = new Uint8Array(a.length + b.length)
   ab.set(a)
   ab.set(b, a.length)
   return ab
+}
+
+export async function decodeMessageV1(
+  envelope: messageApi.Envelope,
+  conversation: ConversationV1Export,
+  registry: CodecRegistry,
+  keys: privateKeyProto.PrivateKeyBundleV1
+): Promise<DecodedMessageExport> {
+  const legacyKeys = PrivateKeyBundleV1.from(keys)
+  const { message, contentTopic } = envelope
+  const messageBytes = fetcher.b64Decode(message as unknown as string)
+  const decoded = await MessageV1.fromBytes(messageBytes)
+  const { senderAddress, recipientAddress } = decoded
+
+  // Filter for topics
+  if (
+    !senderAddress ||
+    !recipientAddress ||
+    !contentTopic ||
+    buildDirectMessageTopic(senderAddress, recipientAddress) !==
+      conversation.topic
+  ) {
+    throw new Error('Headers do not match intended recipient')
+  }
+  const decrypted = await decoded.decrypt(legacyKeys)
+  const { content, contentType, error } = await decodeContent(
+    decrypted,
+    registry
+  )
+
+  return DecodedMessage.exportFromV1Message(
+    decoded,
+    content,
+    contentType,
+    contentTopic,
+    conversation,
+    error
+  )
+}
+
+export async function decodeMessageV2(
+  env: messageApi.Envelope,
+  conversation: ConversationV2Export,
+  registry: CodecRegistry
+): Promise<DecodedMessageExport> {
+  if (!env.message || !env.contentTopic) {
+    throw new Error('empty envelope')
+  }
+  const messageBytes = b64Decode(env.message.toString())
+  const msg = message.Message.decode(messageBytes)
+  if (!msg.v2) {
+    throw new Error('unknown message version')
+  }
+  const msgv2 = msg.v2
+  const header = message.MessageHeaderV2.decode(msgv2.headerBytes)
+  if (header.topic !== conversation.topic) {
+    throw new Error('topic mismatch')
+  }
+  if (!msgv2.ciphertext) {
+    throw new Error('missing ciphertext')
+  }
+  const decrypted = await decrypt(
+    new Ciphertext(msgv2.ciphertext),
+    conversation.keyMaterial,
+    msgv2.headerBytes
+  )
+  const signed = proto.SignedContent.decode(decrypted)
+  if (
+    !signed.sender?.identityKey ||
+    !signed.sender?.preKey ||
+    !signed.signature
+  ) {
+    throw new Error('incomplete signed content')
+  }
+
+  const digest = await sha256(concat(msgv2.headerBytes, signed.payload))
+  if (
+    !new SignedPublicKey(signed.sender?.preKey).verify(
+      new Signature(signed.signature),
+      digest
+    )
+  ) {
+    throw new Error('invalid signature')
+  }
+  const messageV2 = await MessageV2.create(msg, header, signed, messageBytes)
+  const { content, contentType, error } = await decodeContent(
+    signed.payload,
+    registry
+  )
+
+  return DecodedMessage.exportFromV2Message(
+    messageV2,
+    content,
+    contentType,
+    env.contentTopic,
+    conversation,
+    error
+  )
+}
+
+export async function encodeMessageV1(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any,
+  senderBundle: privateKeyProto.PrivateKeyBundleV1,
+  recipientBundle: publicKey.PublicKeyBundle,
+  registry: CodecRegistry,
+  options?: SendOptions
+): Promise<MessageV1> {
+  const sender = PrivateKeyBundleV1.from(senderBundle)
+  const recipient = PublicKeyBundle.from(recipientBundle)
+  const timestamp = options?.timestamp || new Date()
+  const payload = await encodeContent(content, registry, options)
+  return MessageV1.encode(sender, recipient, payload, timestamp)
+}
+
+export async function encodeMessageV2(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any,
+  conversation: ConversationV2Export,
+  keyBundleV2: privateKeyProto.PrivateKeyBundleV2,
+  registry: CodecRegistry,
+  options?: SendOptions
+): Promise<MessageV2> {
+  const keys = PrivateKeyBundleV2.from(keyBundleV2)
+  const payload = await encodeContent(content, registry, options)
+  const header: message.MessageHeaderV2 = {
+    topic: conversation.topic,
+    createdNs: dateToNs(options?.timestamp || new Date()),
+  }
+  const headerBytes = message.MessageHeaderV2.encode(header).finish()
+  const digest = await sha256(concat(headerBytes, payload))
+  const signed = {
+    payload,
+    sender: keys.getPublicKeyBundle(),
+    signature: await keys.getCurrentPreKey().sign(digest),
+  }
+  const signedBytes = proto.SignedContent.encode(signed).finish()
+  const ciphertext = await encrypt(
+    signedBytes,
+    conversation.keyMaterial,
+    headerBytes
+  )
+  const protoMsg = {
+    v1: undefined,
+    v2: { headerBytes, ciphertext },
+  }
+  const bytes = message.Message.encode(protoMsg).finish()
+  return MessageV2.create(protoMsg, header, signed, bytes)
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -50,14 +50,14 @@ const { b64Decode } = fetcher
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-type ConversationV1Export = {
+export type ConversationV1Export = {
   version: 'v1'
   peerAddress: string
   createdAt: string
   topic: string
 }
 
-type ConversationV2Export = {
+export type ConversationV2Export = {
   version: 'v2'
   topic: string
   keyMaterial: string

--- a/src/conversations/index.ts
+++ b/src/conversations/index.ts
@@ -1,2 +1,10 @@
 export { default as Conversations } from './Conversations'
 export { Conversation, ConversationV1, ConversationV2 } from './Conversation'
+export {
+  decodeMessageV1,
+  decodeMessageV2,
+  encodeMessageV1,
+  encodeMessageV2,
+} from './Conversation'
+export * as conversations from './Conversations'
+export * as conversation from './Conversation'

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -10,6 +10,7 @@ import { PublicKey, SignedPublicKey, UnsignedPublicKey } from './PublicKey'
 import Ciphertext from './Ciphertext'
 import { decrypt, encrypt, sha256 } from './encryption'
 import { equalBytes } from './utils'
+import { parseObjectToUint8Array } from '../utils/uint8Array'
 
 // SECP256k1 private key
 type secp256k1 = {
@@ -18,6 +19,9 @@ type secp256k1 = {
 
 // Validate SECP256k1 private key
 function secp256k1Check(key: secp256k1): void {
+  if (typeof key.bytes === 'object') {
+    key.bytes = parseObjectToUint8Array(key.bytes)
+  }
   if (key.bytes.length !== 32) {
     throw new Error(`invalid private key length: ${key.bytes.length}`)
   }

--- a/src/crypto/PublicKeyBundle.ts
+++ b/src/crypto/PublicKeyBundle.ts
@@ -78,6 +78,16 @@ export class PublicKeyBundle implements publicKey.PublicKeyBundle {
     this.preKey = new PublicKey(bundle.preKey)
   }
 
+  static from(
+    bundle: publicKey.PublicKeyBundle | PublicKeyBundle
+  ): PublicKeyBundle {
+    if (bundle instanceof PublicKeyBundle) {
+      return bundle
+    } else {
+      return new PublicKeyBundle(bundle)
+    }
+  }
+
   equals(other: this): boolean {
     return (
       this.identityKey.equals(other.identityKey) &&

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -6,6 +6,7 @@ import { SignedPrivateKey } from './PrivateKey'
 import { utils } from 'ethers'
 import { Signer } from '../types/Signer'
 import { bytesToHex, equalBytes, hexToBytes } from './utils'
+import { parseObjectToUint8Array } from '../utils/uint8Array'
 
 // ECDSA signature with recovery bit.
 export type ECDSACompactWithRecovery = {
@@ -15,6 +16,9 @@ export type ECDSACompactWithRecovery = {
 
 // Validate signature.
 function ecdsaCheck(sig: ECDSACompactWithRecovery): void {
+  if (typeof sig.bytes === 'object') {
+    sig.bytes = parseObjectToUint8Array(sig.bytes)
+  }
   if (sig.bytes.length !== 64) {
     throw new Error(`invalid signature length: ${sig.bytes.length}`)
   }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -23,9 +23,12 @@ export async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
 // in the authentication scope of the encryption.
 export async function encrypt(
   plain: Uint8Array,
-  secret: Uint8Array,
+  secret: Uint8Array | string,
   additionalData?: Uint8Array
 ): Promise<Ciphertext> {
+  if (typeof secret === 'string') {
+    secret = Buffer.from(secret, 'base64')
+  }
   const salt = crypto.getRandomValues(new Uint8Array(KDFSaltSize))
   const nonce = crypto.getRandomValues(new Uint8Array(AESGCMNonceSize))
   const key = await hkdf(secret, salt)
@@ -46,9 +49,12 @@ export async function encrypt(
 // symmetric authenticated decryption of the encrypted ciphertext using the secret and additionalData
 export async function decrypt(
   encrypted: Ciphertext | ciphertext.Ciphertext,
-  secret: Uint8Array,
+  secret: Uint8Array | string,
   additionalData?: Uint8Array
 ): Promise<Uint8Array> {
+  if (typeof secret === 'string') {
+    secret = Buffer.from(secret, 'base64')
+  }
   if (!encrypted.aes256GcmHkdfSha256) {
     throw new Error('invalid payload ciphertext')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-export { Message, DecodedMessage, decodeContent } from './Message'
+export {
+  Message,
+  DecodedMessage,
+  DecodedMessageExport,
+  decodeContent,
+} from './Message'
+export * as message from './Message'
 export {
   PublicKey,
   PublicKeyBundle,
@@ -19,6 +25,7 @@ export {
   Compression,
 } from './Client'
 export { Conversations, Conversation } from './conversations'
+export * as conversations from './conversations'
 export {
   ContentTypeId,
   ContentCodec,

--- a/src/utils/equals.ts
+++ b/src/utils/equals.ts
@@ -1,0 +1,19 @@
+export const deepEqual = <A>(x: A, y: A): boolean => {
+  if (x === y) {
+    return true
+  } else if (
+    typeof x === 'object' &&
+    x != null &&
+    typeof y === 'object' &&
+    y != null
+  ) {
+    if (Object.keys(x).length !== Object.keys(y).length) return false
+
+    for (const prop in x) {
+      if (`${prop}` in y) {
+        if (!deepEqual(x[prop], y[prop])) return false
+      } else return false
+    }
+    return true
+  } else return false
+}

--- a/src/utils/uint8Array.ts
+++ b/src/utils/uint8Array.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const parseObjectToUint8Array = (obj: any): Uint8Array => {
+  if (typeof obj === 'object' && obj !== null) {
+    if (obj instanceof Uint8Array) {
+      return obj
+    }
+    if (obj instanceof ArrayBuffer) {
+      return new Uint8Array(obj)
+    }
+    if (Array.isArray(obj)) {
+      return new Uint8Array(obj)
+    }
+    if (obj instanceof Object) {
+      if ('type' in obj && obj.type === 'Buffer') {
+        return new Uint8Array(obj.data)
+      }
+      return new Uint8Array(Object.values(obj))
+    }
+    throw new Error('We could not parse the object to Uint8Array')
+  } else {
+    throw new Error('We could not parse the object to Uint8Array')
+  }
+}


### PR DESCRIPTION
My main goal is to separate the message encode/decode to workers. The problem with workers, that you can't really move functions between the main thread and the worker thread, just "serialisable" data. The problem with the current implementation that the encode/decode functions are hardly coupled with the `Conversation` for mostly no real reason.

The PR is mostly just copy-paste refactoring.

The PR is WIP because the encodeV1 test is broken. I have no idea why, I can't found any mistake, maybe a sleep will help, but until then more eyes see more.

The list of changes;
 - `Client` was used most of the times, where we could use `CodecRegistry`
 - `encodeContent` was stripped from `Client` so now it can be used with any `CodecRegistry` and without the `Client`
 - `DecodedMessage` has a `Conversation` in it, so I introduced `DecodedMessageExport` which has a `ConversationExport` in it
 - `PrivateKeyBundleV2` and `PrivateKeyBundleV1` now can be "created" with a static from, which can distinguish `PrivateKeyBundle` and `proto.PrivateKeyBundle` from an input to save a class instantiation if we can
 - `PrivateKey`, `PrivateKeyBundle`, `PublicKey`, `PublicKeyBundle`, and `Signature` got a buff, so now they can handle a `JSON.parse(JSON.serialize(uint8Array))` too
 - `Signature` and `encription` now can handle base64 stringed uint8Arrays too natively
 - both v1 and v2 conversation got a `getClient` function
 - `decodeMessageV1`, `decodeMessageV2`, `encodeMessageV1`, `encodeMessageV2` got stripped out from `ConversationV1` and `ConversationV2`, they use proto.Key-s, and Exports as input/output
 - I preserved all of the previous interfaces