### PR TITLE
Make Authenticator an interface and add new Keystore methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.18.0",
+        "@xmtp/proto": "^3.20.0",
         "async-mutex": "^0.4.0",
         "eccrypto": "^1.1.6",
         "ethers": "^5.5.3",
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.18.0.tgz",
-      "integrity": "sha512-tCVQLwZdaMo+ypqIfLdf0Hxnh+3AEyLtQArguhSacTpBq/c2yfpz9mbhzWXCVnC1l/0VOAqMreKdNtamHs2Rbg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.20.0.tgz",
+      "integrity": "sha512-fvCK6WKGyuzPS0OpiL+J4rsoSlaQPXDO3WwotdAjZ3hVTpdvNwrgEi1EcYMcahvNXq5Cij7IZSvcfN3ziK3y1g==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -16747,9 +16747,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.18.0.tgz",
-      "integrity": "sha512-tCVQLwZdaMo+ypqIfLdf0Hxnh+3AEyLtQArguhSacTpBq/c2yfpz9mbhzWXCVnC1l/0VOAqMreKdNtamHs2Rbg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.20.0.tgz",
+      "integrity": "sha512-fvCK6WKGyuzPS0OpiL+J4rsoSlaQPXDO3WwotdAjZ3hVTpdvNwrgEi1EcYMcahvNXq5Cij7IZSvcfN3ziK3y1g==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.18.0",
+    "@xmtp/proto": "^3.20.0",
     "async-mutex": "^0.4.0",
     "eccrypto": "^1.1.6",
     "ethers": "^5.5.3",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -26,7 +26,7 @@ import { compress } from './Compression'
 import { content as proto, messageApi, fetcher } from '@xmtp/proto'
 import { decodeContactBundle, encodeContactBundle } from './ContactBundle'
 import ApiClient, { ApiUrls, PublishParams, SortDirection } from './ApiClient'
-import { Authenticator } from './authn'
+import { KeystoreAuthenticator } from './authn'
 import { Flatten } from './utils/typedefs'
 import BackupClient, { BackupType } from './message-backup/BackupClient'
 import { createBackupClient } from './message-backup/BackupClientFactory'
