### PR TITLE
feat: SIWE signature verification code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^3.22.0-beta.1",
         "async-mutex": "^0.4.0",
@@ -2225,6 +2226,17 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@noble/secp256k1": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.2.tgz",
@@ -2673,6 +2685,17 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       }
     },
     "node_modules/@stardazed/streams-polyfill": {
@@ -3584,6 +3607,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/apg-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.3.tgz",
+      "integrity": "sha512-XYyDcoBho8OpnWPRnedMwyL+76ovCtsESerHZEfY39dO4IrEqN97mdEYkOyHa0XTX5+3+U5FmpqPLttK0f7n6g=="
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -12261,7 +12289,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13983,7 +14010,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -14028,6 +14054,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -16007,6 +16038,11 @@
         "chalk": "^4.0.0"
       }
     },
+    "@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+    },
     "@noble/secp256k1": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.2.tgz",
@@ -16388,6 +16424,17 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "requires": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       }
     },
     "@stardazed/streams-polyfill": {
@@ -17138,6 +17185,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "apg-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.3.tgz",
+      "integrity": "sha512-XYyDcoBho8OpnWPRnedMwyL+76ovCtsESerHZEfY39dO4IrEqN97mdEYkOyHa0XTX5+3+U5FmpqPLttK0f7n6g=="
     },
     "arg": {
       "version": "4.1.3",
@@ -23583,8 +23635,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -24845,7 +24896,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -24886,6 +24936,11 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@spruceid/siwe-parser": "^2.0.2",
         "@stardazed/streams-polyfill": "^2.4.0",
         "@xmtp/proto": "^3.22.0-beta.1",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
-        "ethers": "^5.5.3",
+        "ethers": "^5.5.1",
         "long": "^5.2.0",
         "siwe": "^1.1.6"
       },
@@ -1638,9 +1637,9 @@
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.2.tgz",
-      "integrity": "sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
+      "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
       "funding": [
         {
           "type": "individual",
@@ -2227,17 +2226,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@noble/secp256k1": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.2.tgz",
@@ -2686,17 +2674,6 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "dependencies": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
       }
     },
     "node_modules/@stablelib/binary": {
@@ -6093,9 +6070,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.3.tgz",
-      "integrity": "sha512-fTT4WT8/hTe/BLwRUtl7I5zlpF3XC3P/Xwqxc5AIP2HGlH15qpmjs0Ou78az93b1rLITzXLFxoNX63B8ZbUd7g==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
+      "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
       "funding": [
         {
           "type": "individual",
@@ -6122,11 +6099,11 @@
         "@ethersproject/json-wallets": "5.5.0",
         "@ethersproject/keccak256": "5.5.0",
         "@ethersproject/logger": "5.5.0",
-        "@ethersproject/networks": "5.5.2",
+        "@ethersproject/networks": "5.5.0",
         "@ethersproject/pbkdf2": "5.5.0",
         "@ethersproject/properties": "5.5.0",
-        "@ethersproject/providers": "5.5.2",
-        "@ethersproject/random": "5.5.1",
+        "@ethersproject/providers": "5.5.0",
+        "@ethersproject/random": "5.5.0",
         "@ethersproject/rlp": "5.5.0",
         "@ethersproject/sha2": "5.5.0",
         "@ethersproject/signing-key": "5.5.0",
@@ -6135,8 +6112,67 @@
         "@ethersproject/transactions": "5.5.0",
         "@ethersproject/units": "5.5.0",
         "@ethersproject/wallet": "5.5.0",
-        "@ethersproject/web": "5.5.1",
+        "@ethersproject/web": "5.5.0",
         "@ethersproject/wordlists": "5.5.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@ethersproject/networks": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
+      "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@ethersproject/random": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
+      "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@ethersproject/web": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
+      "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/base64": "^5.5.0",
+        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/properties": "^5.5.0",
+        "@ethersproject/strings": "^5.5.0"
       }
     },
     "node_modules/events": {
@@ -12317,6 +12353,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -14059,6 +14096,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -14103,11 +14141,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -15687,9 +15720,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.2.tgz",
-      "integrity": "sha512-hkbx7x/MKcRjyrO4StKXCzCpWer6s97xnm34xkfPiarhtEUVAN4TBBpamM+z66WcTt7H5B53YwbRj1n7i8pZoQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
+      "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
       "requires": {
         "@ethersproject/abstract-provider": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.5.0",
@@ -16087,11 +16120,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
-    },
     "@noble/secp256k1": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.5.2.tgz",
@@ -16473,17 +16501,6 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
-      "requires": {
-        "@noble/hashes": "^1.1.2",
-        "apg-js": "^4.1.1",
-        "uri-js": "^4.4.1",
-        "valid-url": "^1.0.9"
       }
     },
     "@stablelib/binary": {
@@ -19137,9 +19154,9 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.3.tgz",
-      "integrity": "sha512-fTT4WT8/hTe/BLwRUtl7I5zlpF3XC3P/Xwqxc5AIP2HGlH15qpmjs0Ou78az93b1rLITzXLFxoNX63B8ZbUd7g==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
+      "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
       "requires": {
         "@ethersproject/abi": "5.5.0",
         "@ethersproject/abstract-provider": "5.5.1",
@@ -19156,11 +19173,11 @@
         "@ethersproject/json-wallets": "5.5.0",
         "@ethersproject/keccak256": "5.5.0",
         "@ethersproject/logger": "5.5.0",
-        "@ethersproject/networks": "5.5.2",
+        "@ethersproject/networks": "5.5.0",
         "@ethersproject/pbkdf2": "5.5.0",
         "@ethersproject/properties": "5.5.0",
-        "@ethersproject/providers": "5.5.2",
-        "@ethersproject/random": "5.5.1",
+        "@ethersproject/providers": "5.5.0",
+        "@ethersproject/random": "5.5.0",
         "@ethersproject/rlp": "5.5.0",
         "@ethersproject/sha2": "5.5.0",
         "@ethersproject/signing-key": "5.5.0",
@@ -19169,8 +19186,39 @@
         "@ethersproject/transactions": "5.5.0",
         "@ethersproject/units": "5.5.0",
         "@ethersproject/wallet": "5.5.0",
-        "@ethersproject/web": "5.5.1",
+        "@ethersproject/web": "5.5.0",
         "@ethersproject/wordlists": "5.5.0"
+      },
+      "dependencies": {
+        "@ethersproject/networks": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
+          "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
+          "requires": {
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
+          "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
+          "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
+          "requires": {
+            "@ethersproject/base64": "^5.5.0",
+            "@ethersproject/bytes": "^5.5.0",
+            "@ethersproject/logger": "^5.5.0",
+            "@ethersproject/properties": "^5.5.0",
+            "@ethersproject/strings": "^5.5.0"
+          }
+        }
       }
     },
     "events": {
@@ -23711,7 +23759,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -24992,6 +25041,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -25032,11 +25082,6 @@
           "dev": true
         }
       }
