### PR TITLE
feat: introduce Conversation.prepareMessage

### DIFF
--- a/src/PreparedMessage.ts
+++ b/src/PreparedMessage.ts
@@ -1,0 +1,25 @@
+import { Envelope } from '@xmtp/proto/ts/dist/types/message_api/v1/message_api.pb'
+import { bytesToHex } from './crypto/utils'
+import { sha256 } from './crypto/encryption'
+
+export class PreparedMessage {
+  messageEnvelope: Envelope
+  onSend: () => Promise<void>
+
+  constructor(messageEnvelope: Envelope, onSend: () => Promise<void>) {
+    this.messageEnvelope = messageEnvelope
+    this.onSend = onSend
+  }
+
+  async messageID(): Promise<string> {
+    if (!this.messageEnvelope.message) {
+      throw new Error('no envelope message')
+    }
+
+    return bytesToHex(await sha256(this.messageEnvelope.message))
+  }
+
+  async send() {
+    await this.onSend()
+  }
+}

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -107,7 +107,7 @@ describe('conversation', () => {
     it('ignores failed decoding of messages', async () => {
       const consoleWarn = jest
         .spyOn(console, 'warn')
-        .mockImplementation(() => { })
+        .mockImplementation(() => {})
       const aliceConversation = await alice.conversations.newConversation(
         bob.address
       )
@@ -161,10 +161,12 @@ describe('conversation', () => {
 
     it('can send a prepared message v2', async () => {
       const aliceConversation = await alice.conversations.newConversation(
-        bob.address, {
-        conversationId: "example.com",
-        metadata: {}
-      })
+        bob.address,
+        {
+          conversationId: 'example.com',
+          metadata: {},
+        }
+      )
       expect(aliceConversation.export().version).toBe('v2')
 
       const preparedMessage = await aliceConversation.prepareMessage('sup')
@@ -338,7 +340,7 @@ describe('conversation', () => {
     it('filters out spoofed messages', async () => {
       const consoleWarn = jest
         .spyOn(console, 'warn')
-        .mockImplementation(() => { })
+        .mockImplementation(() => {})
       const aliceConvo = await alice.conversations.newConversation(bob.address)
       const bobConvo = await bob.conversations.newConversation(alice.address)
       const stream = await bobConvo.streamMessages()

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -107,7 +107,7 @@ describe('conversation', () => {
     it('ignores failed decoding of messages', async () => {
       const consoleWarn = jest
         .spyOn(console, 'warn')
-        .mockImplementation(() => {})
+        .mockImplementation(() => { })
       const aliceConversation = await alice.conversations.newConversation(
         bob.address
       )
@@ -141,6 +141,41 @@ describe('conversation', () => {
       expect(messages[0].content).toBe('hey me')
       expect(messages[0].senderAddress).toBe(alice.address)
       expect(messages[0].recipientAddress).toBe(alice.address)
+    })
+
+    it('can send a prepared message v1', async () => {
+      const aliceConversation = await alice.conversations.newConversation(
+        bob.address
+      )
+      expect(aliceConversation.export().version).toBe('v1')
+
+      const preparedMessage = await aliceConversation.prepareMessage('1')
+      const messageID = await preparedMessage.messageID()
+
+      await preparedMessage.send()
+
+      const messages = await aliceConversation.messages()
+      const message = messages[0]
+      expect(message.id).toBe(messageID)
+    })
+
+    it('can send a prepared message v2', async () => {
+      const aliceConversation = await alice.conversations.newConversation(
+        bob.address, {
+        conversationId: "example.com",
+        metadata: {}
+      })
+      expect(aliceConversation.export().version).toBe('v2')
+
+      const preparedMessage = await aliceConversation.prepareMessage('sup')
+      const messageID = await preparedMessage.messageID()
+
+      await preparedMessage.send()
+
+      const messages = await aliceConversation.messages()
+      const message = messages[0]
+      expect(message.id).toBe(messageID)
+      expect(message.content).toBe('sup')
     })
 
     it('allows for sorted listing', async () => {
@@ -303,7 +338,7 @@ describe('conversation', () => {
     it('filters out spoofed messages', async () => {
       const consoleWarn = jest
         .spyOn(console, 'warn')
-        .mockImplementation(() => {})
+        .mockImplementation(() => { })
       const aliceConvo = await alice.conversations.newConversation(bob.address)
       const bobConvo = await bob.conversations.newConversation(alice.address)
       const stream = await bobConvo.streamMessages()


### PR DESCRIPTION
This gives back a PreparedMessage that has a messageID on it. Clients can use this for optimistic sending purposes. Clients can then call `send()` on the prepared message to publish it to the network.

See also https://github.com/xmtp/xmtp-ios/pull/80