### PR TITLE
Keystore provider

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-npx --no-install commitlint --edit $1
+# npx --no-install commitlint --edit $1

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 . "$(dirname "$0")/common.sh"
 
-# npx --no-install commitlint --edit $1
+npx --no-install commitlint --edit $1

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -70,12 +70,14 @@ export type SendOptions = {
   timestamp?: Date
 }
 
+export type XmtpEnv = keyof typeof ApiUrls
+
 /**
  * Network startup options
  */
 type NetworkOptions = {
   // Allow for specifying different envs later
-  env: keyof typeof ApiUrls
+  env: XmtpEnv
   // apiUrl can be used to override the default URL for the env
   apiUrl: string | undefined
   // app identifier included with client version header

--- a/src/keystore/persistence/TopicPersistence.ts
+++ b/src/keystore/persistence/TopicPersistence.ts
@@ -1,0 +1,52 @@
+import { messageApi } from '@xmtp/proto'
+import ApiClient from '../../ApiClient'
+import Authenticator from '../../authn/Authenticator'
+import { b64Decode } from '../../utils/bytes'
+import { buildUserPrivateStoreTopic } from '../../utils/topic'
+import { Persistence } from './interface'
+
+export default class TopicPersistence implements Persistence {
+  apiClient: ApiClient
+  constructor(apiClient: ApiClient) {
+    this.apiClient = apiClient
+  }
+
+  // Returns the first record in a topic if it is present.
+  async getItem(key: string): Promise<Uint8Array | null> {
+    for await (const env of this.apiClient.queryIterator(
+      { contentTopics: [this.buildTopic(key)] },
+      {
+        pageSize: 1,
+        direction: messageApi.SortDirection.SORT_DIRECTION_DESCENDING,
+      }
+    )) {
+      if (!env.message) continue
+      try {
+        const bytes = b64Decode(env.message.toString())
+        return Uint8Array.from(bytes)
+      } catch (e) {
+        console.log(e)
+      }
+    }
+
+    return null
+  }
+
+  async setItem(key: string, value: Uint8Array): Promise<void> {
+    const keys = Uint8Array.from(value)
+    await this.apiClient.publish([
+      {
+        contentTopic: this.buildTopic(key),
+        message: keys,
+      },
+    ])
+  }
+
+  setAuthenticator(authenticator: Authenticator): void {
+    this.apiClient.setAuthenticator(authenticator)
+  }
+
+  private buildTopic(key: string): string {
+    return buildUserPrivateStoreTopic(key)
+  }
+}

--- a/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
+++ b/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
@@ -1,0 +1,38 @@
+import { privateKey } from '@xmtp/proto'
+import ApiClient from '../../ApiClient'
+import { PrivateKeyBundleV1 } from '../../crypto'
+import { Signer } from '../../types/Signer'
+import InMemoryKeystore from '../InMemoryKeystore'
+import { Keystore } from '../interfaces'
+import TopicPersistence from '../persistence/TopicPersistence'
+import { KeystoreProviderUnavailableError } from './errors'
+import { buildPersistenceFromOptions } from './helpers'
+import { KeystoreProviderOptions } from './interfaces'
+import NetworkKeyManager from './NetworkKeyManager'
+
+export default class KeyGeneratorKeystoreProvider {
+  async newKeystore(
+    opts: KeystoreProviderOptions,
+    apiClient: ApiClient,
+    wallet?: Signer
+  ): Promise<Keystore> {
+    if (!wallet) {
+      throw new KeystoreProviderUnavailableError(
+        'Wallet required to generate new keys'
+      )
+    }
+    const bundle = await PrivateKeyBundleV1.generate(wallet)
+    const manager = new NetworkKeyManager(
+      wallet,
+      new TopicPersistence(apiClient)
+    )
+    await manager.storePrivateKeyBundle(bundle)
+
+    return InMemoryKeystore.create(
+      bundle,
+      opts.persistConversations
+        ? await buildPersistenceFromOptions(opts, bundle)
+        : undefined
+    )
+  }
+}

--- a/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
+++ b/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
@@ -1,4 +1,3 @@
-import { privateKey } from '@xmtp/proto'
 import ApiClient from '../../ApiClient'
 import { PrivateKeyBundleV1 } from '../../crypto'
 import { Signer } from '../../types/Signer'

--- a/src/keystore/providers/NetworkKeyManager.ts
+++ b/src/keystore/providers/NetworkKeyManager.ts
@@ -1,0 +1,207 @@
+import { utils } from 'ethers'
+import { Signer } from '../../types/Signer'
+import {
+  PrivateKeyBundleV1,
+  decodePrivateKeyBundle,
+  decrypt,
+  encrypt,
+  PrivateKeyBundleV2,
+} from '../../crypto'
+import { Authenticator } from '../../authn'
+import { bytesToHex, getRandomValues, hexToBytes } from '../../crypto/utils'
+import Ciphertext from '../../crypto/Ciphertext'
+import { privateKey as proto } from '@xmtp/proto'
+import TopicPersistence from '../persistence/TopicPersistence'
+
+const KEY_BUNDLE_NAME = 'key_bundle'
+/**
+ * EncryptedKeyStore wraps Store to enable encryption of private key bundles
+ * using a wallet signature.
+ */
+export default class NetworkKeyManager {
+  private persistence: TopicPersistence
+  private signer: Signer
+
+  constructor(signer: Signer, persistence: TopicPersistence) {
+    this.signer = signer
+    this.persistence = persistence
+  }
+
+  private async getStorageAddress(name: string): Promise<string> {
+    // I think we want to namespace the storage address by wallet
+    // This will allow us to support switching between multiple wallets in the same browser
+    let walletAddress = await this.signer.getAddress()
+    walletAddress = utils.getAddress(walletAddress)
+    return `${walletAddress}/${name}`
+  }
+
+  // Retrieve a private key bundle for the active wallet address in the signer
+  async loadPrivateKeyBundle(): Promise<PrivateKeyBundleV1 | null> {
+    const storageBuffer = await this.persistence.getItem(
+      await this.getStorageAddress(KEY_BUNDLE_NAME)
+    )
+    if (!storageBuffer) {
+      return null
+    }
+
+    const [bundle, needsUpdate] = await this.fromEncryptedBytes(
+      this.signer,
+      Uint8Array.from(storageBuffer)
+    )
+    // If a versioned bundle is not found, the legacy bundle needs to be resaved to the store in
+    // the new format. Once all bundles have been upgraded, this migration code can be removed.
+    if (needsUpdate) {
+      await this.storePrivateKeyBundle(bundle)
+    }
+    return bundle
+  }
+
+  // Store the private key bundle at an address generated based on the active wallet in the signer
+  async storePrivateKeyBundle(bundle: PrivateKeyBundleV1): Promise<void> {
+    const keyAddress = await this.getStorageAddress(KEY_BUNDLE_NAME)
+    const encodedBundle = await this.toEncryptedBytes(bundle, this.signer)
+    // We need to setup the Authenticator so that the underlying store can publish messages without error
+    if (typeof this.persistence.setAuthenticator === 'function') {
+      this.persistence.setAuthenticator(new Authenticator(bundle.identityKey))
+    }
+
+    await this.persistence.setItem(keyAddress, encodedBundle)
+  }
+
+  // encrypts/serializes the bundle for storage
+  async toEncryptedBytes(
+    bundle: PrivateKeyBundleV1,
+    wallet: Signer
+  ): Promise<Uint8Array> {
+    // serialize the contents
+    const bytes = bundle.encode()
+    const wPreKey = getRandomValues(new Uint8Array(32))
+    const input = storageSigRequestText(wPreKey)
+    const walletAddr = await wallet.getAddress()
+
+    let sig = await wallet.signMessage(input)
+
+    // Check that the signature is correct, was created using the expected
+    // input, and retry if not. This mitigates a bug in interacting with
+    // LedgerLive for iOS, where the previous signature response is
+    // returned in some cases.
+    let address = utils.verifyMessage(input, sig)
+    if (address !== walletAddr) {
+      sig = await wallet.signMessage(input)
+      console.log('invalid signature, retrying')
+
+      address = utils.verifyMessage(input, sig)
+      if (address !== walletAddr) {
+        throw new Error('invalid signature')
+      }
+    }
+
+    const secret = hexToBytes(sig)
+    const ciphertext = await encrypt(bytes, secret)
+    return proto.EncryptedPrivateKeyBundle.encode({
+      v1: {
+        walletPreKey: wPreKey,
+        ciphertext,
+      },
+    }).finish()
+  }
+
+  // decrypts/deserializes the bundle from storage bytes
+  async fromEncryptedBytes(
+    wallet: Signer,
+    bytes: Uint8Array
+  ): Promise<[PrivateKeyBundleV1, boolean]> {
+    const [eBundle, needsUpdate] = getEncryptedBundle(bytes)
+
+    if (!eBundle.walletPreKey) {
+      throw new Error('missing wallet pre-key')
+    }
+    if (!eBundle.ciphertext?.aes256GcmHkdfSha256) {
+      throw new Error('missing bundle ciphertext')
+    }
+
+    const secret = hexToBytes(
+      await wallet.signMessage(storageSigRequestText(eBundle.walletPreKey))
+    )
+
+    // Ledger uses the last byte = v=[0,1,...] but Metamask and other wallets generate with
+    // v+27 as the last byte. We need to support both for interoperability. Doing this
+    // on the decryption side provides an immediate retroactive fix.
+    // Ledger is using the canonical way, whereas Ethereum adds 27 due to some legacy stuff
+    // https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739
+    try {
+      // Try the original version of the signature first
+      const ciphertext = new Ciphertext(eBundle.ciphertext)
+      const decrypted = await decrypt(ciphertext, secret)
+      const [bundle, needsUpdate2] = getPrivateBundle(decrypted)
+      return [bundle, needsUpdate || needsUpdate2]
+    } catch (e) {
+      // Assert that the secret is length 65 (encoded signature + recovery byte)
+      if (secret.length !== 65) {
+        throw new Error(
+          'Expected 65 bytes before trying a different recovery byte'
+        )
+      }
+      // Try the other version of recovery byte, either +27 or -27
+      const lastByte = secret[secret.length - 1]
+      let newSecret = secret.slice(0, secret.length - 1)
+      if (lastByte < 27) {
+        // This is a canonical signature, so we need to add 27 to the recovery byte and try again
+        newSecret = new Uint8Array([...newSecret, lastByte + 27])
+      } else {
+        // This canocalizes v to 0 or 1 (or maybe 2 or 3 but very unlikely)
+        newSecret = new Uint8Array([...newSecret, lastByte - 27])
+      }
+      const ciphertext = new Ciphertext(eBundle.ciphertext)
+      const decrypted = await decrypt(ciphertext, newSecret)
+      const [bundle, needsUpdate2] = getPrivateBundle(decrypted)
+      return [bundle, needsUpdate || needsUpdate2]
+    }
+  }
+}
+
+// getEncryptedV1Bundle returns the decoded bundle from the provided bytes. If there is an error decoding the bundle it attempts
+// to decode the bundle as a legacy bundle. Additionally return whether the bundle is in the expected format.
+function getEncryptedBundle(
+  bytes: Uint8Array
+): [proto.EncryptedPrivateKeyBundleV1, boolean] {
+  try {
+    const b = proto.EncryptedPrivateKeyBundle.decode(bytes)
+    if (b.v1) {
+      return [b.v1, false]
+    }
+  } catch (e) {
+    return [proto.EncryptedPrivateKeyBundleV1.decode(bytes), true]
+  }
+  throw new Error('unrecognized encrypted private key bundle version')
+}
+
+// getPrivateV1Bundle returns the decoded bundle from the provided bytes. If there is an error decoding the bundle it attempts
+// to decode the bundle as a legacy bundle. Additionally return whether the bundle is in the expected format.
+function getPrivateBundle(bytes: Uint8Array): [PrivateKeyBundleV1, boolean] {
+  try {
+    // TODO: add support for V2
+    const b = decodePrivateKeyBundle(bytes)
+    if (b instanceof PrivateKeyBundleV2) {
+      throw new Error('V2 bundles not supported yet')
+    }
+    return [b, false]
+  } catch (e) {
+    // Adds a default fallback for older versions of the proto
+    const b = proto.PrivateKeyBundleV1.decode(bytes)
+    return [new PrivateKeyBundleV1(b), true]
+  }
+}
+
+export function storageSigRequestText(preKey: Uint8Array): string {
+  // Note that an update to this signature request text will require
+  // addition of backward compatibility for existing encrypted bundles
+  // and/or a migration; otherwise clients will no longer be able to
+  // decrypt those bundles.
+  return (
+    'XMTP : Enable Identity\n' +
+    `${bytesToHex(preKey)}\n` +
+    '\n' +
+    'For more info: https://xmtp.org/signatures/'
+  )
+}

--- a/src/keystore/providers/NetworkKeystoreProvider.ts
+++ b/src/keystore/providers/NetworkKeystoreProvider.ts
@@ -1,0 +1,32 @@
+import { Signer } from './../../types/Signer'
+import ApiClient from '../../ApiClient'
+import { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
+import NetworkKeyLoader from './NetworkKeyManager'
+import { KeystoreProviderUnavailableError } from './errors'
+import TopicPersistence from '../persistence/TopicPersistence'
+import { Keystore } from '../interfaces'
+import InMemoryKeystore from '../InMemoryKeystore'
+import { buildPersistenceFromOptions } from './helpers'
+
+export default class NetworkKeystoreProvider implements KeystoreProvider {
+  async newKeystore(
+    opts: KeystoreProviderOptions,
+    apiClient: ApiClient,
+    wallet?: Signer
+  ): Promise<Keystore> {
+    if (!wallet) {
+      throw new KeystoreProviderUnavailableError('No wallet provided')
+    }
+
+    const loader = new NetworkKeyLoader(wallet, new TopicPersistence(apiClient))
+    const keys = await loader.loadPrivateKeyBundle()
+    if (!keys) {
+      throw new KeystoreProviderUnavailableError('No keys found')
+    }
+
+    return InMemoryKeystore.create(
+      keys,
+      await buildPersistenceFromOptions(opts, keys)
+    )
+  }
+}

--- a/src/keystore/providers/StaticKeystoreProvider.ts
+++ b/src/keystore/providers/StaticKeystoreProvider.ts
@@ -1,0 +1,32 @@
+import { KeystoreProviderUnavailableError } from './errors'
+import { Keystore } from '../interfaces'
+import type { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
+import InMemoryKeystore from '../InMemoryKeystore'
+import {
+  decodePrivateKeyBundle,
+  PrivateKeyBundleV2,
+} from '../../crypto/PrivateKeyBundle'
+import { buildPersistenceFromOptions } from './helpers'
+
+export default class StaticKeystoreProvider implements KeystoreProvider {
+  async newKeystore(opts: KeystoreProviderOptions): Promise<Keystore> {
+    const { privateKeyOverride } = opts
+    if (!privateKeyOverride) {
+      throw new KeystoreProviderUnavailableError(
+        'No private key override provided'
+      )
+    }
+
+    const bundle = decodePrivateKeyBundle(privateKeyOverride)
+    if (bundle instanceof PrivateKeyBundleV2) {
+      throw new Error('V2 private key bundle found. Only V1 supported')
+    }
+
+    return InMemoryKeystore.create(
+      bundle,
+      opts.persistConversations
+        ? await buildPersistenceFromOptions(opts, bundle)
+        : undefined
+    )
+  }
+}

--- a/src/keystore/providers/errors.ts
+++ b/src/keystore/providers/errors.ts
@@ -1,0 +1,1 @@
+export class KeystoreProviderUnavailableError extends Error {}

--- a/src/keystore/providers/helpers.ts
+++ b/src/keystore/providers/helpers.ts
@@ -1,0 +1,24 @@
+import { PrivateKeyBundleV2 } from './../../crypto/PrivateKeyBundle'
+import { PrivateKeyBundleV1 } from '../../crypto/PrivateKeyBundle'
+import {
+  EncryptedPersistence,
+  LocalStoragePersistence,
+  PrefixedPersistence,
+} from '../persistence'
+import { KeystoreProviderOptions } from './interfaces'
+
+export const buildPersistenceFromOptions = async (
+  opts: KeystoreProviderOptions,
+  keys: PrivateKeyBundleV1 | PrivateKeyBundleV2
+) => {
+  const address = await keys.identityKey.publicKey.walletSignatureAddress()
+  const prefix = `xmtp/${opts.env}/${address}`
+
+  return new PrefixedPersistence(
+    prefix,
+    new EncryptedPersistence(
+      new LocalStoragePersistence(),
+      keys.identityKey.secp256k1.bytes
+    )
+  )
+}

--- a/src/keystore/providers/interfaces.ts
+++ b/src/keystore/providers/interfaces.ts
@@ -1,0 +1,22 @@
+import type { XmtpEnv } from '../../Client'
+import type ApiClient from '../../ApiClient'
+import type { Signer } from '../../types/Signer'
+import type { Keystore } from '../interfaces'
+
+export type KeystoreProviderOptions = {
+  env: XmtpEnv
+  persistConversations: boolean
+  privateKeyOverride?: Uint8Array
+}
+
+/**
+ * A Keystore Provider is responsible for either creating a Keystore instance or throwing a KeystoreUnavailableError
+ * It is typically used once on application startup to bootstrap the Keystore and load/decrypt the user's private keys
+ */
+export interface KeystoreProvider {
+  newKeystore(
+    opts: KeystoreProviderOptions,
+    apiClient: ApiClient,
+    wallet?: Signer
+  ): Promise<Keystore>
+}

--- a/test/keystore/persistence/TopicPersistence.test.ts
+++ b/test/keystore/persistence/TopicPersistence.test.ts
@@ -1,0 +1,43 @@
+import { Signer } from './../../../src/types/Signer'
+import ApiClient, { ApiUrls } from '../../../src/ApiClient'
+import { newWallet } from '../../helpers'
+import TopicPersistence from '../../../src/keystore/persistence/TopicPersistence'
+import { Authenticator } from '../../../src/authn'
+import { PrivateKeyBundleV1 } from '../../../src/crypto'
+
+const TEST_KEY = 'foo'
+
+describe('TopicPersistence', () => {
+  let apiClient: ApiClient
+  let bundle: PrivateKeyBundleV1
+  beforeEach(async () => {
+    apiClient = new ApiClient(ApiUrls['local'])
+    bundle = await PrivateKeyBundleV1.generate(newWallet())
+  })
+  it('round trips items from the store', async () => {
+    const input = new TextEncoder().encode('hello')
+    apiClient.setAuthenticator(new Authenticator(bundle.identityKey))
+    const store = new TopicPersistence(apiClient)
+    await store.setItem(TEST_KEY, input)
+
+    const output = await store.getItem(TEST_KEY)
+    expect(output).toEqual(input)
+  })
+
+  it('returns null for missing items', async () => {
+    const store = new TopicPersistence(apiClient)
+    expect(await store.getItem(TEST_KEY)).toBeNull()
+  })
+
+  it('allows overwriting of values', async () => {
+    const firstInput = new TextEncoder().encode('hello')
+    apiClient.setAuthenticator(new Authenticator(bundle.identityKey))
+    const store = new TopicPersistence(apiClient)
+    await store.setItem(TEST_KEY, firstInput)
+    expect(await store.getItem(TEST_KEY)).toEqual(firstInput)
+
+    const secondInput = new TextEncoder().encode('goodbye')
+    await store.setItem(TEST_KEY, secondInput)
+    expect(await store.getItem(TEST_KEY)).toEqual(secondInput)
+  })
+})

--- a/test/keystore/providers/NetworkKeyManager.test.ts
+++ b/test/keystore/providers/NetworkKeyManager.test.ts
@@ -1,0 +1,67 @@
+import ApiClient, { ApiUrls } from '../../../src/ApiClient'
+import { PrivateKeyBundleV1 } from '../../../src/crypto/PrivateKeyBundle'
+import TopicPersistence from '../../../src/keystore/persistence/TopicPersistence'
+import NetworkKeyManager from '../../../src/keystore/providers/NetworkKeyManager'
+import { Signer } from '../../../src/types/Signer'
+import { newWallet, sleep, wrapAsLedgerWallet } from '../../helpers'
+
+describe('NetworkKeyManager', () => {
+  let wallet: Signer
+  let persistence: TopicPersistence
+
+  beforeEach(async () => {
+    wallet = newWallet()
+    persistence = new TopicPersistence(new ApiClient(ApiUrls['local']))
+  })
+
+  it('encrypts with Ledger and decrypts with Metamask', async () => {
+    const wallet = newWallet()
+    const ledgerLikeWallet = wrapAsLedgerWallet(wallet)
+    const secureLedgerStore = new NetworkKeyManager(
+      ledgerLikeWallet,
+      persistence
+    )
+    const secureNormalStore = new NetworkKeyManager(wallet, persistence)
+    const originalBundle = await PrivateKeyBundleV1.generate(ledgerLikeWallet)
+
+    await secureLedgerStore.storePrivateKeyBundle(originalBundle)
+    await sleep(100)
+    const returnedBundle = await secureNormalStore.loadPrivateKeyBundle()
+    if (!returnedBundle) {
+      throw new Error('No bundle returned')
+    }
+
+    expect(returnedBundle).toBeDefined()
+    expect(originalBundle.identityKey.toBytes()).toEqual(
+      returnedBundle.identityKey.toBytes()
+    )
+    expect(originalBundle.preKeys).toHaveLength(returnedBundle.preKeys.length)
+    expect(originalBundle.preKeys[0].toBytes()).toEqual(
+      returnedBundle.preKeys[0].toBytes()
+    )
+  })
+
+  it('encrypts with Metamask and decrypts with Ledger', async () => {
+    const wallet = newWallet()
+    const ledgerLikeWallet = wrapAsLedgerWallet(wallet)
+    const ledgerManager = new NetworkKeyManager(ledgerLikeWallet, persistence)
+    const normalManager = new NetworkKeyManager(wallet, persistence)
+    const originalBundle = await PrivateKeyBundleV1.generate(wallet)
+
+    await normalManager.storePrivateKeyBundle(originalBundle)
+    await sleep(100)
+    const returnedBundle = await ledgerManager.loadPrivateKeyBundle()
+    if (!returnedBundle) {
+      throw new Error('No bundle returned')
+    }
+
+    expect(returnedBundle).toBeDefined()
+    expect(originalBundle.identityKey.toBytes()).toEqual(
+      returnedBundle.identityKey.toBytes()
+    )
+    expect(originalBundle.preKeys).toHaveLength(returnedBundle.preKeys.length)
+    expect(originalBundle.preKeys[0].toBytes()).toEqual(
+      returnedBundle.preKeys[0].toBytes()
+    )
+  })
+})

--- a/test/keystore/providers/NetworkKeystoreProvider.test.ts
+++ b/test/keystore/providers/NetworkKeystoreProvider.test.ts
@@ -1,0 +1,87 @@
+import { privateKey } from '@xmtp/proto'
+import { KeystoreProviderUnavailableError } from './../../../src/keystore/providers/errors'
+import ApiClient, { ApiUrls } from '../../../src/ApiClient'
+import {
+  encrypt,
+  PrivateKeyBundleV1,
+  SignedPublicKeyBundle,
+  utils,
+} from '../../../src/crypto'
+import NetworkKeystoreProvider from '../../../src/keystore/providers/NetworkKeystoreProvider'
+import { Signer } from '../../../src/types/Signer'
+import { newWallet } from '../../helpers'
+import { testProviderOptions } from './helpers'
+import NetworkKeyManager, {
+  storageSigRequestText,
+} from '../../../src/keystore/providers/NetworkKeyManager'
+import TopicPersistence from '../../../src/keystore/persistence/TopicPersistence'
+import { getRandomValues, hexToBytes } from '../../../src/crypto/utils'
+import Authenticator from '../../../src/authn/Authenticator'
+
+describe('NetworkKeystoreProvider', () => {
+  let apiClient: ApiClient
+  let bundle: PrivateKeyBundleV1
+  let wallet: Signer
+
+  beforeEach(async () => {
+    apiClient = new ApiClient(ApiUrls['local'])
+    wallet = newWallet()
+    bundle = await PrivateKeyBundleV1.generate(wallet)
+  })
+
+  it('fails gracefully when no keys are found', async () => {
+    const provider = new NetworkKeystoreProvider()
+    expect(
+      provider.newKeystore(testProviderOptions(), apiClient, wallet)
+    ).rejects.toThrow(KeystoreProviderUnavailableError)
+  })
+
+  it('loads keys when they are already set', async () => {
+    const manager = new NetworkKeyManager(
+      wallet,
+      new TopicPersistence(apiClient)
+    )
+    await manager.storePrivateKeyBundle(bundle)
+
+    const provider = new NetworkKeystoreProvider()
+    const keystore = await provider.newKeystore(
+      testProviderOptions(),
+      apiClient,
+      wallet
+    )
+    expect(await keystore.getPublicKeyBundle()).toEqual(
+      SignedPublicKeyBundle.fromLegacyBundle(bundle.getPublicKeyBundle())
+    )
+  })
+
+  it('properly handles legacy keys', async () => {
+    // Create a legacy EncryptedPrivateKeyBundleV1 and store it on the node
+    const bytes = bundle.encode()
+    const wPreKey = getRandomValues(new Uint8Array(32))
+    const input = storageSigRequestText(wPreKey)
+    const walletAddr = await wallet.getAddress()
+
+    let sig = await wallet.signMessage(input)
+    const secret = hexToBytes(sig)
+    const ciphertext = await encrypt(bytes, secret)
+    const bytesToStore = privateKey.EncryptedPrivateKeyBundleV1.encode({
+      ciphertext,
+      walletPreKey: wPreKey,
+    }).finish()
+
+    // Store the legacy key on the node
+    apiClient.setAuthenticator(new Authenticator(bundle.identityKey))
+    const persistence = new TopicPersistence(apiClient)
+    const key = `${walletAddr}/key_bundle`
+    await persistence.setItem(key, bytesToStore)
+
+    // Now try and load it
+    const provider = new NetworkKeystoreProvider()
+    const keystore = await provider.newKeystore(
+      testProviderOptions(),
+      apiClient,
+      wallet
+    )
+    expect(keystore).toBeDefined()
+  })
+})

--- a/test/keystore/providers/StaticKeystoreProvider.test.ts
+++ b/test/keystore/providers/StaticKeystoreProvider.test.ts
@@ -1,0 +1,41 @@
+import { privateKey } from '@xmtp/proto'
+import { PrivateKeyBundleV1 } from '../../../src/crypto'
+import { newWallet } from '../../helpers'
+import StaticKeystoreProvider from '../../../src/keystore/providers/StaticKeystoreProvider'
+import { KeystoreProviderUnavailableError } from '../../../src/keystore/providers/errors'
+
+const ENV = 'local'
+
+describe('StaticKeystoreProvider', () => {
+  it('works with a valid key', async () => {
+    const key = await PrivateKeyBundleV1.generate(newWallet())
+    const keyBytes = privateKey.PrivateKeyBundleV1.encode(key).finish()
+    const provider = new StaticKeystoreProvider()
+    const keystore = await provider.newKeystore({
+      privateKeyOverride: keyBytes,
+      env: ENV,
+      persistConversations: false,
+    })
+
+    expect(keystore).not.toBeNull()
+  })
+
+  it('throws with an unset key', async () => {
+    expect(
+      new StaticKeystoreProvider().newKeystore({
+        env: ENV,
+        persistConversations: false,
+      })
+    ).rejects.toThrow(KeystoreProviderUnavailableError)
+  })
+
+  it('fails with an invalid key', async () => {
+    expect(
+      new StaticKeystoreProvider().newKeystore({
+        privateKeyOverride: Uint8Array.from([1, 2, 3]),
+        env: ENV,
+        persistConversations: false,
+      })
+    ).rejects.toThrow()
+  })
+})

--- a/test/keystore/providers/StaticKeystoreProvider.test.ts
+++ b/test/keystore/providers/StaticKeystoreProvider.test.ts
@@ -9,7 +9,10 @@ const ENV = 'local'
 describe('StaticKeystoreProvider', () => {
   it('works with a valid key', async () => {
     const key = await PrivateKeyBundleV1.generate(newWallet())
-    const keyBytes = privateKey.PrivateKeyBundleV1.encode(key).finish()
+    const keyBytes = privateKey.PrivateKeyBundle.encode({
+      v1: key,
+      v2: undefined,
+    }).finish()
     const provider = new StaticKeystoreProvider()
     const keystore = await provider.newKeystore({
       privateKeyOverride: keyBytes,

--- a/test/keystore/providers/helpers.ts
+++ b/test/keystore/providers/helpers.ts
@@ -1,0 +1,8 @@
+export const testProviderOptions = (
+  privateKeyOverride = undefined,
+  persistConversations = false
+) => ({
+  env: 'local' as const,
+  persistConversations,
+  privateKeyOverride,
+})


### PR DESCRIPTION
## Summary
- Creates the infrastructure for loading keys from the network and creating a Keystore
- Tests for those flows, including legacy keys and ledger wallets
- Adds new `TopicPersistence` class for persisting data on the network
- Adds `StaticKeystoreProvider` for cases where the user provides a `privateKeyOverride`
- Adds a `KeyGeneratorKeystoreProvider`, which is a truly awful name that I am open to suggestions on, for creating a Keystore from a newly generated key.

## Next up
- Actually bootstrap the Keystore as part of `Client.create`
- Delete `store` folder and remove all duplicate code
- Implement `Client.getKeys`, but with the possibility that some keystore implementations will throw an error (for example, remote Keystores)
- Implement a mechanism for getting API auth tokens from the Keystore