-    },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "@xmtp/proto": "^3.22.0-beta.1",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
-        "ethers": "^5.5.1",
+        "ethers": "^5.5.3",
         "long": "^5.2.0",
-        "siwe": "^1.1.6"
+        "siwe": "^2.1.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -1250,9 +1250,9 @@
       }
     },
     "node_modules/@ethersproject/abi": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
-      "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "funding": [
         {
           "type": "individual",
@@ -1264,21 +1264,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-provider": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
-      "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "funding": [
         {
           "type": "individual",
@@ -1290,19 +1290,19 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/abstract-signer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
-      "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -1314,17 +1314,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/address": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
-      "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "funding": [
         {
           "type": "individual",
@@ -1336,17 +1336,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/base64": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-      "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "funding": [
         {
           "type": "individual",
@@ -1358,13 +1358,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/basex": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.5.0.tgz",
-      "integrity": "sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "funding": [
         {
           "type": "individual",
@@ -1376,14 +1376,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -1395,15 +1395,20 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "bn.js": "^4.11.9"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
       }
     },
+    "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
-      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -1415,13 +1420,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
-      "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "funding": [
         {
           "type": "individual",
@@ -1433,13 +1438,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/contracts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.5.0.tgz",
-      "integrity": "sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "funding": [
         {
           "type": "individual",
@@ -1451,22 +1456,22 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "^5.5.0",
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
-      "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -1478,20 +1483,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hdnode": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.5.0.tgz",
-      "integrity": "sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "funding": [
         {
           "type": "individual",
@@ -1503,24 +1509,24 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/json-wallets": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz",
-      "integrity": "sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "funding": [
         {
           "type": "individual",
@@ -1532,25 +1538,25 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "node_modules/@ethersproject/keccak256": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-      "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "funding": [
         {
           "type": "individual",
@@ -1562,14 +1568,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "funding": [
         {
           "type": "individual",
@@ -1582,9 +1588,9 @@
       ]
     },
     "node_modules/@ethersproject/networks": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.2.tgz",
-      "integrity": "sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "funding": [
         {
           "type": "individual",
@@ -1596,13 +1602,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz",
-      "integrity": "sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "funding": [
         {
           "type": "individual",
@@ -1614,14 +1620,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
-      "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "funding": [
         {
           "type": "individual",
@@ -1633,13 +1639,13 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/providers": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
-      "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "funding": [
         {
           "type": "individual",
@@ -1651,31 +1657,32 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "node_modules/@ethersproject/random": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.1.tgz",
-      "integrity": "sha512-YaU2dQ7DuhL5Au7KbcQLHxcRHfgyNgvFV4sQOo0HrtW3Zkrc9ctWNz8wXQ4uCSfSDsqX2vcjhroxU5RQRV0nqA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "funding": [
         {
           "type": "individual",
@@ -1687,14 +1694,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
-      "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "funding": [
         {
           "type": "individual",
@@ -1706,14 +1713,14 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "funding": [
         {
           "type": "individual",
@@ -1725,15 +1732,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
-      "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "funding": [
         {
           "type": "individual",
@@ -1745,18 +1752,23 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "bn.js": "^4.11.9",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
     },
+    "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
     "node_modules/@ethersproject/solidity": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.5.0.tgz",
-      "integrity": "sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "funding": [
         {
           "type": "individual",
@@ -1768,18 +1780,18 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/strings": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "funding": [
         {
           "type": "individual",
@@ -1791,15 +1803,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/transactions": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
-      "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -1811,21 +1823,21 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/units": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.5.0.tgz",
-      "integrity": "sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "funding": [
         {
           "type": "individual",
@@ -1837,15 +1849,15 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.5.0.tgz",
-      "integrity": "sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "funding": [
         {
           "type": "individual",
@@ -1857,27 +1869,27 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/json-wallets": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/web": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
-      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "funding": [
         {
           "type": "individual",
@@ -1889,17 +1901,17 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/base64": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wordlists": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.5.0.tgz",
-      "integrity": "sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "funding": [
         {
           "type": "individual",
@@ -1911,11 +1923,11 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2225,6 +2237,17 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/secp256k1": {
       "version": "1.5.2",
@@ -2674,6 +2697,17 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       }
     },
     "node_modules/@stablelib/binary": {
@@ -3491,7 +3525,7 @@
     "node_modules/aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -6070,9 +6104,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
-      "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "funding": [
         {
           "type": "individual",
@@ -6084,95 +6118,36 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.5.0",
-        "@ethersproject/abstract-provider": "5.5.1",
-        "@ethersproject/abstract-signer": "5.5.0",
-        "@ethersproject/address": "5.5.0",
-        "@ethersproject/base64": "5.5.0",
-        "@ethersproject/basex": "5.5.0",
-        "@ethersproject/bignumber": "5.5.0",
-        "@ethersproject/bytes": "5.5.0",
-        "@ethersproject/constants": "5.5.0",
-        "@ethersproject/contracts": "5.5.0",
-        "@ethersproject/hash": "5.5.0",
-        "@ethersproject/hdnode": "5.5.0",
-        "@ethersproject/json-wallets": "5.5.0",
-        "@ethersproject/keccak256": "5.5.0",
-        "@ethersproject/logger": "5.5.0",
-        "@ethersproject/networks": "5.5.0",
-        "@ethersproject/pbkdf2": "5.5.0",
-        "@ethersproject/properties": "5.5.0",
-        "@ethersproject/providers": "5.5.0",
-        "@ethersproject/random": "5.5.0",
-        "@ethersproject/rlp": "5.5.0",
-        "@ethersproject/sha2": "5.5.0",
-        "@ethersproject/signing-key": "5.5.0",
-        "@ethersproject/solidity": "5.5.0",
-        "@ethersproject/strings": "5.5.0",
-        "@ethersproject/transactions": "5.5.0",
-        "@ethersproject/units": "5.5.0",
-        "@ethersproject/wallet": "5.5.0",
-        "@ethersproject/web": "5.5.0",
-        "@ethersproject/wordlists": "5.5.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/networks": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
-      "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/random": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
-      "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
-      }
-    },
-    "node_modules/ethers/node_modules/@ethersproject/web": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
-      "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/base64": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/events": {
@@ -12353,7 +12328,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13109,24 +13083,17 @@
       "dev": true
     },
     "node_modules/siwe": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-1.1.6.tgz",
-      "integrity": "sha512-3WRdEil32Tc2vuNzqJ2/Z/MIvsvy0Nkzc2ov+QujmpHO7tM83dgcb47z0Pu236T4JQkOQCqQkq3AJ/rVIezniA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
       "dependencies": {
-        "@spruceid/siwe-parser": "^1.1.3",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
-        "apg-js": "^4.1.1"
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       },
       "peerDependencies": {
-        "ethers": "5.5.1"
-      }
-    },
-    "node_modules/siwe/node_modules/@spruceid/siwe-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz",
-      "integrity": "sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==",
-      "dependencies": {
-        "apg-js": "^4.1.1"
+        "ethers": "^5.5.1"
       }
     },
     "node_modules/slash": {
@@ -14096,7 +14063,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -14141,6 +14107,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -15513,372 +15484,388 @@
       }
     },
     "@ethersproject/abi": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.5.0.tgz",
-      "integrity": "sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "requires": {
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz",
-      "integrity": "sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz",
-      "integrity": "sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.5.0.tgz",
-      "integrity": "sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-      "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0"
       }
     },
     "@ethersproject/basex": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.5.0.tgz",
-      "integrity": "sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0"
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-      "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "bn.js": "^4.11.9"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
-      "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.5.0.tgz",
-      "integrity": "sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "@ethersproject/contracts": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.5.0.tgz",
-      "integrity": "sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
       "requires": {
-        "@ethersproject/abi": "^5.5.0",
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0"
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0"
       }
     },
     "@ethersproject/hash": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
-      "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/hdnode": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.5.0.tgz",
-      "integrity": "sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/json-wallets": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz",
-      "integrity": "sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
       "requires": {
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/pbkdf2": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/pbkdf2": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-      "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
+        "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
       }
     },
     "@ethersproject/logger": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.5.0.tgz",
-      "integrity": "sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
     },
     "@ethersproject/networks": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.2.tgz",
-      "integrity": "sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/pbkdf2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz",
-      "integrity": "sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0"
       }
     },
     "@ethersproject/properties": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.5.0.tgz",
-      "integrity": "sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "requires": {
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/providers": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.5.0.tgz",
-      "integrity": "sha512-xqMbDnS/FPy+J/9mBLKddzyLLAQFjrVff5g00efqxPzcAwXiR+SiCGVy6eJ5iAIirBOATjx7QLhDNPGV+AEQsw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/basex": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/networks": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/web": "^5.5.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/basex": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/networks": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bech32": "1.1.4",
         "ws": "7.4.6"
       }
     },
     "@ethersproject/random": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.1.tgz",
-      "integrity": "sha512-YaU2dQ7DuhL5Au7KbcQLHxcRHfgyNgvFV4sQOo0HrtW3Zkrc9ctWNz8wXQ4uCSfSDsqX2vcjhroxU5RQRV0nqA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.5.0.tgz",
-      "integrity": "sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/sha2": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-      "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
         "hash.js": "1.1.7"
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.5.0.tgz",
-      "integrity": "sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "bn.js": "^4.11.9",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "bn.js": "^5.2.1",
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        }
       }
     },
     "@ethersproject/solidity": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.5.0.tgz",
-      "integrity": "sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/sha2": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/sha2": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/strings": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-      "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.5.0.tgz",
-      "integrity": "sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "requires": {
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/rlp": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0"
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "@ethersproject/units": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.5.0.tgz",
-      "integrity": "sha512-7+DpjiZk4v6wrikj+TCyWWa9dXLNU73tSTa7n0TSJDxkYbV3Yf1eRh9ToMLlZtuctNYu9RDNNy2USq3AdqSbag==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
       "requires": {
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/constants": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0"
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.5.0.tgz",
-      "integrity": "sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.5.0",
-        "@ethersproject/abstract-signer": "^5.5.0",
-        "@ethersproject/address": "^5.5.0",
-        "@ethersproject/bignumber": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/hdnode": "^5.5.0",
-        "@ethersproject/json-wallets": "^5.5.0",
-        "@ethersproject/keccak256": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/random": "^5.5.0",
-        "@ethersproject/signing-key": "^5.5.0",
-        "@ethersproject/transactions": "^5.5.0",
-        "@ethersproject/wordlists": "^5.5.0"
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/hdnode": "^5.7.0",
+        "@ethersproject/json-wallets": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/random": "^5.7.0",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wordlists": "^5.7.0"
       }
     },
     "@ethersproject/web": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.1.tgz",
-      "integrity": "sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "requires": {
-        "@ethersproject/base64": "^5.5.0",
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/base64": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@ethersproject/wordlists": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.5.0.tgz",
-      "integrity": "sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
       "requires": {
-        "@ethersproject/bytes": "^5.5.0",
-        "@ethersproject/hash": "^5.5.0",
-        "@ethersproject/logger": "^5.5.0",
-        "@ethersproject/properties": "^5.5.0",
-        "@ethersproject/strings": "^5.5.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/strings": "^5.7.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -16119,6 +16106,11 @@
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0"
       }
+    },
+    "@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
     },
     "@noble/secp256k1": {
       "version": "1.5.2",
@@ -16501,6 +16493,17 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "requires": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       }
     },
     "@stablelib/binary": {
@@ -17191,7 +17194,7 @@
     "aes-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -19154,71 +19157,40 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.5.1.tgz",
-      "integrity": "sha512-RodEvUFZI+EmFcE6bwkuJqpCYHazdzeR1nMzg+YWQSmQEsNtfl1KHGfp/FWZYl48bI/g7cgBeP2IlPthjiVngw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
       "requires": {
-        "@ethersproject/abi": "5.5.0",
-        "@ethersproject/abstract-provider": "5.5.1",
-        "@ethersproject/abstract-signer": "5.5.0",
-        "@ethersproject/address": "5.5.0",
-        "@ethersproject/base64": "5.5.0",
-        "@ethersproject/basex": "5.5.0",
-        "@ethersproject/bignumber": "5.5.0",
-        "@ethersproject/bytes": "5.5.0",
-        "@ethersproject/constants": "5.5.0",
-        "@ethersproject/contracts": "5.5.0",
-        "@ethersproject/hash": "5.5.0",
-        "@ethersproject/hdnode": "5.5.0",
-        "@ethersproject/json-wallets": "5.5.0",
-        "@ethersproject/keccak256": "5.5.0",
-        "@ethersproject/logger": "5.5.0",
-        "@ethersproject/networks": "5.5.0",
-        "@ethersproject/pbkdf2": "5.5.0",
-        "@ethersproject/properties": "5.5.0",
-        "@ethersproject/providers": "5.5.0",
-        "@ethersproject/random": "5.5.0",
-        "@ethersproject/rlp": "5.5.0",
-        "@ethersproject/sha2": "5.5.0",
-        "@ethersproject/signing-key": "5.5.0",
-        "@ethersproject/solidity": "5.5.0",
-        "@ethersproject/strings": "5.5.0",
-        "@ethersproject/transactions": "5.5.0",
-        "@ethersproject/units": "5.5.0",
-        "@ethersproject/wallet": "5.5.0",
-        "@ethersproject/web": "5.5.0",
-        "@ethersproject/wordlists": "5.5.0"
-      },
-      "dependencies": {
-        "@ethersproject/networks": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.5.0.tgz",
-          "integrity": "sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==",
-          "requires": {
-            "@ethersproject/logger": "^5.5.0"
-          }
-        },
-        "@ethersproject/random": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.5.0.tgz",
-          "integrity": "sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.5.0",
-            "@ethersproject/logger": "^5.5.0"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.5.0.tgz",
-          "integrity": "sha512-BEgY0eL5oH4mAo37TNYVrFeHsIXLRxggCRG/ksRIxI2X5uj5IsjGmcNiRN/VirQOlBxcUhCgHhaDLG4m6XAVoA==",
-          "requires": {
-            "@ethersproject/base64": "^5.5.0",
-            "@ethersproject/bytes": "^5.5.0",
-            "@ethersproject/logger": "^5.5.0",
-            "@ethersproject/properties": "^5.5.0",
-            "@ethersproject/strings": "^5.5.0"
-          }
-        }
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "events": {
@@ -23759,8 +23731,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -24332,23 +24303,14 @@
       "dev": true
     },
     "siwe": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-1.1.6.tgz",
-      "integrity": "sha512-3WRdEil32Tc2vuNzqJ2/Z/MIvsvy0Nkzc2ov+QujmpHO7tM83dgcb47z0Pu236T4JQkOQCqQkq3AJ/rVIezniA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
       "requires": {
-        "@spruceid/siwe-parser": "^1.1.3",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
-        "apg-js": "^4.1.1"
-      },
-      "dependencies": {
-        "@spruceid/siwe-parser": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz",
-          "integrity": "sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==",
-          "requires": {
-            "apg-js": "^4.1.1"
-          }
-        }
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
       }
     },
     "slash": {
@@ -25041,7 +25003,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -25082,6 +25043,11 @@
           "dev": true
         }
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
-        "long": "^5.2.0"
+        "long": "^5.2.0",
+        "siwe": "^1.1.6"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -2697,6 +2698,33 @@
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
       }
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@stardazed/streams-polyfill": {
       "version": "2.4.0",
