### PR TITLE
PROTOTYPE: Snap Keystore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
         "@commitlint/config-conventional": "^16.0.0",
+        "@metamask/providers": "^10.2.1",
         "@types/benchmark": "^2.1.2",
         "@types/bl": "^5.0.2",
         "@types/callback-to-async-iterator": "^1.1.4",
@@ -2237,6 +2238,79 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@metamask/object-multiplex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+      "integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.4",
+        "once": "^1.4.0",
+        "readable-stream": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@metamask/object-multiplex/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@metamask/object-multiplex/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@metamask/providers": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-10.2.1.tgz",
+      "integrity": "sha512-p2TXw2a1Nb8czntDGfeIYQnk4LLVbd5vlcb3GY//lylYlKdSqp+uUTegCvxiFblRDOT68jsY8Ib1VEEzVUOolA==",
+      "dev": true,
+      "dependencies": {
+        "@metamask/object-multiplex": "^1.1.0",
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "@types/chrome": "^0.0.136",
+        "detect-browser": "^5.2.0",
+        "eth-rpc-errors": "^4.0.2",
+        "extension-port-stream": "^2.0.1",
+        "fast-deep-equal": "^2.0.1",
+        "is-stream": "^2.0.0",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^4.2.1",
+        "pump": "^3.0.0",
+        "webextension-polyfill-ts": "^0.25.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@metamask/providers/node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true
+    },
+    "node_modules/@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==",
+      "dev": true
+    },
     "node_modules/@noble/hashes": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
@@ -2846,6 +2920,16 @@
       "integrity": "sha512-NVyiWSufzQNxYUsDQGcAEL8z83Z2NPvWoDHv3KqapWovxIxxmNq5/UTg2QWNtPSojoTevbilAO5rEFExStWVfQ==",
       "dev": true
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.136",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+      "integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/elliptic": {
       "version": "6.4.14",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.14.tgz",
@@ -2881,6 +2965,21 @@
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
     },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -2889,6 +2988,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
+      "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -2939,7 +3044,8 @@
     "node_modules/@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -3424,9 +3530,9 @@
       }
     },
     "node_modules/@xmtp/proto/node_modules/protobufjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
-      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3439,7 +3545,6 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -4153,6 +4258,17 @@
       "peer": true,
       "dependencies": {
         "semver": "^7.0.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/call-bind": {
@@ -4974,6 +5090,12 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "dev": true
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -5160,6 +5282,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.8.3",
@@ -6086,6 +6217,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "dev": true,
+      "dependencies": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "node_modules/ethers": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
@@ -6199,6 +6339,28 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/extension-port-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+      "integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+      "dev": true,
+      "dependencies": {
+        "webextension-polyfill-ts": "^0.22.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extension-port-stream/node_modules/webextension-polyfill-ts": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+      "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+      "deprecated": "This project has moved to @types/webextension-polyfill",
+      "dev": true,
+      "dependencies": {
+        "webextension-polyfill": "^0.7.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6237,6 +6399,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "node_modules/fastest-levenshtein": {
@@ -8328,6 +8496,56 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "node_modules/json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "dev": true,
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/json-rpc-middleware-stream": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-4.2.1.tgz",
+      "integrity": "sha512-6QKayke/8lg0nTjOpRCq4JCgRx7bVybldmloIfY21HSDV0GUevcV9i8DJNvuKTJx4KR9EDIf6HTStAnEovGUvA==",
+      "dev": true,
+      "dependencies": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/json-rpc-middleware-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/json-rpc-middleware-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -12307,6 +12525,16 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -13244,6 +13472,14 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -14008,9 +14244,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.2.tgz",
-      "integrity": "sha512-3KLq3pXMS0Y4IELV045fTxqz04Nk9Ms7yfBBHum3yxsTR4XNn+ZCaUbf/mWitgYDAhsplQ0B1G4S5D345lMO3A==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
         "node": ">=12.18"
       }
@@ -14159,6 +14398,22 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==",
+      "dev": true
+    },
+    "node_modules/webextension-polyfill-ts": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+      "integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+      "deprecated": "This project has moved to @types/webextension-polyfill",
+      "dev": true,
+      "dependencies": {
+        "webextension-polyfill": "^0.7.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -16090,6 +16345,77 @@
         "chalk": "^4.0.0"
       }
     },
+    "@metamask/object-multiplex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz",
+      "integrity": "sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.4.4",
+        "once": "^1.4.0",
+        "readable-stream": "^2.3.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "@metamask/providers": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-10.2.1.tgz",
+      "integrity": "sha512-p2TXw2a1Nb8czntDGfeIYQnk4LLVbd5vlcb3GY//lylYlKdSqp+uUTegCvxiFblRDOT68jsY8Ib1VEEzVUOolA==",
+      "dev": true,
+      "requires": {
+        "@metamask/object-multiplex": "^1.1.0",
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "@types/chrome": "^0.0.136",
+        "detect-browser": "^5.2.0",
+        "eth-rpc-errors": "^4.0.2",
+        "extension-port-stream": "^2.0.1",
+        "fast-deep-equal": "^2.0.1",
+        "is-stream": "^2.0.0",
+        "json-rpc-engine": "^6.1.0",
+        "json-rpc-middleware-stream": "^4.2.1",
+        "pump": "^3.0.0",
+        "webextension-polyfill-ts": "^0.25.0"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+          "dev": true
+        }
+      }
+    },
+    "@metamask/safe-event-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==",
+      "dev": true
+    },
     "@noble/hashes": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
