### PR TITLE
V2 conversations in keystore

### DIFF
--- a/bench/decode.ts
+++ b/bench/decode.ts
@@ -4,7 +4,7 @@ import {
 } from './../src/conversations/Conversation'
 import { MessageV1 } from '../src/Message'
 import { newLocalHostClient } from '../test/helpers'
-import { utils } from '../src/crypto'
+import { SignedPublicKeyBundle, utils } from '../src/crypto'
 import {
   MESSAGE_SIZES,
   newPrivateKeyBundle,
@@ -13,6 +13,7 @@ import {
 } from './helpers'
 import { add } from 'benny'
 import { fetcher } from '@xmtp/proto'
+import { dateToNs } from '../src/utils'
 
 const decodeV1 = () => {
   return MESSAGE_SIZES.map((size) =>
@@ -58,10 +59,16 @@ const decodeV2 = () => {
       const bob = await newPrivateKeyBundle()
 
       const message = randomBytes(size)
+      const invite = await alice.keystore.createInvite({
+        recipient: SignedPublicKeyBundle.fromLegacyBundle(
+          bob.getPublicKeyBundle()
+        ),
+        createdNs: dateToNs(new Date()),
+        context: undefined,
+      })
       const convo = new ConversationV2(
         alice,
-        'xmtp/0/foo',
-        utils.getRandomValues(new Uint8Array(32)),
+        invite.conversation?.topic ?? '',
         bob.identityKey.publicKey.walletSignatureAddress(),
         new Date(),
         undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.15.0",
+        "@xmtp/proto": "^3.18.0",
         "async-mutex": "^0.4.0",
         "eccrypto": "^1.1.6",
         "ethers": "^5.5.3",
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.15.0.tgz",
-      "integrity": "sha512-qASpc4cR1ExKOqwl5F4sfEzKkfI05NW1LOkfyi5ND4E/2iaHifAN1vQHQrJgMTxHOiZ/dFgCgsLay6X3gSOw8A==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.18.0.tgz",
+      "integrity": "sha512-tCVQLwZdaMo+ypqIfLdf0Hxnh+3AEyLtQArguhSacTpBq/c2yfpz9mbhzWXCVnC1l/0VOAqMreKdNtamHs2Rbg==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16747,9 +16747,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.15.0.tgz",
-      "integrity": "sha512-qASpc4cR1ExKOqwl5F4sfEzKkfI05NW1LOkfyi5ND4E/2iaHifAN1vQHQrJgMTxHOiZ/dFgCgsLay6X3gSOw8A==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.18.0.tgz",
+      "integrity": "sha512-tCVQLwZdaMo+ypqIfLdf0Hxnh+3AEyLtQArguhSacTpBq/c2yfpz9mbhzWXCVnC1l/0VOAqMreKdNtamHs2Rbg==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.15.0",
+    "@xmtp/proto": "^3.18.0",
     "async-mutex": "^0.4.0",
     "eccrypto": "^1.1.6",
     "ethers": "^5.5.3",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -27,7 +27,6 @@ import { content as proto, messageApi, fetcher } from '@xmtp/proto'
 import { decodeContactBundle, encodeContactBundle } from './ContactBundle'
 import ApiClient, { ApiUrls, PublishParams, SortDirection } from './ApiClient'
 import { Authenticator } from './authn'
-import { SealedInvitation } from './Invitation'
 import { Flatten } from './utils/typedefs'
 import BackupClient, { BackupType } from './message-backup/BackupClient'
 import { createBackupClient } from './message-backup/BackupClientFactory'
@@ -192,6 +191,10 @@ export default class Client {
 
   get publicKeyBundle(): PublicKeyBundle {
     return this.legacyKeys.getPublicKeyBundle()
+  }
+
+  get signedPublicKeyBundle(): SignedPublicKeyBundle {
+    return SignedPublicKeyBundle.fromLegacyBundle(this.publicKeyBundle)
   }
 
   /**
@@ -497,10 +500,10 @@ export default class Client {
     return proto.EncodedContent.encode(encoded).finish()
   }
 
-  listInvitations(opts?: ListMessagesOptions): Promise<SealedInvitation[]> {
+  listInvitations(opts?: ListMessagesOptions): Promise<messageApi.Envelope[]> {
     return this.listEnvelopes(
       [buildUserInviteTopic(this.address)],
-      SealedInvitation.fromEnvelope,
+      async (env) => env,
       opts
     )
   }

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -104,9 +104,11 @@ export const getKeyMaterial = (
 export const topicDataToConversationReference = ({
   invitation,
   createdNs,
+  peerAddress,
 }: TopicData): keystore.ConversationReference => ({
   context: invitation.context,
   topic: invitation.topic,
+  peerAddress,
   createdNs,
 })
 

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,10 @@
+import { fetcher } from '@xmtp/proto'
+
+export const { b64Decode, b64Encode } = fetcher
+
+export function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const ab = new Uint8Array(a.length + b.length)
+  ab.set(a)
+  ab.set(b, a.length)
+  return ab
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './topic'
 export * from './async'
 export * from './date'
+export * from './bytes'

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -18,7 +18,7 @@ import {
 } from '../../src/crypto'
 import { ConversationV2 } from '../../src/conversations/Conversation'
 import { ContentTypeTestKey, TestKeyCodec } from '../ContentTypeTestKey'
-import { messageApi, message, content as proto, fetcher } from '@xmtp/proto'
+import { content as proto, fetcher } from '@xmtp/proto'
 
 describe('conversation', () => {
   let alice: Client
@@ -384,32 +384,6 @@ describe('conversation', () => {
       await bobStream.return()
       await aliceStream.return()
     })
-
-    it('exports', async () => {
-      const convo = await alice.conversations.newConversation(bob.address)
-      const exported = convo.export()
-
-      expect(exported.peerAddress).toBe(bob.address)
-      expect(exported.createdAt).toBe(convo.createdAt.toISOString())
-      expect(exported.version).toBe('v1')
-    })
-
-    it('imports', async () => {
-      const convo = await alice.conversations.newConversation(bob.address)
-      const exported = convo.export()
-
-      if (exported.version !== 'v1') {
-        fail()
-      }
-      const imported = ConversationV1.fromExport(alice, exported)
-      expect(imported.createdAt).toEqual(convo.createdAt)
-      await imported.send('hello')
-      await sleep(50)
-
-      const results = await convo.messages()
-      expect(results).toHaveLength(1)
-      expect(results[0].content).toBe('hello')
-    })
   })
 
   describe('v2', () => {
@@ -442,7 +416,6 @@ describe('conversation', () => {
         fail()
       }
       expect(bc.topic).toBe(ac.topic)
-      expect(bc.export().keyMaterial).toEqual(ac.export().keyMaterial)
       const bs = await bc.streamMessages()
       await sleep(100)
 
@@ -617,47 +590,6 @@ describe('conversation', () => {
 
       await bobStream.return()
       await aliceStream.return()
-    })
-
-    it('exports', async () => {
-      const conversationId = 'xmtp.org/foo'
-      const convo = await alice.conversations.newConversation(bob.address, {
-        conversationId,
-        metadata: {},
-      })
-      const exported = convo.export()
-
-      if (exported.version !== 'v2') {
-        fail()
-      }
-      expect(exported.peerAddress).toBe(bob.address)
-      expect(exported.createdAt).toBe(convo.createdAt.toISOString())
-      expect(exported.context?.conversationId).toBe(conversationId)
-      expect(exported.keyMaterial).toBeTruthy()
-      expect(exported.topic).toBe(convo.topic)
-    })
-
-    it('imports', async () => {
-      const conversationId = 'xmtp.org/foo'
-      const convo = await alice.conversations.newConversation(bob.address, {
-        conversationId,
-        metadata: {},
-      })
-      const exported = convo.export()
-
-      if (exported.version !== 'v2') {
-        fail()
-      }
-
-      const imported = ConversationV2.fromExport(alice, exported)
-      expect(imported.createdAt).toEqual(convo.createdAt)
-      await imported.send('hello')
-      await sleep(50)
-
-      // Get messages from original conversation
-      const results = await convo.messages()
-      expect(results).toHaveLength(1)
-      expect(results[0].content).toBe('hello')
     })
   })
 })

--- a/test/keystore/InviteStore.test.ts
+++ b/test/keystore/InviteStore.test.ts
@@ -5,6 +5,7 @@ import { dateToNs } from '../../src/utils'
 
 const buildTopicData = (): TopicData => ({
   createdNs: dateToNs(new Date()).toUnsigned(),
+  peerAddress: getRandomValues(new Uint8Array(42)).toString(),
   invitation: {
     topic: getRandomValues(new Uint8Array(32)).toString(),
     aes256GcmHkdfSha256: {


### PR DESCRIPTION
## Summary

- Adds support for managing V2 conversations using the Keystore
- Renamed some internal methods to avoid confusion
- Simplified `MessageV2.create` to not require the message to have been decrypted before usage. This helps with the sequencing of batch decrypts (now we can decode to a MessageV2 -> Decrypt -> Convert to `DecodedMessage`).

## Notes
- Builds will be broken until https://github.com/xmtp/proto/pull/51 is merged. Tested using `npm link` and tests all pass.
- I moved all the private methods to the bottom of the `Conversation` class, which does make the diff larger than it should be.