### PR TITLE
fix: verify prekey signed by identity key in decodeMessage

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -544,17 +544,14 @@ export class ConversationV2 {
     if (!senderPreKey || !senderPreKey.signature || !senderPreKey.keyBytes) {
       throw new Error('missing pre-key or pre-key signature')
     }
-    const keyDigest = await sha256(senderPreKey.keyBytes)
     const senderIdentityKey = signed.sender?.identityKey
     if (!senderIdentityKey) {
       throw new Error('missing identity key in bundle')
     }
-    if (
-      !new SignedPublicKey(senderIdentityKey).verify(
-        new Signature(senderPreKey.signature),
-        keyDigest
-      )
-    ) {
+    const isValidPrekey = await new SignedPublicKey(
+      senderIdentityKey
+    ).verifyKey(new SignedPublicKey(senderPreKey))
+    if (!isValidPrekey) {
       throw new Error('pre key not signed by identity key')
     }
 


### PR DESCRIPTION
**Issue**

Messages are signed by the users PreKey, however in all SDK implementations the Prekey is not verified to be signed by the IdentityKey. This means a crafted bundle using Amal's IdentityKey, and Mallory's PreKey resulting in a message signature being considered valid. As the sender's address is derived from the wallet signature on the identity key, Mallory's message appears to be sent from Amal.

**Changes**

- Add test case to catch this issue (uses an exported conversation and a hand-crafted malicious message to reproduce)
- Add check in `decodeMessage` for conversation V2

**Tests**

- Unit test
- Verified in SDK integration