### PR TITLE
Encrypted persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "async-mutex": "^0.4.0",
         "eccrypto": "^1.1.6",
         "ethers": "^5.5.3",
-        "long": "^5.2.0",
-        "save": "^2.9.0"
+        "long": "^5.2.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -3656,11 +3655,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
     "node_modules/async-mutex": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
@@ -4866,11 +4860,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -5970,20 +5959,6 @@
         "@ethersproject/wordlists": "5.5.0"
       }
     },
-    "node_modules/event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "dependencies": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -6237,11 +6212,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "node_modules/from2": {
       "version": "2.3.0",
@@ -8400,11 +8370,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
-    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -8588,11 +8553,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
     },
     "node_modules/marked": {
       "version": "4.0.12",
@@ -8800,11 +8760,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/mingo": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.7.tgz",
-      "integrity": "sha512-r+yKmrZ+6SjwGxSot+/3S8sP9+LCxWNueR6xppMx7BzV60OegjbeklWAf/UveyQi8PDW8g/mwrQSHZVY/5jBJQ=="
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
@@ -11858,14 +11813,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "dependencies": {
-        "through": "~2.3"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -12551,17 +12498,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/save": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
-      "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
-      "dependencies": {
-        "async": "^3.2.2",
-        "event-stream": "^4.0.1",
-        "lodash.assign": "^4.2.0",
-        "mingo": "^6.1.0"
-      }
-    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -12963,6 +12899,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
       "dependencies": {
         "through": "2"
       },
@@ -13004,15 +12941,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-      "dependencies": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "node_modules/stream-combiner2": {
@@ -13438,7 +13366,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -17058,11 +16987,6 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
-    "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
     "async-mutex": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
@@ -18018,11 +17942,6 @@
         "create-hmac": "^1.1.4"
       }
     },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -18828,20 +18747,6 @@
         "@ethersproject/wordlists": "5.5.0"
       }
     },
-    "event-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
-      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -19046,11 +18951,6 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "from2": {
       "version": "2.3.0",
@@ -20666,11 +20566,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
-    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -20832,11 +20727,6 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-    },
     "marked": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