@@ -214,7 +214,7 @@ export default class Client {
     const keys = await loadOrCreateKeysFromOptions(options, wallet, apiClient)
     // TODO: Properly bootstrap the keystore and replace `loadOrCreateKeysFromOptions`
     const keystore = await InMemoryKeystore.create(keys)
-    apiClient.setAuthenticator(new Authenticator(keys.identityKey))
+    apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(
       keys.identityKey.publicKey.walletSignatureAddress(),
       options.env

--- a/src/authn/AuthCache.ts
+++ b/src/authn/AuthCache.ts
@@ -1,4 +1,4 @@
-import Authenticator from './Authenticator'
+import { Authenticator } from './interfaces'
 import Token from './Token'
 
 // Default to 10 seconds less than expected expiry to give some wiggle room near the end

--- a/src/authn/KeystoreAuthenticator.ts
+++ b/src/authn/KeystoreAuthenticator.ts
@@ -1,0 +1,27 @@
+import { authn } from '@xmtp/proto'
+import { Keystore } from '../keystore'
+import { dateToNs } from '../utils'
+import Token from './Token'
+
+const wrapToken = (token: authn.Token): Token => {
+  if (token instanceof Token) {
+    return token
+  }
+  return new Token(token)
+}
+
+export default class KeystoreAuthenticator {
+  private keystore: Keystore
+
+  constructor(keystore: Keystore) {
+    this.keystore = keystore
+  }
+
+  async createToken(timestamp?: Date): Promise<Token> {
+    const token = await this.keystore.createAuthToken({
+      timestampNs: timestamp ? dateToNs(timestamp) : undefined,
+    })
+
+    return wrapToken(token)
+  }
+}

--- a/src/authn/LocalAuthenticator.ts
+++ b/src/authn/LocalAuthenticator.ts
@@ -5,13 +5,14 @@ import { PrivateKey } from '../crypto'
 import { hexToBytes } from '../crypto/utils'
 import Token from './Token'
 
-export default class Authenticator {
+export default class LocalAuthenticator {
   private identityKey: PrivateKey
 
   constructor(identityKey: PrivateKey) {
     if (!identityKey.publicKey.signature) {
       throw new Error('Provided public key is not signed')
     }
+
     this.identityKey = identityKey
   }
 

--- a/src/authn/index.ts
+++ b/src/authn/index.ts
@@ -1,4 +1,5 @@
-// Commenting out this package until we have support for authn in GRPC
-export { default as Authenticator } from './Authenticator'
+export { default as LocalAuthenticator } from './LocalAuthenticator'
+export { default as KeystoreAuthenticator } from './KeystoreAuthenticator'
 export { default as AuthData } from './AuthData'
 export { default as Token } from './Token'
+export * from './interfaces'

--- a/src/authn/interfaces.ts
+++ b/src/authn/interfaces.ts
@@ -1,0 +1,5 @@
+import Token from './Token'
+
+export interface Authenticator {
+  createToken(timestamp?: Date): Promise<Token>
+}

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -1,10 +1,10 @@
-import { keystore } from '@xmtp/proto'
+import { authn, keystore, privateKey, signature } from '@xmtp/proto'
 import {
   PrivateKeyBundleV1,
   PrivateKeyBundleV2,
 } from './../crypto/PrivateKeyBundle'
 import { InvitationV1, SealedInvitation } from './../Invitation'
-import { SignedPublicKeyBundle } from '../crypto'
+import { PrivateKey, PublicKeyBundle } from '../crypto'
 import { Keystore, TopicData } from './interfaces'
 import { decryptV1, encryptV1, encryptV2, decryptV2 } from './encryption'
 import { KeystoreError } from './errors'
@@ -20,17 +20,20 @@ import {
 import { nsToDate } from '../utils'
 import InviteStore from './InviteStore'
 import { Persistence } from './persistence'
+import LocalAuthenticator from '../authn/LocalAuthenticator'
 const { ErrorCode } = keystore
 
 export default class InMemoryKeystore implements Keystore {
   private v1Keys: PrivateKeyBundleV1
   private v2Keys: PrivateKeyBundleV2 // Do I need this?
   private inviteStore: InviteStore
+  private authenticator: LocalAuthenticator
 
   constructor(keys: PrivateKeyBundleV1, inviteStore: InviteStore) {
     this.v1Keys = keys
     this.v2Keys = PrivateKeyBundleV2.fromLegacyBundle(keys)
     this.inviteStore = inviteStore
+    this.authenticator = new LocalAuthenticator(keys.identityKey)
   }
 
   static async create(keys: PrivateKeyBundleV1, persistence?: Persistence) {
@@ -136,6 +139,14 @@ export default class InMemoryKeystore implements Keystore {
     return keystore.EncryptResponse.fromPartial({
       responses,
     })
+  }
+
+  async createAuthToken({
+    timestampNs,
+  }: keystore.CreateAuthTokenRequest): Promise<authn.Token> {
+    return this.authenticator.createToken(
+      timestampNs ? nsToDate(timestampNs) : undefined
+    )
   }
 
   async encryptV2(
@@ -254,6 +265,41 @@ export default class InMemoryKeystore implements Keystore {
     }
   }
 
+  async signDigest(
+    req: keystore.SignDigestRequest
+  ): Promise<signature.Signature> {
+    if (!validateObject(req, ['digest'], [])) {
+      throw new KeystoreError(
+        ErrorCode.ERROR_CODE_INVALID_INPUT,
+        'missing required field'
+      )
+    }
+
+    const { digest, identityKey, prekeyIndex } = req
+    let key: PrivateKey
+    if (identityKey) {
+      key = this.v1Keys.identityKey
+    } else if (
+      typeof prekeyIndex !== 'undefined' &&
+      Number.isInteger(prekeyIndex)
+    ) {
+      key = this.v1Keys.preKeys[prekeyIndex]
+      if (!key) {
+        throw new KeystoreError(
+          ErrorCode.ERROR_CODE_NO_MATCHING_PREKEY,
+          'no prekey found'
+        )
+      }
+    } else {
+      throw new KeystoreError(
+        ErrorCode.ERROR_CODE_INVALID_INPUT,
+        'must specifify identityKey or prekeyIndex'
+      )
+    }
+
+    return key.sign(digest)
+  }
+
   async getV2Conversations(): Promise<keystore.ConversationReference[]> {
     const convos = this.inviteStore.topics.map((invite) =>
       topicDataToConversationReference(invite)
@@ -265,8 +311,12 @@ export default class InMemoryKeystore implements Keystore {
     return convos
   }
 
-  async getPublicKeyBundle(): Promise<SignedPublicKeyBundle> {
-    return this.v2Keys.getPublicKeyBundle()
+  async getPublicKeyBundle(): Promise<PublicKeyBundle> {
+    return this.v1Keys.getPublicKeyBundle()
+  }
+
+  async getPrivateKeyBundle(): Promise<privateKey.PrivateKeyBundleV1> {
+    return this.v1Keys
   }
 
   async getAccountAddress(): Promise<string> {

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -1,4 +1,4 @@
-import { keystore, publicKey } from '@xmtp/proto'
+import { keystore, privateKey, publicKey, authn, signature } from '@xmtp/proto'
 import { WithoutUndefined } from './utils'
 export interface Keystore {
   // Decrypt a batch of V1 messages
@@ -17,10 +17,16 @@ export interface Keystore {
   createInvite(
     req: keystore.CreateInviteRequest
   ): Promise<keystore.CreateInviteResponse>
+  // Get an API auth token
+  createAuthToken(req: keystore.CreateAuthTokenRequest): Promise<authn.Token>
+  // Sign the provided digest
+  signDigest(req: keystore.SignDigestRequest): Promise<signature.Signature>
   // Get V2 conversations
   getV2Conversations(): Promise<keystore.ConversationReference[]>
   // Used for publishing the contact
-  getPublicKeyBundle(): Promise<publicKey.SignedPublicKeyBundle>
+  getPublicKeyBundle(): Promise<publicKey.PublicKeyBundle>
+  // Export the private keys. May throw an error if the keystore does not allow this operation
+  getPrivateKeyBundle(): Promise<privateKey.PrivateKeyBundleV1>
   // Technically duplicative of `getPublicKeyBundle`, but nice for ergonomics
   getAccountAddress(): Promise<string>
 }

--- a/src/keystore/persistence/TopicPersistence.ts
+++ b/src/keystore/persistence/TopicPersistence.ts
@@ -1,6 +1,6 @@
 import { messageApi } from '@xmtp/proto'
 import ApiClient from '../../ApiClient'
-import Authenticator from '../../authn/Authenticator'
+import { Authenticator } from '../../authn'
 import { b64Decode } from '../../utils/bytes'
 import { buildUserPrivateStoreTopic } from '../../utils/topic'
 import { Persistence } from './interface'

--- a/src/keystore/providers/NetworkKeyManager.ts
+++ b/src/keystore/providers/NetworkKeyManager.ts
@@ -7,7 +7,7 @@ import {
   encrypt,
   PrivateKeyBundleV2,
 } from '../../crypto'
-import { Authenticator } from '../../authn'
+import { LocalAuthenticator } from '../../authn'
 import { bytesToHex, getRandomValues, hexToBytes } from '../../crypto/utils'
 import Ciphertext from '../../crypto/Ciphertext'
 import { privateKey as proto } from '@xmtp/proto'
@@ -62,7 +62,9 @@ export default class NetworkKeyManager {
     const encodedBundle = await this.toEncryptedBytes(bundle, this.signer)
     // We need to setup the Authenticator so that the underlying store can publish messages without error
     if (typeof this.persistence.setAuthenticator === 'function') {
-      this.persistence.setAuthenticator(new Authenticator(bundle.identityKey))
+      this.persistence.setAuthenticator(
+        new LocalAuthenticator(bundle.identityKey)
+      )
     }
 
     await this.persistence.setItem(keyAddress, encodedBundle)

--- a/src/store/EncryptedStore.ts
+++ b/src/store/EncryptedStore.ts
@@ -8,7 +8,7 @@ import {
   encrypt,
 } from '../crypto'
 import { KeyStore } from './KeyStore'
-import { Authenticator } from '../authn'
+import { LocalAuthenticator } from '../authn'
 import { bytesToHex, getRandomValues, hexToBytes } from '../crypto/utils'
 import Ciphertext from '../crypto/Ciphertext'
 import { privateKey as proto } from '@xmtp/proto'
@@ -62,7 +62,7 @@ export default class EncryptedKeyStore implements KeyStore {
     const encodedBundle = await this.toEncryptedBytes(bundle, this.signer)
     // We need to setup the Authenticator so that the underlying store can publish messages without error
     if (typeof this.store.setAuthenticator === 'function') {
-      this.store.setAuthenticator(new Authenticator(bundle.identityKey))
+      this.store.setAuthenticator(new LocalAuthenticator(bundle.identityKey))
     }
     await this.store.set(keyAddress, Buffer.from(encodedBundle))
   }

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -5,7 +5,7 @@ import {
 import ApiClient, { GrpcStatus, PublishParams } from '../src/ApiClient'
 import { messageApi } from '@xmtp/proto'
 import { sleep } from './helpers'
-import { Authenticator } from '../src/authn'
+import { LocalAuthenticator } from '../src/authn'
 import { PrivateKey } from '../src'
 import { version } from '../package.json'
 import { dateToNs } from '../src/utils'
@@ -152,7 +152,9 @@ describe('Publish', () => {
 
   it('publishes valid messages', async () => {
     // This Authenticator will not actually be used by the mock
-    publishClient.setAuthenticator(new Authenticator(PrivateKey.generate()))
+    publishClient.setAuthenticator(
+      new LocalAuthenticator(PrivateKey.generate())
+    )
 
     const now = new Date()
     const msg: PublishParams = {
@@ -203,7 +205,9 @@ describe('Publish authn', () => {
 
   it('retries on invalid message', async () => {
     const publishMock = createAuthErrorPublishMock(1)
-    publishClient.setAuthenticator(new Authenticator(PrivateKey.generate()))
+    publishClient.setAuthenticator(
+      new LocalAuthenticator(PrivateKey.generate())
+    )
 
     const now = new Date()
     const msg: PublishParams = {
@@ -218,7 +222,9 @@ describe('Publish authn', () => {
 
   it('gives up after a second auth error', async () => {
     const publishMock = createAuthErrorPublishMock(5)
-    publishClient.setAuthenticator(new Authenticator(PrivateKey.generate()))
+    publishClient.setAuthenticator(
+      new LocalAuthenticator(PrivateKey.generate())
+    )
 
     const now = new Date()
     const msg: PublishParams = {

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -29,7 +29,7 @@ const mockGetToken = jest.fn().mockReturnValue(
     age: 10,
   })
 )
-jest.mock('../src/authn/Authenticator', () => {
+jest.mock('../src/authn/LocalAuthenticator', () => {
   return jest.fn().mockImplementation(() => {
     return { createToken: mockGetToken }
   })

--- a/test/ApiClientE2E.test.ts
+++ b/test/ApiClientE2E.test.ts
@@ -1,6 +1,6 @@
 import ApiClient, { ApiUrls, GrpcStatus, PublishParams } from '../src/ApiClient'
 import { newWallet, sleep } from './helpers'
-import { Authenticator } from '../src/authn'
+import { LocalAuthenticator } from '../src/authn'
 import { buildUserPrivateStoreTopic, dateToNs } from '../src/utils'
 import { Wallet } from 'ethers'
 import { PrivateKeyBundleV1 } from '../src/crypto'
@@ -29,7 +29,7 @@ describe('e2e tests', () => {
         wallet = newWallet()
         client = new ApiClient(testCase.api)
         keys = await PrivateKeyBundleV1.generate(wallet)
-        client.setAuthenticator(new Authenticator(keys.identityKey))
+        client.setAuthenticator(new LocalAuthenticator(keys.identityKey))
       })
 
       it('publish success', async () => {

--- a/test/authn/Authn.test.ts
+++ b/test/authn/Authn.test.ts
@@ -1,7 +1,7 @@
 import { keccak256 } from 'js-sha3'
 import Long from 'long'
 import { PrivateKey, PrivateKeyBundleV1, Signature } from '../../src/crypto'
-import Authenticator from '../../src/authn/Authenticator'
+import Authenticator from '../../src/authn/LocalAuthenticator'
 import Token from '../../src/authn/Token'
 import { hexToBytes } from '../../src/crypto/utils'
 import { newWallet, sleep } from '../helpers'

--- a/test/keystore/persistence/TopicPersistence.test.ts
+++ b/test/keystore/persistence/TopicPersistence.test.ts
@@ -2,7 +2,7 @@ import { Signer } from './../../../src/types/Signer'
 import ApiClient, { ApiUrls } from '../../../src/ApiClient'
 import { newWallet } from '../../helpers'
 import TopicPersistence from '../../../src/keystore/persistence/TopicPersistence'
-import { Authenticator } from '../../../src/authn'
+import { LocalAuthenticator } from '../../../src/authn'
 import { PrivateKeyBundleV1 } from '../../../src/crypto'
 
 // We restrict publishing to topics that do not match this pattern
@@ -20,7 +20,7 @@ describe('TopicPersistence', () => {
     const storageKey = buildValidKey(
       bundle.identityKey.publicKey.walletSignatureAddress()
     )
-    apiClient.setAuthenticator(new Authenticator(bundle.identityKey))
+    apiClient.setAuthenticator(new LocalAuthenticator(bundle.identityKey))
     const store = new TopicPersistence(apiClient)
     try {
       await store.setItem(storageKey, input)
@@ -46,7 +46,7 @@ describe('TopicPersistence', () => {
       bundle.identityKey.publicKey.walletSignatureAddress()
     )
     const store = new TopicPersistence(apiClient)
-    store.setAuthenticator(new Authenticator(bundle.identityKey))
+    store.setAuthenticator(new LocalAuthenticator(bundle.identityKey))
     await store.setItem(storageKey, firstInput)
     expect(await store.getItem(storageKey)).toEqual(firstInput)
 

--- a/test/keystore/providers/NetworkKeystoreProvider.test.ts
+++ b/test/keystore/providers/NetworkKeystoreProvider.test.ts
@@ -16,7 +16,7 @@ import NetworkKeyManager, {
 } from '../../../src/keystore/providers/NetworkKeyManager'
 import TopicPersistence from '../../../src/keystore/persistence/TopicPersistence'
 import { getRandomValues, hexToBytes } from '../../../src/crypto/utils'
-import Authenticator from '../../../src/authn/Authenticator'
+import { LocalAuthenticator } from '../../../src/authn'
 
 describe('NetworkKeystoreProvider', () => {
   let apiClient: ApiClient
@@ -50,7 +50,7 @@ describe('NetworkKeystoreProvider', () => {
       wallet
     )
     expect(await keystore.getPublicKeyBundle()).toEqual(
-      SignedPublicKeyBundle.fromLegacyBundle(bundle.getPublicKeyBundle())
+      bundle.getPublicKeyBundle()
     )
   })
 
@@ -70,7 +70,7 @@ describe('NetworkKeystoreProvider', () => {
     }).finish()
 
     // Store the legacy key on the node
-    apiClient.setAuthenticator(new Authenticator(bundle.identityKey))
+    apiClient.setAuthenticator(new LocalAuthenticator(bundle.identityKey))
     const persistence = new TopicPersistence(apiClient)
     const key = `${walletAddr}/key_bundle`
     await persistence.setItem(key, bytesToStore)

--- a/test/store/NetworkStore.test.ts
+++ b/test/store/NetworkStore.test.ts
@@ -4,7 +4,7 @@ import { newWallet, pollFor } from '../helpers'
 import { PrivateTopicStore } from '../../src/store'
 import ApiClient, { ApiUrls } from '../../src/ApiClient'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
-import Authenticator from '../../src/authn/Authenticator'
+import LocalAuthenticator from '../../src/authn/LocalAuthenticator'
 
 type TestCase = { name: string; api: string }
 
@@ -32,7 +32,7 @@ describe('PrivateTopicStore', () => {
         wallet = newWallet()
         store = new PrivateTopicStore(new ApiClient(testCase.api))
         const keys = await PrivateKeyBundleV1.generate(wallet)
-        store.setAuthenticator(new Authenticator(keys.identityKey))
+        store.setAuthenticator(new LocalAuthenticator(keys.identityKey))
       })
 
       it('roundtrip', async () => {


### PR DESCRIPTION
## Summary

- With the move to the Keystore, there are now two types of Authenticator needed. Once the Keystore is bootstrapped, we can use a `KeystoreAuthenticator` that proxies all calls to the Keystore. But the Keystore itself needs to be able to generate auth tokens, so the existing Authenticator class has been renamed `LocalAuthenticator` and is used inside the Keystore.
- Adds support for `signDigest` API
- Swaps `SignedPublicKeyBundle` with `PublicKeyBundle` in the `getPublicKeyBundle` Keystore endpoint. This is to allow the caller to convert to `SignedPublicKeyBundle` to have both. Conversion is only possible in one direction.
