### PR TITLE
Small tweak: debug jest tests against current file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,16 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Jest Tests",
+      "name": "Debug Jest Test: Current File",
+      // If you use nvm and VSCode can't find node,
+      // move your nvm init script to your .zprofile
+      // instead of your .zshrc
       "type": "node",
       "request": "launch",
       "runtimeArgs": [
         "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
+        "${fileBasenameNoExtension}",
         "--no-cache",
         "--runInBand",
         "--env=node",


### PR DESCRIPTION
Small quality of life improvement so that you don't have to wait for the rest of the tests when you're debugging a specific test.

The comment is fine here and accepted by VSCode.