@@ -13043,6 +13071,27 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
+    "node_modules/siwe": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-1.1.6.tgz",
+      "integrity": "sha512-3WRdEil32Tc2vuNzqJ2/Z/MIvsvy0Nkzc2ov+QujmpHO7tM83dgcb47z0Pu236T4JQkOQCqQkq3AJ/rVIezniA==",
+      "dependencies": {
+        "@spruceid/siwe-parser": "^1.1.3",
+        "@stablelib/random": "^1.0.1",
+        "apg-js": "^4.1.1"
+      },
+      "peerDependencies": {
+        "ethers": "5.5.1"
+      }
+    },
+    "node_modules/siwe/node_modules/@spruceid/siwe-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz",
+      "integrity": "sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==",
+      "dependencies": {
+        "apg-js": "^4.1.1"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -16436,6 +16485,33 @@
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
       }
+    },
+    "@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "requires": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "@stardazed/streams-polyfill": {
       "version": "2.4.0",
@@ -24205,6 +24281,26 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
+    },
+    "siwe": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-1.1.6.tgz",
+      "integrity": "sha512-3WRdEil32Tc2vuNzqJ2/Z/MIvsvy0Nkzc2ov+QujmpHO7tM83dgcb47z0Pu236T4JQkOQCqQkq3AJ/rVIezniA==",
+      "requires": {
+        "@spruceid/siwe-parser": "^1.1.3",
+        "@stablelib/random": "^1.0.1",
+        "apg-js": "^4.1.1"
+      },
+      "dependencies": {
+        "@spruceid/siwe-parser": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz",
+          "integrity": "sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==",
+          "requires": {
+            "apg-js": "^4.1.1"
+          }
+        }
+      }
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
+    "@spruceid/siwe-parser": "^2.0.2",
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^3.22.0-beta.1",
     "async-mutex": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
     "ethers": "^5.5.3",