@@ -16623,6 +16949,16 @@
       "integrity": "sha512-NVyiWSufzQNxYUsDQGcAEL8z83Z2NPvWoDHv3KqapWovxIxxmNq5/UTg2QWNtPSojoTevbilAO5rEFExStWVfQ==",
       "dev": true
     },
+    "@types/chrome": {
+      "version": "0.0.136",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.136.tgz",
+      "integrity": "sha512-XDEiRhLkMd+SB7Iw3ZUIj/fov3wLd4HyTdLltVszkgl1dBfc3Rb7oPMVZ2Mz2TLqnF7Ow+StbR8E7r9lqpb4DA==",
+      "dev": true,
+      "requires": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "@types/elliptic": {
       "version": "6.4.14",
       "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.14.tgz",
@@ -16658,6 +16994,21 @@
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
       "dev": true
     },
+    "@types/filesystem": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
+      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
+      "dev": true,
+      "requires": {
+        "@types/filewriter": "*"
+      }
+    },
+    "@types/filewriter": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
+      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ==",
+      "dev": true
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -16666,6 +17017,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/har-format": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.10.tgz",
+      "integrity": "sha512-o0J30wqycjF5miWDKYKKzzOU1ZTLuA42HZ4HE7/zqTOc/jTLdQ5NhYWvsRQo45Nfi1KHoRdNhteSI4BAxTF1Pg==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -16716,7 +17073,8 @@
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -17090,9 +17448,9 @@
       },
       "dependencies": {
         "protobufjs": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
-          "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+          "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -17104,7 +17462,6 @@
             "@protobufjs/path": "^1.1.2",
             "@protobufjs/pool": "^1.1.0",
             "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
             "@types/node": ">=13.7.0",
             "long": "^5.0.0"
           }
@@ -17674,6 +18031,14 @@
       "peer": true,
       "requires": {
         "semver": "^7.0.0"
+      }
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
       }
     },
     "call-bind": {
@@ -18315,6 +18680,12 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "dev": true
+    },
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -18466,6 +18837,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enhanced-resolve": {
       "version": "5.8.3",
@@ -19123,6 +19503,15 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eth-rpc-errors": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "dev": true,
+      "requires": {
+        "fast-safe-stringify": "^2.0.6"
+      }
+    },
     "ethers": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
@@ -19211,6 +19600,26 @@
         "jest-message-util": "^27.4.6"
       }
     },
