### PR TITLE
Limit queries across topics

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -45,7 +45,7 @@ export type GrpcError = Flatten<Error & { code?: GrpcStatus }>
 export type QueryParams = {
   startTime?: Date
   endTime?: Date
-  contentTopics: string[]
+  contentTopic: string
 }
 
 export type QueryAllOptions = {
@@ -284,10 +284,10 @@ export default class ApiClient {
   // Creates an async generator that will paginate through the Query API until it reaches the end
   // Will yield each page of results as needed
   async *queryIteratePages(
-    { contentTopics, startTime, endTime }: QueryParams,
+    { contentTopic, startTime, endTime }: QueryParams,
     { direction, pageSize = 10 }: QueryStreamOptions
   ): AsyncGenerator<messageApi.Envelope[]> {
-    if (!contentTopics || !contentTopics.length) {
+    if (!contentTopic || !contentTopic.length) {
       throw new Error('Must specify content topics')
     }
 
@@ -303,7 +303,7 @@ export default class ApiClient {
       }
 
       const result = await this._query({
-        contentTopics,
+        contentTopics: [contentTopic],
         startTimeNs,
         endTimeNs,
         pagingInfo,
@@ -339,7 +339,7 @@ export default class ApiClient {
 
       for (const queryParams of queriesInBatch) {
         constructedQueries.push({
-          contentTopics: queryParams.contentTopics,
+          contentTopics: [queryParams.contentTopic],
           startTimeNs: toNanoString(queryParams.startTime),
           endTimeNs: toNanoString(queryParams.endTime),
           pagingInfo: {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -571,7 +571,7 @@ export default class Client {
 
   listInvitations(opts?: ListMessagesOptions): Promise<messageApi.Envelope[]> {
     return this.listEnvelopes(
-      [buildUserInviteTopic(this.address)],
+      buildUserInviteTopic(this.address),
       async (env) => env,
       opts
     )
@@ -585,7 +585,7 @@ export default class Client {
    * envelope will be discarded.
    */
   async listEnvelopes<Out>(
-    topics: string[],
+    topic: string,
     mapper: EnvelopeMapper<Out>,
     opts?: ListMessagesOptions
   ): Promise<Out[]> {
@@ -595,7 +595,7 @@ export default class Client {
     const { startTime, endTime, limit } = opts
 
     const envelopes = await this.apiClient.query(
-      { contentTopics: topics, startTime, endTime },
+      { contentTopic: topic, startTime, endTime },
       {
         direction:
           opts.direction || messageApi.SortDirection.SORT_DIRECTION_ASCENDING,
@@ -619,14 +619,14 @@ export default class Client {
    * List messages on a given set of content topics, yielding one page at a time
    */
   listEnvelopesPaginated<Out>(
-    contentTopics: string[],
+    contentTopic: string,
     mapper: EnvelopeMapper<Out>,
     opts?: ListMessagesPaginatedOptions
   ): AsyncGenerator<Out[]> {
     return mapPaginatedStream(
       this.apiClient.queryIteratePages(
         {
-          contentTopics,
+          contentTopic,
           startTime: opts?.startTime,
           endTime: opts?.endTime,
         },
@@ -650,7 +650,7 @@ async function getUserContactFromNetwork(
   peerAddress: string
 ): Promise<PublicKeyBundle | SignedPublicKeyBundle | undefined> {
   const stream = apiClient.queryIterator(
-    { contentTopics: [buildUserContactTopic(peerAddress)] },
+    { contentTopic: buildUserContactTopic(peerAddress) },
     { pageSize: 5, direction: SortDirection.SORT_DIRECTION_DESCENDING }
   )
 
@@ -676,7 +676,7 @@ async function getUserContactsFromNetwork(
   const userContactTopics = peerAddresses.map(buildUserContactTopic)
   const topicToEnvelopes = await apiClient.batchQuery(
     userContactTopics.map((topic) => ({
-      contentTopics: [topic],
+      contentTopic: topic,
       pageSize: 5,
       direction: SortDirection.SORT_DIRECTION_DESCENDING,
     }))

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -134,7 +134,7 @@ export class ConversationV1 implements Conversation {
   async messages(opts?: ListMessagesOptions): Promise<DecodedMessage[]> {
     const topic = buildDirectMessageTopic(this.peerAddress, this.client.address)
     const messages = await this.client.listEnvelopes(
-      [topic],
+      topic,
       this.processEnvelope.bind(this),
       opts
     )
@@ -146,7 +146,7 @@ export class ConversationV1 implements Conversation {
     opts?: ListMessagesPaginatedOptions
   ): AsyncGenerator<DecodedMessage[]> {
     return this.client.listEnvelopesPaginated(
-      [this.topic],
+      this.topic,
       // This won't be performant once we start supporting a remote keystore
       // TODO: Either better batch support or we ditch this under-utilized feature
       this.decodeMessage.bind(this),
@@ -351,7 +351,7 @@ export class ConversationV2 implements Conversation {
    */
   async messages(opts?: ListMessagesOptions): Promise<DecodedMessage[]> {
     const messages = await this.client.listEnvelopes(
-      [this.topic],
+      this.topic,
       this.processEnvelope.bind(this),
       opts
     )
@@ -363,7 +363,7 @@ export class ConversationV2 implements Conversation {
     opts?: ListMessagesPaginatedOptions
   ): AsyncGenerator<DecodedMessage[]> {
     return this.client.listEnvelopesPaginated(
-      [this.topic],
+      this.topic,
       this.decodeMessage.bind(this),
       opts
     )

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -383,7 +383,7 @@ export default class Conversations {
   ): Promise<Map<string, Date>> {
     const topic = buildUserIntroTopic(this.client.address)
     const messages = await this.client.listEnvelopes(
-      [topic],
+      topic,
       (env) => {
         return MessageV1.fromBytes(b64Decode(env.message as unknown as string))
       },

--- a/src/keystore/persistence/TopicPersistence.ts
+++ b/src/keystore/persistence/TopicPersistence.ts
@@ -14,7 +14,7 @@ export default class TopicPersistence implements Persistence {
   // Returns the first record in a topic if it is present.
   async getItem(key: string): Promise<Uint8Array | null> {
     for await (const env of this.apiClient.queryIterator(
-      { contentTopics: [this.buildTopic(key)] },
+      { contentTopic: this.buildTopic(key) },
       {
         pageSize: 1,
         direction: messageApi.SortDirection.SORT_DIRECTION_DESCENDING,

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -42,7 +42,7 @@ describe('Query', () => {
 
   it('stops when receiving empty results', async () => {
     const apiMock = createQueryMock([], 1)
-    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopic: CONTENT_TOPIC }, {})
     expect(result).toHaveLength(0)
     expect(apiMock).toHaveBeenCalledTimes(1)
     const expectedReq: messageApi.QueryRequest = {
@@ -64,7 +64,7 @@ describe('Query', () => {
   it('stops when limit is used', async () => {
     const apiMock = createQueryMock([createEnvelope()], 3)
     const result = await client.query(
-      { contentTopics: [CONTENT_TOPIC] },
+      { contentTopic: CONTENT_TOPIC },
       { limit: 2 }
     )
     expect(result).toHaveLength(2)
@@ -73,14 +73,14 @@ describe('Query', () => {
 
   it('stops when receiving some results and a null cursor', async () => {
     const apiMock = createQueryMock([createEnvelope()], 1)
-    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopic: CONTENT_TOPIC }, {})
     expect(result).toHaveLength(1)
     expect(apiMock).toHaveBeenCalledTimes(1)
   })
 
   it('gets multiple pages of results', async () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
-    const result = await client.query({ contentTopics: [CONTENT_TOPIC] }, {})
+    const result = await client.query({ contentTopic: CONTENT_TOPIC }, {})
     expect(result).toHaveLength(4)
     expect(apiMock).toHaveBeenCalledTimes(2)
   })
@@ -89,7 +89,7 @@ describe('Query', () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 1)
     let count = 0
     for await (const _envelope of client.queryIterator(
-      { contentTopics: ['foo'] },
+      { contentTopic: 'foo' },
       { pageSize: 5 }
     )) {
       count++
@@ -116,7 +116,7 @@ describe('Query', () => {
     const apiMock = createQueryMock([createEnvelope(), createEnvelope()], 2)
     let count = 0
     for await (const _envelope of client.queryIterator(
-      { contentTopics: [CONTENT_TOPIC] },
+      { contentTopic: CONTENT_TOPIC },
       { pageSize: 5 }
     )) {
       count++

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -251,7 +251,7 @@ describe('conversation', () => {
       // Verify that messages are actually compressed
       const envelopes = await alice.apiClient.query(
         {
-          contentTopics: [convo.topic],
+          contentTopic: convo.topic,
         },
         { limit: 1 }
       )


### PR DESCRIPTION
## Summary

As part of our decentralization roadmap, we are limiting the ability to query across multiple topics in a single query. This will allow for easier sharding across the network as `topic` will be the sharding key. The API endpoint will remain the same, but will throw an exception if the `contentTopics` array has a length > 1.

This adjusts our SDK to only allow for querying on a single topic.

## Notes

The ability to query across multiple topics is a relatively unused feature in our SDK, as none of our higher level methods take advantage of it. There are only a few usages of this feature in clients that use the `listEnvelopes` API directly. Those will break and will need to be adjusted as part of the v8 migration. `batchQuery` is a reasonable replacement for most of those use-cases.