@@ -20978,11 +20868,6 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
-    },
-    "mingo": {
-      "version": "6.2.7",
-      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.7.tgz",
-      "integrity": "sha512-r+yKmrZ+6SjwGxSot+/3S8sP9+LCxWNueR6xppMx7BzV60OegjbeklWAf/UveyQi8PDW8g/mwrQSHZVY/5jBJQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -23156,14 +23041,6 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
-      "requires": {
-        "through": "~2.3"
-      }
-    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -23672,17 +23549,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "save": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
-      "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
-      "requires": {
-        "async": "^3.2.2",
-        "event-stream": "^4.0.1",
-        "lodash.assign": "^4.2.0",
-        "mingo": "^6.1.0"
-      }
-    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -24006,6 +23872,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -24040,15 +23907,6 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "stream-combiner2": {
@@ -24351,7 +24209,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^3.15.0",
         "async-mutex": "^0.4.0",
+        "eccrypto": "^1.1.6",
         "ethers": "^5.5.3",
-        "long": "^5.2.0"
+        "long": "^5.2.0",
+        "save": "^2.9.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -22,6 +24,7 @@
         "@types/benchmark": "^2.1.2",
         "@types/bl": "^5.0.2",
         "@types/callback-to-async-iterator": "^1.1.4",
+        "@types/eccrypto": "^1.1.3",
         "@types/jest": "^27.0.1",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
@@ -2771,6 +2774,16 @@
       "integrity": "sha512-NVyiWSufzQNxYUsDQGcAEL8z83Z2NPvWoDHv3KqapWovxIxxmNq5/UTg2QWNtPSojoTevbilAO5rEFExStWVfQ==",
       "dev": true
     },
+    "node_modules/@types/eccrypto": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/eccrypto/-/eccrypto-1.1.3.tgz",
+      "integrity": "sha512-3O0qER6JMYReqVbcQTGmXeMHdw3O+rVps63tlo5g5zoB3altJS8yzSvboSivwVWeYO9o5jSATu7P0UIqYZPgow==",
+      "dev": true,
+      "dependencies": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -2795,6 +2808,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "node_modules/@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -3637,6 +3656,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "node_modules/async-mutex": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
@@ -3804,6 +3828,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -3847,6 +3889,20 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "optional": true,
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.19.1",
@@ -3897,6 +3953,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "optional": true
     },
     "node_modules/builtins": {
       "version": "5.0.1",
@@ -4027,6 +4089,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -4340,6 +4412,33 @@
         "@types/node": "*",
         "cosmiconfig": ">=7",
         "typescript": ">=3"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "optional": true,
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "optional": true,
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "node_modules/create-require": {
@@ -4753,6 +4852,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
+      "optional": true,
+      "dependencies": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
     "node_modules/duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4784,6 +4902,57 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/eccrypto": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
+      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "acorn": "7.1.1",
+        "elliptic": "6.5.4",
+        "es6-promise": "4.2.8",
+        "nan": "2.14.0"
+      },
+      "optionalDependencies": {
+        "secp256k1": "3.7.1"
+      }
+    },
+    "node_modules/eccrypto/node_modules/acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eccrypto/node_modules/nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "node_modules/eccrypto/node_modules/secp256k1": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.4.1",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4940,6 +5109,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -5796,6 +5970,20 @@
         "@ethersproject/wordlists": "5.5.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -5803,6 +5991,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "optional": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/execa": {
@@ -5952,6 +6150,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6033,6 +6237,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "node_modules/from2": {
       "version": "2.3.0",
@@ -6507,6 +6716,40 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash-base/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -8157,6 +8400,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -8341,6 +8589,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
+    },
     "node_modules/marked": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
@@ -8410,6 +8663,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "optional": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/meow": {
@@ -8536,6 +8800,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/mingo": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.7.tgz",
+      "integrity": "sha512-r+yKmrZ+6SjwGxSot+/3S8sP9+LCxWNueR6xppMx7BzV60OegjbeklWAf/UveyQi8PDW8g/mwrQSHZVY/5jBJQ=="
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
@@ -11589,6 +11858,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -12007,7 +12284,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -12216,6 +12493,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "optional": true,
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12256,13 +12543,24 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/save": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
+      "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
+      "dependencies": {
+        "async": "^3.2.2",
+        "event-stream": "^4.0.1",
+        "lodash.assign": "^4.2.0",
+        "mingo": "^6.1.0"
+      }
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -12396,6 +12694,19 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
       }
     },
     "node_modules/shallow-clone": {
@@ -12652,7 +12963,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
       "dependencies": {
         "through": "2"
       },
@@ -12696,6 +13006,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -12734,7 +13053,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -12743,7 +13062,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -13119,8 +13438,7 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "node_modules/through2": {
       "version": "4.0.2",
@@ -13547,7 +13865,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.0",
@@ -16037,6 +16355,16 @@
       "integrity": "sha512-NVyiWSufzQNxYUsDQGcAEL8z83Z2NPvWoDHv3KqapWovxIxxmNq5/UTg2QWNtPSojoTevbilAO5rEFExStWVfQ==",
       "dev": true
     },
+    "@types/eccrypto": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/eccrypto/-/eccrypto-1.1.3.tgz",
+      "integrity": "sha512-3O0qER6JMYReqVbcQTGmXeMHdw3O+rVps63tlo5g5zoB3altJS8yzSvboSivwVWeYO9o5jSATu7P0UIqYZPgow==",
+      "dev": true,
+      "requires": {
+        "@types/expect": "^1.20.4",
+        "@types/node": "*"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
@@ -16061,6 +16389,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
+      "dev": true
+    },
+    "@types/expect": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
+      "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -16724,6 +17058,11 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    },
     "async-mutex": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
@@ -16868,6 +17207,24 @@
         }
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -16909,6 +17266,20 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "optional": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "browserslist": {
       "version": "4.19.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
@@ -16945,6 +17316,12 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "optional": true
     },
     "builtins": {
       "version": "5.0.1",
@@ -17038,6 +17415,16 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
       "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
       "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
@@ -17281,6 +17668,33 @@
       "requires": {
         "cosmiconfig": "^7",
         "ts-node": "^10.5.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "optional": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "optional": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-require": {
@@ -17593,6 +18007,22 @@
         "is-obj": "^2.0.0"
       }
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
+      "optional": true,
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -17624,6 +18054,46 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "eccrypto": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
+      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
+      "requires": {
+        "acorn": "7.1.1",
+        "elliptic": "6.5.4",
+        "es6-promise": "4.2.8",
+        "nan": "2.14.0",
+        "secp256k1": "3.7.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        },
+        "secp256k1": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+          "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.4.1",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
           }
         }
       }