+    "extension-port-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-2.0.1.tgz",
+      "integrity": "sha512-ltrv4Dh/979I04+D4Te6TFygfRSOc5EBzzlHRldWMS8v73V80qWluxH88hqF0qyUsBXTb8NmzlmSipcre6a+rg==",
+      "dev": true,
+      "requires": {
+        "webextension-polyfill-ts": "^0.22.0"
+      },
+      "dependencies": {
+        "webextension-polyfill-ts": {
+          "version": "0.22.0",
+          "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+          "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+          "dev": true,
+          "requires": {
+            "webextension-polyfill": "^0.7.0"
+          }
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -19246,6 +19655,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "fastest-levenshtein": {
@@ -20803,6 +21218,52 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
+    },
+    "json-rpc-engine": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "dev": true,
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "eth-rpc-errors": "^4.0.2"
+      }
+    },
+    "json-rpc-middleware-stream": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-middleware-stream/-/json-rpc-middleware-stream-4.2.1.tgz",
+      "integrity": "sha512-6QKayke/8lg0nTjOpRCq4JCgRx7bVybldmloIfY21HSDV0GUevcV9i8DJNvuKTJx4KR9EDIf6HTStAnEovGUvA==",
+      "dev": true,
+      "requires": {
+        "@metamask/safe-event-emitter": "^2.0.0",
+        "readable-stream": "^2.3.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -23695,6 +24156,16 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -24428,6 +24899,11 @@
         }
       }
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -24941,9 +25417,12 @@
       }
     },
     "undici": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.2.tgz",
