### PR TITLE
Use latest xmtp/proto beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.22.0-beta.1",
+        "@xmtp/proto": "^3.24.0-beta.2",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -3413,9 +3413,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.22.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.22.0-beta.1.tgz",
-      "integrity": "sha512-CCsrtRxbqgayZhkHihZu3hY4cGCXlitF1bA8Vi0EDlB7vKuzPT0faXelYs1u9P9sJv9M6yZjVmz5vHNHa/XGeQ==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
@@ -17079,9 +17079,9 @@
       "requires": {}
     },
     "@xmtp/proto": {
-      "version": "3.22.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.22.0-beta.1.tgz",
-      "integrity": "sha512-CCsrtRxbqgayZhkHihZu3hY4cGCXlitF1bA8Vi0EDlB7vKuzPT0faXelYs1u9P9sJv9M6yZjVmz5vHNHa/XGeQ==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@stardazed/streams-polyfill": "^2.4.0",
-    "@xmtp/proto": "^3.22.0-beta.1",
+    "@xmtp/proto": "^3.24.0-beta.2",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
     "ethers": "^5.5.3",

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -7,7 +7,7 @@ import type Client from './Client'
 import {
   message as proto,
   content as protoContent,
-  keystore,
+  conversationReference,
 } from '@xmtp/proto'
 import Long from 'long'
 import Ciphertext from './crypto/Ciphertext'
@@ -398,7 +398,7 @@ export async function decodeContent(contentBytes: Uint8Array, client: Client) {
 }
 
 function conversationReferenceToConversation(
-  reference: keystore.ConversationReference,
+  reference: conversationReference.ConversationReference,
   client: Client,
   version: DecodedMessage['messageVersion']
 ): Conversation {

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -1,4 +1,4 @@
-import { messageApi, keystore } from '@xmtp/proto'
+import { messageApi, keystore, conversationReference } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
 import { SignedPublicKeyBundle } from './../crypto/PublicKeyBundle'
 import { ListMessagesOptions } from './../Client'
@@ -197,7 +197,7 @@ export default class Conversations {
   }
 
   private conversationReferenceToV2(
-    convoRef: keystore.ConversationReference
+    convoRef: conversationReference.ConversationReference
   ): ConversationV2 {
     return new ConversationV2(
       this.client,

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -1,4 +1,10 @@
-import { authn, keystore, privateKey, signature } from '@xmtp/proto'
+import {
+  authn,
+  keystore,
+  privateKey,
+  signature,
+  conversationReference,
+} from '@xmtp/proto'
 import {
   PrivateKeyBundleV1,
   PrivateKeyBundleV2,
@@ -326,7 +332,9 @@ export default class InMemoryKeystore implements Keystore {
     return key.sign(digest)
   }
 
-  async getV2Conversations(): Promise<keystore.ConversationReference[]> {
+  async getV2Conversations(): Promise<
+    conversationReference.ConversationReference[]
+  > {
     const convos = this.inviteStore.topics.map((invite) =>
       topicDataToConversationReference(invite)
     )

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -1,4 +1,11 @@
-import { keystore, publicKey, authn, privateKey, signature } from '@xmtp/proto'
+import {
+  conversationReference,
+  keystore,
+  publicKey,
+  authn,
+  privateKey,
+  signature,
+} from '@xmtp/proto'
 import { WithoutUndefined } from '../utils/typedefs'
 
 /**
@@ -46,7 +53,7 @@ export interface Keystore {
   /**
    * Get a list of V2 conversations
    */
-  getV2Conversations(): Promise<keystore.ConversationReference[]>
+  getV2Conversations(): Promise<conversationReference.ConversationReference[]>
   /**
    * Get the `PublicKeyBundle` associated with the Keystore's private keys
    */

--- a/src/keystore/utils.ts
+++ b/src/keystore/utils.ts
@@ -1,5 +1,10 @@
 import { TopicData } from './interfaces'
-import { publicKey, keystore, invitation } from '@xmtp/proto'
+import {
+  conversationReference,
+  publicKey,
+  keystore,
+  invitation,
+} from '@xmtp/proto'
 import { PublicKeyBundle, SignedPublicKeyBundle } from '../crypto'
 import { KeystoreError } from './errors'
 import { WithoutUndefined } from '../utils/typedefs'
@@ -104,7 +109,7 @@ export const topicDataToConversationReference = ({
   invitation,
   createdNs,
   peerAddress,
-}: TopicData): keystore.ConversationReference => ({
+}: TopicData): conversationReference.ConversationReference => ({
   context: invitation.context,
   topic: invitation.topic,
   peerAddress,


### PR DESCRIPTION
## Summary

To resolve a circular dep, we moved the `ConversationReference` proto to another folder in the latest beta of `xmtp/proto`. This uses that version and updates all imports