-    "long": "^5.2.0"
+    "long": "^5.2.0",
+    "siwe": "^1.1.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -67,12 +67,11 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@spruceid/siwe-parser": "^2.0.2",
     "@stardazed/streams-polyfill": "^2.4.0",
     "@xmtp/proto": "^3.22.0-beta.1",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
-    "ethers": "^5.5.3",
+    "ethers": "^5.5.1",
     "long": "^5.2.0",
     "siwe": "^1.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "@xmtp/proto": "^3.22.0-beta.1",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
-    "ethers": "^5.5.1",
+    "ethers": "^5.5.3",
     "long": "^5.2.0",
-    "siwe": "^1.1.6"
+    "siwe": "^2.1.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -279,31 +279,6 @@ export class AccountLinkedPrivateKey
     })
   }
 
-  // Create a random key pair signed by the signer using SIWE signatures
-  static async generateSIWE(
-    signer: AccountLinkSigner,
-    role: AccountLinkedRole
-  ): Promise<AccountLinkedPrivateKey> {
-    const secp256k1 = {
-      bytes: secp.utils.randomPrivateKey(),
-    }
-    const createdNs = Long.fromNumber(new Date().getTime()).mul(1000000)
-    const unsigned = new UnsignedPublicKey({
-      secp256k1Uncompressed: {
-        bytes: secp.getPublicKey(secp256k1.bytes),
-      },
-      createdNs,
-    })
-    const signed = await signer.signKeyWithRoleSIWE(unsigned, role)
-    return new AccountLinkedPrivateKey({
-      v1: new AccountLinkedPrivateKeyV1({
-        secp256k1,
-        createdNs,
-        publicKey: signed,
-      }),
-    })
-  }
-
   public static fromLegacyKey(
     key: SignedPrivateKey,
     role: AccountLinkedRole

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -279,6 +279,31 @@ export class AccountLinkedPrivateKey
     })
   }
 