-      "integrity": "sha512-3KLq3pXMS0Y4IELV045fTxqz04Nk9Ms7yfBBHum3yxsTR4XNn+ZCaUbf/mWitgYDAhsplQ0B1G4S5D345lMO3A=="
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.0.tgz",
+      "integrity": "sha512-HOjK8l6a57b2ZGXOcUsI5NLfoTrfmbOl90ixJDl0AEFG4wgHNDQxtZy15/ZQp7HhjkpaGlp/eneMgtsu1dIlUA==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unique-string": {
       "version": "2.0.0",
@@ -25073,6 +25552,21 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==",
+      "dev": true
+    },
+    "webextension-polyfill-ts": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.25.0.tgz",
+      "integrity": "sha512-ikQhwwHYkpBu00pFaUzIKY26I6L87DeRI+Q6jBT1daZUNuu8dSrg5U9l/ZbqdaQ1M/TTSPKeAa3kolP5liuedw==",
+      "dev": true,
+      "requires": {
+        "webextension-polyfill": "^0.7.0"
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",
     "@commitlint/config-conventional": "^16.0.0",
+    "@metamask/providers": "^10.2.1",
     "@types/benchmark": "^2.1.2",
     "@types/bl": "^5.0.2",
     "@types/callback-to-async-iterator": "^1.1.4",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -244,7 +244,6 @@ export default class Client {
     const apiClient = createApiClientFromOptions(options)
     const keystore = await bootstrapKeystore(options, apiClient, wallet)
     const rawBundle = await keystore.getPublicKeyBundle()
-    console.log(rawBundle)
     const publicKeyBundle = new PublicKeyBundle(rawBundle)
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -27,6 +27,7 @@ import {
   NetworkKeystoreProvider,
   StaticKeystoreProvider,
 } from './keystore/providers'
+import SnapKeystoreProvider from './keystore/providers/SnapProvider'
 const { Compression } = proto
 const { b64Decode } = fetcher
 
@@ -242,9 +243,9 @@ export default class Client {
     const options = defaultOptions(opts)
     const apiClient = createApiClientFromOptions(options)
     const keystore = await bootstrapKeystore(options, apiClient, wallet)
-    const publicKeyBundle = new PublicKeyBundle(
-      await keystore.getPublicKeyBundle()
-    )
+    const rawBundle = await keystore.getPublicKeyBundle()
+    console.log(rawBundle)
+    const publicKeyBundle = new PublicKeyBundle(rawBundle)
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
@@ -720,6 +721,7 @@ async function getUserContactsFromNetwork(
  */
 export function defaultKeystoreProviders(): KeystoreProvider[] {
   return [
+    new SnapKeystoreProvider(),
     // First check to see if a `privateKeyOverride` is provided and use that
     new StaticKeystoreProvider(),
     // Next check to see if a EncryptedPrivateKeyBundle exists on the network for the wallet

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export {
   SignedPublicKeyBundle,
   PrivateKey,
   PrivateKeyBundle,
+  PrivateKeyBundleV1,
+  PrivateKeyBundleV2,
   Signature,
   encrypt,
   decrypt,
@@ -46,7 +48,13 @@ export {
   toNanoString,
   mapPaginatedStream,
 } from './utils'
-export { Keystore, InMemoryKeystore, TopicData } from './keystore'
+export {
+  Keystore,
+  InMemoryKeystore,
+  TopicData,
+  SnapKeystore,
+  apiDefs as keystoreApiDefs,
+} from './keystore'
 export {
   KeystoreProvider,
   KeyGeneratorKeystoreProvider,

--- a/src/keystore/SnapKeystore.ts
+++ b/src/keystore/SnapKeystore.ts
@@ -1,0 +1,137 @@
+import { Keystore } from './interfaces'
+import {
+  fetcher,
+  conversationReference,
+  keystore,
+  authn,
+  publicKey,
+  signature,
+} from '@xmtp/proto'
+import { Reader, Writer } from 'protobufjs/minimal'
+const { b64Encode, b64Decode } = fetcher
+
+type Codec<T> = {
+  decode(input: Reader | Uint8Array, length?: number): T
+  encode(message: T, writer?: Writer): Writer
+}
+type ApiDefs = {
+  [k: string]: {
+    req: Codec<any> | null
+    res: Codec<any>
+  }
+}
+
+export const defaultSnapOrigin = `local:http://localhost:8080`
+
+export const apiDefs: ApiDefs = {
+  decryptV1: {
+    req: keystore.DecryptV1Request,
+    res: keystore.DecryptResponse,
+  },
+  encryptV1: {
+    req: keystore.EncryptV1Request,
+    res: keystore.EncryptResponse,
+  },
+  encryptV2: {
+    req: keystore.EncryptV2Request,
+    res: keystore.EncryptResponse,
+  },
+  decryptV2: {
+    req: keystore.DecryptV2Request,
+    res: keystore.DecryptResponse,
+  },
+  saveInvites: {
+    req: keystore.SaveInvitesRequest,
+    res: keystore.SaveInvitesResponse,
+  },
+  createInvite: {
+    req: keystore.CreateInviteRequest,
+    res: keystore.CreateInviteResponse,
+  },
+  createAuthToken: {
+    req: keystore.CreateAuthTokenRequest,
+    res: authn.Token,
+  },
+  signDigest: {
+    req: keystore.SignDigestRequest,
+    res: signature.Signature,
+  },
+  getPublicKeyBundle: {
+    req: null,
+    res: publicKey.PublicKeyBundle,
+  },
+} as const
+
+export function SnapKeystore(): Keystore {
+  const generatedMethods: any = {}
+  const ethereum = window.ethereum
+
+  async function ethereumRequest<T extends keyof Keystore>(
+    method: T,
+    req: Uint8Array | null
+  ): Promise<string | string[]> {
+    console.log('Calling method', method)
+    const response = await ethereum.request({
+      method: 'wallet_invokeSnap',
+      params: {
+        snapId: defaultSnapOrigin,
+        request: {
+          method,
+          params: { req: req ? b64Encode(req, 0, req.length) : null },
+        },
+      },
+    })
+
+    if (!response || typeof response !== 'object') {
+      throw new Error('No response value')
+    }
+
+    console.log('Raw response', response)
+
+    return (response as any).res as unknown as string | string[]
+  }
+
+  async function getResponse<T extends keyof Keystore>(
+    method: T,
+    req: Uint8Array | null,
+    resDecoder: typeof apiDefs[T]['res']
+  ): Promise<typeof apiDefs[T]['res']> {
+    const responseString = await ethereumRequest(method, req)
+    if (Array.isArray(responseString)) {
+      throw new Error('Unexpected array response')
+    }
+    console.log('Got a response string', responseString)
+    return resDecoder.decode(b64Decode(responseString))
+  }
+
+  for (const [method, apiDef] of Object.entries(apiDefs)) {
+    generatedMethods[method] = async (req: any) => {
+      if (!apiDef.req) {
+        return getResponse(method as keyof Keystore, null, apiDef.res)
+      }
+      const reqBytes = apiDef.req.encode(req).finish()
+      return getResponse(method as keyof Keystore, reqBytes, apiDef.res)
+    }
+  }
+
+  return {
+    ...generatedMethods,
+    async getV2Conversations() {
+      const rawResponse = await ethereumRequest('getV2Conversations', null)
+      if (Array.isArray(rawResponse)) {
+        return rawResponse.map((r) =>
+          conversationReference.ConversationReference.decode(
+            fetcher.b64Decode(r)
+          )
+        )
+      }
+    },
+    async getAccountAddress() {
+      const rawResponse = await ethereumRequest('getAccountAddress', null)
+      if (Array.isArray(rawResponse)) {
+        throw new Error('Unexpected array response')
+      }
+      return rawResponse
+    },
+  }
+}

--- a/src/keystore/SnapKeystore.ts
+++ b/src/keystore/SnapKeystore.ts
@@ -70,7 +70,6 @@ export function SnapKeystore(): Keystore {
     method: T,
     req: Uint8Array | null
   ): Promise<string | string[]> {
-    console.log('Calling method', method)
     const response = await ethereum.request({
       method: 'wallet_invokeSnap',
       params: {
@@ -86,8 +85,6 @@ export function SnapKeystore(): Keystore {
       throw new Error('No response value')
     }
 
-    console.log('Raw response', response)
-
     return (response as any).res as unknown as string | string[]
   }
 
@@ -100,7 +97,6 @@ export function SnapKeystore(): Keystore {
     if (Array.isArray(responseString)) {
       throw new Error('Unexpected array response')
     }
-    console.log('Got a response string', responseString)
     return resDecoder.decode(b64Decode(responseString))
   }
 

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,5 +1,6 @@
 export { default as InMemoryKeystore } from './InMemoryKeystore'
 export { default as InviteStore } from './InviteStore'
+export * from './SnapKeystore'
 export * from './encryption'
 export * from './errors'
 export * from './interfaces'

--- a/src/keystore/providers/SnapProvider.ts
+++ b/src/keystore/providers/SnapProvider.ts
@@ -1,0 +1,91 @@
+import { KeystoreProviderUnavailableError } from './errors'
+import { Keystore } from './../interfaces'
+import { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
+import { defaultSnapOrigin, SnapKeystore } from '../SnapKeystore'
+
+export type Snap = {
+  permissionName: string
+  id: string
+  version: string
+  initialPermissions: Record<string, unknown>
+}
+
+export type GetSnapsResponse = Record<string, Snap>
+
+const isFlask = async () => {
+  const provider = window.ethereum
+
+  try {
+    const clientVersion = await provider?.request({
+      method: 'web3_clientVersion',
+    })
+
+    const isFlaskDetected = (clientVersion as string[])?.includes('flask')
+
+    return Boolean(provider && isFlaskDetected)
+  } catch {
+    return false
+  }
+}
+
+const getSnaps = async (): Promise<GetSnapsResponse> => {
+  console.log('Getting snap')
+  return (await window.ethereum.request({
+    method: 'wallet_getSnaps',
+  })) as unknown as GetSnapsResponse
+}
+
+const getSnap = async (version?: string): Promise<Snap | undefined> => {
+  try {
+    const snaps = await getSnaps()
+
+    return Object.values(snaps).find(
+      (snap) =>
+        snap.id === defaultSnapOrigin && (!version || snap.version === version)
+    )
+  } catch (e) {
+    console.log('Failed to obtain installed snap', e)
+    return undefined
+  }
+}
+
+const initSnap = async () => {
+  await window.ethereum.request({
+    method: 'wallet_invokeSnap',
+    params: {
+      snapId: defaultSnapOrigin,
+      request: {
+        method: 'init',
+      },
+    },
+  })
+}
+
+const connectSnap = async (
+  snapId: string = defaultSnapOrigin,
+  params: Record<'version' | string, unknown> = {}
+) => {
+  console.log('Connecting snap')
+  await window.ethereum.request({
+    method: 'wallet_requestSnaps',
+    params: {
+      [snapId]: params,
+    },
+  })
+}
+
+export default class SnapKeystoreProvider implements KeystoreProvider {
+  async newKeystore(opts: KeystoreProviderOptions): Promise<Keystore> {
+    if (!isFlask()) {
+      throw new KeystoreProviderUnavailableError('Flask not detected')
+    }
+    const hasSnap = await getSnap()
+    console.log('hasSnap', hasSnap)
+    if (!hasSnap) {
+      await connectSnap()
+    }
+    await initSnap()
+
+    return SnapKeystore()
+  }
+}

--- a/src/keystore/providers/SnapProvider.ts
+++ b/src/keystore/providers/SnapProvider.ts
@@ -29,7 +29,6 @@ const isFlask = async () => {
 }
 
 const getSnaps = async (): Promise<GetSnapsResponse> => {
-  console.log('Getting snap')
   return (await window.ethereum.request({
     method: 'wallet_getSnaps',
   })) as unknown as GetSnapsResponse
@@ -44,7 +43,7 @@ const getSnap = async (version?: string): Promise<Snap | undefined> => {
         snap.id === defaultSnapOrigin && (!version || snap.version === version)
     )
   } catch (e) {
-    console.log('Failed to obtain installed snap', e)
+    console.warn('Failed to obtain installed snap', e)
     return undefined
   }
 }
@@ -65,7 +64,6 @@ const connectSnap = async (
   snapId: string = defaultSnapOrigin,
   params: Record<'version' | string, unknown> = {}
 ) => {
-  console.log('Connecting snap')
   await window.ethereum.request({
     method: 'wallet_requestSnaps',
     params: {
@@ -80,7 +78,6 @@ export default class SnapKeystoreProvider implements KeystoreProvider {
       throw new KeystoreProviderUnavailableError('Flask not detected')
     }
     const hasSnap = await getSnap()
-    console.log('hasSnap', hasSnap)
     if (!hasSnap) {
       await connectSnap()
     }

--- a/src/types/metamask.ts
+++ b/src/types/metamask.ts
@@ -1,0 +1,12 @@
+/* eslint-disable*/
+
+import { MetaMaskInpageProvider } from '@metamask/providers'
+/*
+ * Window type extension to support ethereum
+ */
+
+declare global {
+  interface Window {
+    ethereum: MetaMaskInpageProvider
+  }
+}


### PR DESCRIPTION
## Summary

- Implements a Snap Keystore, which proxies all Keystore API requests to a MM Snap
- Uses a declarative model for defining both the sending and receiving handlers. Just encodes/decodes requests/responses based on a declared mapping of API methods to proto types
- Gracefully falls back to existing behaviour if the user doesn't have a Snaps-compatible browser. 

## Todo
Listing a bunch of todos, but with no intention of actually doing them any time soon

- Package up the Snap as a NPM module
- Proper error handling
- Permissions management for applications
- Better type safety of API handlers
- Maybe update `getV2Conversations` to return a single proto object instead of an array, to make generating handlers easier
- Performance profiling
- 