@@ -17752,6 +18222,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -18353,11 +18828,35 @@
         "@ethersproject/wordlists": "5.5.0"
       }
     },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "optional": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "execa": {
       "version": "5.1.1",
@@ -18481,6 +18980,12 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -18541,6 +19046,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "from2": {
       "version": "2.3.0",
@@ -18893,6 +19403,25 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "optional": true
+        }
       }
     },
     "hash.js": {
@@ -20137,6 +20666,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -20298,6 +20832,11 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
+    },
     "marked": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
@@ -20339,6 +20878,17 @@
           "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         }
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "optional": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "meow": {
@@ -20428,6 +20978,11 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mingo": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-6.2.7.tgz",
+      "integrity": "sha512-r+yKmrZ+6SjwGxSot+/3S8sP9+LCxWNueR6xppMx7BzV60OegjbeklWAf/UveyQi8PDW8g/mwrQSHZVY/5jBJQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -22601,6 +23156,14 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -22918,7 +23481,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -23063,6 +23626,16 @@
         "glob": "^7.1.3"
       }
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "optional": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -23091,13 +23664,24 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "devOptional": true
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "save": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/save/-/save-2.9.0.tgz",
+      "integrity": "sha512-eg8+g8CjvehE/2C6EbLdtK1pINVD27pcJLj4M9PjWWhoeha/y5bWf4dp/0RF+OzbKTcG1bae9qi3PAqiR8CJTg==",
+      "requires": {
+        "async": "^3.2.2",
+        "event-stream": "^4.0.1",
+        "lodash.assign": "^4.2.0",
+        "mingo": "^6.1.0"
+      }
     },
     "saxes": {
       "version": "5.0.1",
@@ -23199,6 +23783,16 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "optional": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -23412,7 +24006,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
       "requires": {
         "through": "2"
       }
@@ -23447,6 +24040,15 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "stream-combiner2": {
@@ -23489,7 +24091,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -23498,7 +24100,7 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -23749,8 +24351,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "4.0.2",
@@ -24042,7 +24643,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "devOptional": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,10 @@
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^3.15.0",
     "async-mutex": "^0.4.0",
+    "eccrypto": "^1.1.6",
     "ethers": "^5.5.3",
-    "long": "^5.2.0"
+    "long": "^5.2.0",
+    "save": "^2.9.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
@@ -79,6 +81,7 @@
     "@types/benchmark": "^2.1.2",
     "@types/bl": "^5.0.2",
     "@types/callback-to-async-iterator": "^1.1.4",
+    "@types/eccrypto": "^1.1.3",
     "@types/jest": "^27.0.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "async-mutex": "^0.4.0",
     "eccrypto": "^1.1.6",
     "ethers": "^5.5.3",
-    "long": "^5.2.0",
-    "save": "^2.9.0"
+    "long": "^5.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -4,6 +4,7 @@ import eccrypto, { Ecies } from 'eccrypto'
 const IV_LENGTH = 16
 const EPHEMERAL_PUBLIC_KEY_LENGTH = 65
 const MAC_LENGTH = 32
+const CIPHERTEXT_BLOCK_SIZE_BYTES = 16
 
 const assertEciesLengths = (ecies: Ecies): void => {
   if (ecies.iv.length !== IV_LENGTH) {
@@ -12,7 +13,10 @@ const assertEciesLengths = (ecies: Ecies): void => {
   if (ecies.ephemPublicKey.length !== EPHEMERAL_PUBLIC_KEY_LENGTH) {
     throw new Error('Invalid ephemPublicKey length')
   }
-  if (ecies.ciphertext.length < 1 || ecies.ciphertext.length % 16 !== 0) {
+  if (
+    ecies.ciphertext.length < 1 ||
+    ecies.ciphertext.length % CIPHERTEXT_BLOCK_SIZE_BYTES !== 0
+  ) {
     throw new Error('Invalid ciphertext length')
   }
   if (ecies.mac.length !== MAC_LENGTH) {
@@ -34,7 +38,13 @@ const serializeEcies = (ecies: Ecies): Uint8Array => {
 }
 
 const deserializeEcies = (data: Uint8Array): Ecies => {
-  if (data.length < IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH + MAC_LENGTH) {
+  if (
+    data.length <
+    IV_LENGTH +
+      EPHEMERAL_PUBLIC_KEY_LENGTH +
+      MAC_LENGTH +
+      CIPHERTEXT_BLOCK_SIZE_BYTES
+  ) {
     throw new Error('Invalid data length')
   }
   const iv = data.slice(0, IV_LENGTH)

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -66,6 +66,8 @@ const deserializeEcies = (data: Uint8Array): Ecies => {
 
 /**
  * EncryptedPersistence is a Persistence implementation that uses ECIES to encrypt all values
+ * ECIES encryption protects against unauthorized reads, but not unauthorized writes.
+ * A third party with access to the underlying store could write malicious data using the public key of the owner
  */
 export default class EncryptedPersistence implements Persistence {
   private persistence: Persistence

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -1,0 +1,82 @@
+import { Persistence } from './interface'
+import eccrypto, { Ecies } from 'eccrypto'
+
+const assertEciesLengths = (ecies: Ecies): void => {
+  if (ecies.iv.length !== 16) {
+    throw new Error('Invalid iv length')
+  }
+  if (ecies.ephemPublicKey.length !== 65) {
+    throw new Error('Invalid ephemPublicKey length')
+  }
+  if (ecies.ciphertext.length < 1) {
+    throw new Error('Invalid ciphertext length')
+  }
+  if (ecies.mac.length !== 32) {
+    throw new Error('Invalid mac length')
+  }
+}
+
+const serializeEcies = (ecies: Ecies): Uint8Array => {
+  assertEciesLengths(ecies)
+  const { iv, ephemPublicKey, ciphertext, mac } = ecies
+  const result = new Uint8Array(
+    iv.length + ephemPublicKey.length + ciphertext.length + mac.length
+  )
+  result.set(iv, 0)
+  result.set(ephemPublicKey, iv.length)
+  result.set(ciphertext, iv.length + ephemPublicKey.length)
+  result.set(mac, iv.length + ephemPublicKey.length + ciphertext.length)
+  return result
+}
+
+const deserializeEcies = (data: Uint8Array): Ecies => {
+  const iv = data.slice(0, 16)
+  const ephemPublicKey = data.slice(16, 81)
+  const ciphertext = data.slice(81, data.length - 32)
+  const mac = data.slice(data.length - 32, data.length)
+  return {
+    iv: Buffer.from(iv),
+    ephemPublicKey: Buffer.from(ephemPublicKey),
+    ciphertext: Buffer.from(ciphertext),
+    mac: Buffer.from(mac),
+  }
+}
+
+/**
+ * EncryptedPersistence is a Persistence implementation that uses ECIES to encrypt all values
+ */
+export default class EncryptedPersistence implements Persistence {
+  private persistence: Persistence
+  private privateKey: Buffer
+  private publicKey: Buffer
+
+  constructor(persistence: Persistence, privateKey: Uint8Array) {
+    this.persistence = persistence
+    this.privateKey = Buffer.from(privateKey)
+    this.publicKey = eccrypto.getPublic(Buffer.from(privateKey))
+  }
+
+  async getItem(key: string): Promise<Uint8Array | null> {
+    const encrypted = await this.persistence.getItem(key)
+    if (encrypted) {
+      return this.decrypt(encrypted)
+    }
+    return null
+  }
+
+  async setItem(key: string, value: Uint8Array): Promise<void> {
+    const encrypted = await this.encrypt(value)
+    await this.persistence.setItem(key, encrypted)
+  }
+
+  private async encrypt(value: Uint8Array): Promise<Uint8Array> {
+    const ecies = await eccrypto.encrypt(this.publicKey, Buffer.from(value))
+    return serializeEcies(ecies)
+  }
+
+  private async decrypt(value: Uint8Array): Promise<Uint8Array> {
+    const ecies = deserializeEcies(value)
+    const result = await eccrypto.decrypt(this.privateKey, ecies)
+    return Uint8Array.from(result)
+  }
+}

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -53,9 +53,9 @@ const deserializeEcies = (data: Uint8Array): Ecies => {
   )
   const ciphertext = data.slice(
     IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH,
-    data.length - 32
+    data.length - MAC_LENGTH
   )
-  const mac = data.slice(data.length - 32, data.length)
+  const mac = data.slice(data.length - MAC_LENGTH, data.length)
   return {
     iv: Buffer.from(iv),
     ephemPublicKey: Buffer.from(ephemPublicKey),

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -53,7 +53,7 @@ export default class EncryptedPersistence implements Persistence {
   constructor(persistence: Persistence, privateKey: Uint8Array) {
     this.persistence = persistence
     this.privateKey = Buffer.from(privateKey)
-    this.publicKey = eccrypto.getPublic(Buffer.from(privateKey))
+    this.publicKey = eccrypto.getPublic(this.privateKey)
   }
 
   async getItem(key: string): Promise<Uint8Array | null> {

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -4,7 +4,9 @@ import eccrypto, { Ecies } from 'eccrypto'
 const IV_LENGTH = 16
 const EPHEMERAL_PUBLIC_KEY_LENGTH = 65
 const MAC_LENGTH = 32
-const CIPHERTEXT_BLOCK_SIZE_BYTES = 16
+const AES_BLOCK_SIZE = 16
+const MIN_DATA_LENGTH =
+  IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH + MAC_LENGTH + AES_BLOCK_SIZE
 
 const assertEciesLengths = (ecies: Ecies): void => {
   if (ecies.iv.length !== IV_LENGTH) {
@@ -15,7 +17,7 @@ const assertEciesLengths = (ecies: Ecies): void => {
   }
   if (
     ecies.ciphertext.length < 1 ||
-    ecies.ciphertext.length % CIPHERTEXT_BLOCK_SIZE_BYTES !== 0
+    ecies.ciphertext.length % AES_BLOCK_SIZE !== 0
   ) {
     throw new Error('Invalid ciphertext length')
   }
@@ -39,11 +41,8 @@ const serializeEcies = (ecies: Ecies): Uint8Array => {
 
 const deserializeEcies = (data: Uint8Array): Ecies => {
   if (
-    data.length <
-    IV_LENGTH +
-      EPHEMERAL_PUBLIC_KEY_LENGTH +
-      MAC_LENGTH +
-      CIPHERTEXT_BLOCK_SIZE_BYTES
+    data.length < MIN_DATA_LENGTH ||
+    (data.length - MIN_DATA_LENGTH) % AES_BLOCK_SIZE !== 0
   ) {
     throw new Error('Invalid data length')
   }

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -34,6 +34,9 @@ const serializeEcies = (ecies: Ecies): Uint8Array => {
 }
 
 const deserializeEcies = (data: Uint8Array): Ecies => {
+  if (data.length < IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH + MAC_LENGTH) {
+    throw new Error('Invalid data length')
+  }
   const iv = data.slice(0, IV_LENGTH)
   const ephemPublicKey = data.slice(
     IV_LENGTH,

--- a/src/keystore/persistence/EncryptedPersistence.ts
+++ b/src/keystore/persistence/EncryptedPersistence.ts
@@ -1,17 +1,21 @@
 import { Persistence } from './interface'
 import eccrypto, { Ecies } from 'eccrypto'
 
+const IV_LENGTH = 16
+const EPHEMERAL_PUBLIC_KEY_LENGTH = 65
+const MAC_LENGTH = 32
+
 const assertEciesLengths = (ecies: Ecies): void => {
-  if (ecies.iv.length !== 16) {
+  if (ecies.iv.length !== IV_LENGTH) {
     throw new Error('Invalid iv length')
   }
-  if (ecies.ephemPublicKey.length !== 65) {
+  if (ecies.ephemPublicKey.length !== EPHEMERAL_PUBLIC_KEY_LENGTH) {
     throw new Error('Invalid ephemPublicKey length')
   }
-  if (ecies.ciphertext.length < 1) {
+  if (ecies.ciphertext.length < 1 || ecies.ciphertext.length % 16 !== 0) {
     throw new Error('Invalid ciphertext length')
   }
-  if (ecies.mac.length !== 32) {
+  if (ecies.mac.length !== MAC_LENGTH) {
     throw new Error('Invalid mac length')
   }
 }
@@ -23,16 +27,22 @@ const serializeEcies = (ecies: Ecies): Uint8Array => {
     iv.length + ephemPublicKey.length + ciphertext.length + mac.length
   )
   result.set(iv, 0)
-  result.set(ephemPublicKey, iv.length)
-  result.set(ciphertext, iv.length + ephemPublicKey.length)
-  result.set(mac, iv.length + ephemPublicKey.length + ciphertext.length)
+  result.set(ephemPublicKey, IV_LENGTH)
+  result.set(ciphertext, IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH)
+  result.set(mac, IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH + ciphertext.length)
   return result
 }
 
 const deserializeEcies = (data: Uint8Array): Ecies => {
-  const iv = data.slice(0, 16)
-  const ephemPublicKey = data.slice(16, 81)
-  const ciphertext = data.slice(81, data.length - 32)
+  const iv = data.slice(0, IV_LENGTH)
+  const ephemPublicKey = data.slice(
+    IV_LENGTH,
+    IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH
+  )
+  const ciphertext = data.slice(
+    IV_LENGTH + EPHEMERAL_PUBLIC_KEY_LENGTH,
+    data.length - 32
+  )
   const mac = data.slice(data.length - 32, data.length)
   return {
     iv: Buffer.from(iv),

--- a/src/keystore/persistence/index.ts
+++ b/src/keystore/persistence/index.ts
@@ -1,3 +1,4 @@
 export * from './interface'
 export { default as LocalStoragePersistence } from './LocalStoragePersistence'
 export { default as PrefixedPersistence } from './PrefixedPersistence'
+export { default as EncryptedPersistence } from './EncryptedPersistence'

--- a/test/keystore/persistence/EncryptedPersistence.test.ts
+++ b/test/keystore/persistence/EncryptedPersistence.test.ts
@@ -1,0 +1,70 @@
+import { PrivateKeyBundleV1 } from './../../../src/crypto/PrivateKeyBundle'
+import {
+  EncryptedPersistence,
+  LocalStoragePersistence,
+} from '../../../src/keystore/persistence'
+import { getRandomValues } from '../../../src/crypto/utils'
+
+const TEST_KEY = 'test-key'
+const TEST_KEY_2 = 'test-key-2'
+
+describe('EncryptedPersistence', () => {
+  let privateKey: Uint8Array
+
+  beforeEach(async () => {
+    const bundle = await PrivateKeyBundleV1.generate()
+    privateKey = bundle.getCurrentPreKey().secp256k1.bytes
+  })
+
+  it('can encrypt and decrypt a value', async () => {
+    const data = getRandomValues(new Uint8Array(128))
+    const persistence = new LocalStoragePersistence()
+    const encryptedPersistence = new EncryptedPersistence(
+      persistence,
+      privateKey
+    )
+
+    await encryptedPersistence.setItem(TEST_KEY, data)
+    const result = await encryptedPersistence.getItem(TEST_KEY)
+    expect(result).toEqual(data)
+
+    const rawResult = await persistence.getItem(TEST_KEY)
+    expect(rawResult).not.toEqual(data)
+  })
+
+  it('works with arbitrarily sized inputs', async () => {
+    const inputs = [
+      getRandomValues(new Uint8Array(32)),
+      getRandomValues(new Uint8Array(128)),
+      getRandomValues(new Uint8Array(1024)),
+    ]
+    for (const input of inputs) {
+      const encryptedPersistence = new EncryptedPersistence(
+        new LocalStoragePersistence(),
+        privateKey
+      )
+
+      await encryptedPersistence.setItem(TEST_KEY, input)
+      const returnedResult = await encryptedPersistence.getItem(TEST_KEY)
+      expect(returnedResult).toEqual(input)
+    }
+  })
+
+  it('uses random values to encrypt repeatedly', async () => {
+    const data = getRandomValues(new Uint8Array(128))
+    const persistence = new LocalStoragePersistence()
+    const encryptedPersistence = new EncryptedPersistence(
+      persistence,
+      privateKey
+    )
+
+    await encryptedPersistence.setItem(TEST_KEY, data)
+    await encryptedPersistence.setItem(TEST_KEY_2, data)
+
+    const [rawResult1, rawResult2] = await Promise.all([
+      persistence.getItem(TEST_KEY),
+      persistence.getItem(TEST_KEY_2),
+    ])
+    expect(rawResult1).not.toEqual(rawResult2)
+  })
+})

--- a/test/keystore/persistence/EncryptedPersistence.test.ts
+++ b/test/keystore/persistence/EncryptedPersistence.test.ts
@@ -67,4 +67,67 @@ describe('EncryptedPersistence', () => {
     ])
     expect(rawResult1).not.toEqual(rawResult2)
   })
+
+  it('catches garbage values', async () => {
+    const data = getRandomValues(new Uint8Array(128))
+    const persistence = new LocalStoragePersistence()
+    const encryptedPersistence = new EncryptedPersistence(
+      persistence,
+      privateKey
+    )
+
+    // Set an unencrypted value of 'garbage' as bytes
+    await persistence.setItem(
+      TEST_KEY,
+      new Uint8Array([103, 97, 114, 98, 97, 103, 101])
+    )
+    // Expect an error if the ciphertext is tampered with
+    await expect(encryptedPersistence.getItem(TEST_KEY)).rejects.toThrow(
+      'Invalid data length'
+    )
+  })
+
+  it('detects bad mac', async () => {
+    const data = getRandomValues(new Uint8Array(128))
+    const persistence = new LocalStoragePersistence()
+    const encryptedPersistence = new EncryptedPersistence(
+      persistence,
+      privateKey
+    )
+
+    // Write the value with encryption
+    await encryptedPersistence.setItem(TEST_KEY, data)
+
+    // Read the raw result, change one byte, write it back
+    const rawResult = await persistence.getItem(TEST_KEY)!
+    rawResult![7] += 1
+    await persistence.setItem(TEST_KEY, rawResult!)
+
+    // Expect an error if the ciphertext is tampered with
+    await expect(encryptedPersistence.getItem(TEST_KEY)).rejects.toThrow(
+      'Bad MAC'
+    )
+  })
+
+  it('detects length modified ciphertext', async () => {
+    const data = getRandomValues(new Uint8Array(128))
+    const persistence = new LocalStoragePersistence()
+    const encryptedPersistence = new EncryptedPersistence(
+      persistence,
+      privateKey
+    )
+
+    await encryptedPersistence.setItem(TEST_KEY, data)
+    // Read the raw result, change one byte, write it back
+    const rawResult = await persistence.getItem(TEST_KEY)!
+    // Add a byte to the rawResult
+    const newRawResult = new Uint8Array(rawResult!.length + 1)
+    newRawResult.set(rawResult!)
+    await persistence.setItem(TEST_KEY, newRawResult)
+
+    // Expect an error if the ciphertext is tampered with
+    await expect(encryptedPersistence.getItem(TEST_KEY)).rejects.toThrow(
+      'Invalid data length'
+    )
+  })
 })

--- a/test/keystore/persistence/EncryptedPersistence.test.ts
+++ b/test/keystore/persistence/EncryptedPersistence.test.ts
@@ -13,7 +13,7 @@ describe('EncryptedPersistence', () => {
 
   beforeEach(async () => {
     const bundle = await PrivateKeyBundleV1.generate()
-    privateKey = bundle.getCurrentPreKey().secp256k1.bytes
+    privateKey = bundle.identityKey.secp256k1.bytes
   })
 
   it('can encrypt and decrypt a value', async () => {


### PR DESCRIPTION
## Summary

- Adds an ecrypted persistence layer using ECIES for single party encryption
- Uses [`bitchan/eccrypto`](https://github.com/bitchan/eccrypto) as recommended by [Cryptobook](https://cryptobook.nakov.com/asymmetric-key-ciphers/exercises-ecies-encrypt-decrypt) and @michaelx11

## Notes
- I don't love `bitchan/eccrypto` . It's also been basically untouched in 3+ years. It uses a different implementation of secp256k1 than we do, which just adds some bloat to our bundle. All the code is one file. The good news is that the library is quite small, and mostly just calls out to the underlying crypto libraries.
- This PR is not opinionated on where the key comes from, but I assume I want to use the `IdentityKey` here, given that we don't have metadata to describe which `preKey` to use for decryption and `preKeys` could theoretically change.
- Targeting this PR at `nmolnar/v2-conversation-persistence` until https://github.com/xmtp/xmtp-js/pull/292 merges. Then will target at `main`
- Still need to do some browser testing before I merge to make sure that `eccrypto` works correctly with webpack and uses the native browser crypto libs.