+  // Create a random key pair signed by the signer using SIWE signatures
+  static async generateSIWE(
+    signer: AccountLinkSigner,
+    role: AccountLinkedRole
+  ): Promise<AccountLinkedPrivateKey> {
+    const secp256k1 = {
+      bytes: secp.utils.randomPrivateKey(),
+    }
+    const createdNs = Long.fromNumber(new Date().getTime()).mul(1000000)
+    const unsigned = new UnsignedPublicKey({
+      secp256k1Uncompressed: {
+        bytes: secp.getPublicKey(secp256k1.bytes),
+      },
+      createdNs,
+    })
+    const signed = await signer.signKeyWithRoleSIWE(unsigned, role)
+    return new AccountLinkedPrivateKey({
+      v1: new AccountLinkedPrivateKeyV1({
+        secp256k1,
+        createdNs,
+        publicKey: signed,
+      }),
+    })
+  }
+
   public static fromLegacyKey(
     key: SignedPrivateKey,
     role: AccountLinkedRole

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -7,6 +7,7 @@ import {
 import {
   AccountLinkedRole,
   StaticWalletAccountLinkSigner,
+  SIWEWalletAccountLinkSigner,
   WalletSigner,
 } from './Signature'
 import { PublicKey, SignedPublicKey } from './PublicKey'
@@ -56,8 +57,8 @@ export class PrivateKeyBundleV3 implements proto.PrivateKeyBundleV3 {
     wallet: Signer,
     role: AccountLinkedRole
   ): Promise<PrivateKeyBundleV3> {
-    const accountLinkedKey = await AccountLinkedPrivateKey.generateSIWE(
-      new StaticWalletAccountLinkSigner(wallet),
+    const accountLinkedKey = await AccountLinkedPrivateKey.generate(
+      new SIWEWalletAccountLinkSigner(wallet),
       role
     )
     const bundle = new PrivateKeyBundleV3({

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -49,6 +49,25 @@ export class PrivateKeyBundleV3 implements proto.PrivateKeyBundleV3 {
     return bundle
   }
 
+  // Generate a new key bundle with the preKey signed by the accountLinkedKey.
+  // Sign the accountLinkedKey with the provided wallet as well. Same as above
+  // but uses SIWE format signature text
+  static async generateSIWE(
+    wallet: Signer,
+    role: AccountLinkedRole
+  ): Promise<PrivateKeyBundleV3> {
+    const accountLinkedKey = await AccountLinkedPrivateKey.generateSIWE(
+      new StaticWalletAccountLinkSigner(wallet),
+      role
+    )
+    const bundle = new PrivateKeyBundleV3({
+      accountLinkedKey,
+      preKeys: [],
+    })
+    await bundle.addPreKey()
+    return bundle
+  }
+
   public static fromLegacyBundle(
     bundle: PrivateKeyBundleV2,
     role: AccountLinkedRole

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -52,7 +52,9 @@ export class PrivateKeyBundleV3 implements proto.PrivateKeyBundleV3 {
 
   // Generate a new key bundle with the preKey signed by the accountLinkedKey.
   // Sign the accountLinkedKey with the provided wallet as well. Same as above
-  // but uses SIWE format signature text
+  // but uses SIWE format signature text. NOTE: in practice, consumers should
+  // only use this method if they're okay with using a default SIWE rather than
+  // reusing their app-specific login SIWE.
   static async generateSIWE(
     wallet: Signer,
     role: AccountLinkedRole

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -252,8 +252,8 @@ export class AccountLinkedPublicKeyV1
     return this.keyBytes
   }
 
-  public getSIWELinkedAddressWithoutDomainCheck(
-    expectedAddress: string,
+  // Return the extracted address from the SIWE signature checking role and keys, but not domain
+  private getSIWELinkedAddressWithoutDomainCheck(
     role: AccountLinkedRole
   ): string {
     // The criteria for successful SIWE-signed keys with roles are:
@@ -336,7 +336,7 @@ export class AccountLinkedPublicKeyV1
       }
       return publicKey.getEthereumAddress()
     } else {
-      throw new Error('SIWE signature not implemented')
+      return this.getSIWELinkedAddressWithoutDomainCheck(role)
     }
   }
 

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -283,12 +283,11 @@ export class AccountLinkedPublicKeyV1
     const resources = siwe.resources || []
     const roleString =
       StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
-    const resourceRegex = new RegExp(
-      `https://xmtp.org/siwe/${roleString}/secp256k1/${bytesToHex(
-        this.bytesToSign()
-      )}`
-    )
-    if (!resources.some((resource) => resourceRegex.test(resource))) {
+
+    const expectedResource = `https://xmtp.org/siwe/${roleString}/secp256k1/${bytesToHex(
+      this.bytesToSign()
+    )}`
+    if (!resources.includes(expectedResource)) {
       throw new Error(
         'Expected xmtp public key resource (https://xmtp.org/siwe/[role]/(keybytes as hex, uncompressed){64})'
       )

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -282,8 +282,6 @@ export class AccountLinkedPublicKeyV1
     // }
     // Rule 2: Check the resources
     const resources = siwe.resources || []
-    const roleString =
-      SIWEWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
 
     const expectedResource =
       SIWEWalletAccountLinkSigner.accountLinkedSIWEResourceRoleText(

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -284,11 +284,13 @@ export class AccountLinkedPublicKeyV1
     const roleString =
       StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
     const resourceRegex = new RegExp(
-      `https://xmtp.org/${roleString}/${bytesToHex(this.bytesToSign())}`
+      `https://xmtp.org/siwe/${roleString}/secp256k1/${bytesToHex(
+        this.bytesToSign()
+      )}`
     )
     if (!resources.some((resource) => resourceRegex.test(resource))) {
       throw new Error(
-        'Expected xmtp public key resource (https://xmtp.org/[role]/(keybytes as hex, uncompressed){64})'
+        'Expected xmtp public key resource (https://xmtp.org/siwe/[role]/(keybytes as hex, uncompressed){64})'
       )
     }
 

--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -7,6 +7,7 @@ import Signature, {
   AccountLinkedSIWESignature,
   ecdsaSignerKey,
   StaticWalletAccountLinkSigner,
+  SIWEWalletAccountLinkSigner,
   WalletSigner,
 } from './Signature'
 import { bytesToHex, equalBytes, hexToBytes } from './utils'
@@ -282,7 +283,7 @@ export class AccountLinkedPublicKeyV1
     // Rule 2: Check the resources
     const resources = siwe.resources || []
     const roleString =
-      StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
+      SIWEWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
 
     const expectedResource = `https://xmtp.org/siwe/${roleString}/secp256k1/${bytesToHex(
       this.bytesToSign()

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -354,14 +354,17 @@ export class StaticWalletAccountLinkSigner implements AccountLinkSigner {
 
   // Prepare the SIWE text to be signed
   // NOTE: TODO: must one day include a real domain and a real URI before GA
+  // in practice, the SDK consumer will decide this text. We would just provide
+  // the resource string.
   public static accountLinkSIWERequestText(
     key: UnsignedPublicKey,
     role: AccountLinkedRole,
     walletAddress: string
   ): string {
     // Create a SIWE message
-    // - statement can contain garbage as long as it contains the role statement for SIWE
+    // - statement can be anything
     // - TODO: use the right domain for the consuming app? open question if we even care about cross-app shenanigans
+    // - TODO: use the right uri
     // - get the address from the signer
     // - add the resource string with keybytes
     const keyBytes = key.toBytes()

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -10,7 +10,7 @@ import {
 import { SignedPrivateKey } from './PrivateKey'
 import { utils } from 'ethers'
 import { Signer } from '../types/Signer'
-import { bytesToHex, equalBytes, hexToBytes } from './utils'
+import { bytesToBase64, bytesToHex, equalBytes, hexToBytes } from './utils'
 import { toUtf8Bytes } from 'ethers/lib/utils'
 import { SiweMessage } from 'siwe'
 
@@ -326,7 +326,7 @@ export class SIWEWalletAccountLinkSigner implements AccountLinkSigner {
   ): string {
     return `https://xmtp.org/siwe/${SIWEWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
       role
-    )}/secp256k1/${bytesToHex(keyBytes)}`
+    )}/secp256k1/${bytesToBase64(keyBytes)}`
   }
 
   // Default SIWE text to be signed, most apps will NOT want to use this.

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -334,6 +334,15 @@ export class StaticWalletAccountLinkSigner implements AccountLinkSigner {
     }
   }
 
+  public static accountLinkedSIWEResourceRoleText(
+    keyBytes: Uint8Array,
+    role: AccountLinkedRole
+  ): string {
+    return `https://xmtp.org/siwe/${StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
+      role
+    )}/secp256k1/${bytesToHex(keyBytes)}`
+  }
+
   public static accountLinkRequestText(
     keyBytes: Uint8Array,
     role: AccountLinkedRole
@@ -368,9 +377,11 @@ export class StaticWalletAccountLinkSigner implements AccountLinkSigner {
     // - get the address from the signer
     // - add the resource string with keybytes
     const keyBytes = key.toBytes()
-    const roleString =
-      StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(role)
-    const resource = `https://xmtp.org/${roleString}/${bytesToHex(keyBytes)}`
+    const resource =
+      StaticWalletAccountLinkSigner.accountLinkedSIWEResourceRoleText(
+        keyBytes,
+        role
+      )
     const siwe = new SiweMessage({
       statement: 'TODO REPLACE THIS',
       address: walletAddress,

--- a/src/crypto/utils.ts
+++ b/src/crypto/utils.ts
@@ -19,6 +19,10 @@ export function hexToBytes(s: string): Uint8Array {
   return bytes
 }
 
+export function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64')
+}
+
 export function equalBytes(b1: Uint8Array, b2: Uint8Array): boolean {
   if (b1.length !== b2.length) {
     return false

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -67,12 +67,27 @@ describe('Account Linked Signatures', () => {
   test.each([AccountLinkedRole.INBOX_KEY, AccountLinkedRole.SEND_KEY])(
     'Account linked signatures throw when used for the wrong role',
     async (role) => {
-      const newBundle = await PrivateKeyBundleV3.generate(
-        wallet,
-        AccountLinkedRole.INBOX_KEY
-      )
+      const otherRole =
+        role === AccountLinkedRole.INBOX_KEY
+          ? AccountLinkedRole.SEND_KEY
+          : AccountLinkedRole.INBOX_KEY
+      const newBundle = await PrivateKeyBundleV3.generateSIWE(wallet, role)
       expect(() => {
-        newBundle.getLinkedAddress(AccountLinkedRole.SEND_KEY)
+        newBundle.getLinkedAddress(otherRole)
+      }).toThrow()
+    }
+  )
+
+  test.each([AccountLinkedRole.INBOX_KEY, AccountLinkedRole.SEND_KEY])(
+    'Account linked SIWE signatures throw when used for the wrong role',
+    async (role) => {
+      const otherRole =
+        role === AccountLinkedRole.INBOX_KEY
+          ? AccountLinkedRole.SEND_KEY
+          : AccountLinkedRole.INBOX_KEY
+      const newBundle = await PrivateKeyBundleV3.generateSIWE(wallet, role)
+      expect(() => {
+        newBundle.getLinkedAddress(otherRole)
       }).toThrow()
     }
   )

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   AccountLinkedRole,
   StaticWalletAccountLinkSigner,
+  SIWEWalletAccountLinkSigner,
 } from '../../src/crypto/Signature'
 import { newWallet } from '../helpers'
 import { SiweMessage } from 'siwe'
@@ -129,7 +130,7 @@ describe('Account Linked Signatures', () => {
     // Swap the role to SEND_KEY
     if (siweMessage?.resources?.length === 1) {
       const roleConst =
-        StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
+        SIWEWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
           AccountLinkedRole.SEND_KEY
         )
       siweMessage.resources[0] = `https://xmtp.org/siwe/${roleConst}/secp256k1/${bytesToHex(

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -132,7 +132,7 @@ describe('Account Linked Signatures', () => {
         StaticWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
           AccountLinkedRole.SEND_KEY
         )
-      siweMessage.resources[0] = `https://xmtp.org/${roleConst}/${bytesToHex(
+      siweMessage.resources[0] = `https://xmtp.org/siwe/${roleConst}/secp256k1/${bytesToHex(
         key.keyBytes
       )}`
     } else {
@@ -142,7 +142,7 @@ describe('Account Linked Signatures', () => {
     // Expect this to throw and have "expected address"
     expect(() => {
       newBundle.getLinkedAddress(AccountLinkedRole.SEND_KEY)
-    }).toThrow()
+    }).toThrow(/Expected address.+/)
   })
 
   test('Old signatures can be converted to account linked inbox key signatures', async () => {

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -137,10 +137,10 @@ describe('Account Linked Signatures', () => {
         key.keyBytes
       )}`
     } else {
-      throw new Error('Expected at one resource')
+      throw new Error('Expected at least one resource')
     }
     key.siweSignature.text = toUtf8Bytes(siweMessage.prepareMessage())
-    // Expect this to throw and have "expected address"
+    // Expect this to throw and have "Expected address"
     expect(() => {
       newBundle.getLinkedAddress(AccountLinkedRole.SEND_KEY)
     }).toThrow(/Expected address.+/)

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -59,7 +59,7 @@ describe('Account Linked Signatures', () => {
   )
 
   test.each([AccountLinkedRole.INBOX_KEY, AccountLinkedRole.SEND_KEY])(
-    'SIWE account linked signatures can be verified',
+    'Account linked SIWE signatures can be verified',
     async (role) => {
       const newBundle = await PrivateKeyBundleV3.generateSIWE(wallet, role)
       expect(newBundle.getLinkedAddress(role)).toEqual(wallet.address)

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -57,6 +57,14 @@ describe('Account Linked Signatures', () => {
   )
 
   test.each([AccountLinkedRole.INBOX_KEY, AccountLinkedRole.SEND_KEY])(
+    'SIWE account linked signatures can be verified',
+    async (role) => {
+      const newBundle = await PrivateKeyBundleV3.generateSIWE(wallet, role)
+      expect(newBundle.getLinkedAddress(role)).toEqual(wallet.address)
+    }
+  )
+
+  test.each([AccountLinkedRole.INBOX_KEY, AccountLinkedRole.SEND_KEY])(
     'Account linked signatures throw when used for the wrong role',
     async (role) => {
       const newBundle = await PrivateKeyBundleV3.generate(

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert'
 import { Wallet } from 'ethers'
 import { toUtf8Bytes } from 'ethers/lib/utils'
-import { bytesToHex } from '../../src/crypto/utils'
+import { bytesToBase64 } from '../../src/crypto/utils'
 import { PrivateKeyBundleV1 } from '../../src/crypto'
 import {
   PrivateKeyBundleV2,
@@ -133,7 +133,7 @@ describe('Account Linked Signatures', () => {
         SIWEWalletAccountLinkSigner.accountLinkedSIWERoleRequestText(
           AccountLinkedRole.SEND_KEY
         )
-      siweMessage.resources[0] = `https://xmtp.org/siwe/${roleConst}/secp256k1/${bytesToHex(
+      siweMessage.resources[0] = `https://xmtp.org/siwe/${roleConst}/secp256k1/${bytesToBase64(
         key.keyBytes
       )}`
     } else {


### PR DESCRIPTION
**Overview**

Initial support for SIWE signatures in AccountLinkedRoles. We only use the Resources part of the SIWE, and it's open to any and all feedback. The goal here is to be able to read these SIWE signatures (lock down the Resource / SIWE text spec) but actually constructing them is a more intricate problem. In this PR, we provide default XMTP-related SIWE account linking message generation, but most apps will want to use their own Login SIWE text with our Resource string.

**Tests**
- Unit tests

I was using an old version of SIWE. All good now. ~~NOTE: tests are failing because I had to force upgrade for `siwe` package, looking now. Downgraded `ethers` from `^5.5.3` to `^5.5.1` (siwe seems to want 5.5.1).~~