### PR TITLE
feat: publish then use voodoo identities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "siwe": "^2.1.3",
-        "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities"
+        "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -14484,7 +14484,7 @@
     },
     "node_modules/xmtpv3_wasm": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#85fe9056b071285ffdb3cd94654d5c37085c6f9e",
+      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#97b948140ec611678b24df981abaa7e7b02835af",
       "license": "MIT",
       "dependencies": {
         "@xmtp/proto": "^3.18.0"
@@ -25350,8 +25350,8 @@
       "dev": true
     },
     "xmtpv3_wasm": {
-      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#85fe9056b071285ffdb3cd94654d5c37085c6f9e",
-      "from": "xmtpv3_wasm@xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities",
+      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#97b948140ec611678b24df981abaa7e7b02835af",
+      "from": "xmtpv3_wasm@xmtp/libxmtp#vodozemac_dev",
       "requires": {
         "@xmtp/proto": "^3.18.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "siwe": "^2.1.3",
-        "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
+        "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -14484,7 +14484,7 @@
     },
     "node_modules/xmtpv3_wasm": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#7701394a106dadd9d1fe43802505f1b510761974",
+      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#85fe9056b071285ffdb3cd94654d5c37085c6f9e",
       "license": "MIT",
       "dependencies": {
         "@xmtp/proto": "^3.18.0"
@@ -25350,8 +25350,8 @@
       "dev": true
     },
     "xmtpv3_wasm": {
-      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#7701394a106dadd9d1fe43802505f1b510761974",
-      "from": "xmtpv3_wasm@xmtp/libxmtp#vodozemac_dev",
+      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#85fe9056b071285ffdb3cd94654d5c37085c6f9e",
+      "from": "xmtpv3_wasm@xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities",
       "requires": {
         "@xmtp/proto": "^3.18.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "siwe": "^2.1.3",
-    "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities"
+    "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "siwe": "^2.1.3",
-    "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
+    "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx_export_and_import_of_vodozemac_identities"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/src/voodoo/utils.ts
+++ b/src/voodoo/utils.ts
@@ -1,0 +1,20 @@
+import { utils } from 'ethers'
+import { buildContentTopic } from '../utils'
+
+// == Voodoo demo topics ==
+export const buildVoodooUserContactTopic = (walletAddr: string): string => {
+  // EIP55 normalize the address case.
+  return buildContentTopic(`voodoo-contact-${utils.getAddress(walletAddr)}`)
+}
+
+export const buildVoodooUserInviteTopic = (walletAddr: string): string => {
+  // EIP55 normalize the address case.
+  return buildContentTopic(`voodoo-invite-${utils.getAddress(walletAddr)}`)
+}
+
+export const buildVoodooUserPrivateStoreTopic = (
+  addrPrefixedKey: string
+): string => {
+  // e.g. "0x1111111111222222222233333333334444444444/key_bundle"
+  return buildContentTopic(`voodoo-privatestore-${addrPrefixedKey}`)
+}

--- a/src/voodoo/utils.ts
+++ b/src/voodoo/utils.ts
@@ -1,5 +1,7 @@
 import { utils } from 'ethers'
-import { buildContentTopic } from '../utils'
+
+export const buildContentTopic = (name: string): string =>
+  `/xmtp/1/${name}/proto`
 
 // == Voodoo demo topics ==
 export const buildVoodooUserContactTopic = (walletAddr: string): string => {

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -10,25 +10,34 @@ describe('VoodooClient', () => {
     // Check that client voodooInstance is truthy
     expect(client.voodooInstance).toBeTruthy()
   })
-  it('can do a roundtrip', async () => {
+  it('can publish contact bundle and get it back', async () => {
+    const alice = newWallet()
+    // Client creation should publish the contact bundle
+    const aliceClient = await Client.createVoodoo(alice, { env: 'local' })
+
+    // Should get the contact bundle
+    const aliceContactBundle = await aliceClient.getUserContactFromNetwork(
+      alice.address
+    )
+    expect(aliceContactBundle).toBeTruthy()
+  })
+  it('can do a roundtrip with published contact bundles', async () => {
     const alice = newWallet()
     const bob = newWallet()
     const aliceClient = await Client.createVoodoo(alice, { env: 'local' })
     const bobClient = await Client.createVoodoo(bob, { env: 'local' })
 
-    aliceClient.setContact(bobClient.contact)
-    bobClient.setContact(aliceClient.contact)
-
     const aliceMessage = 'Hello Bob'
     // Have alice send a message to bob, starting the session and also encrypting it
     const outboundJson = await aliceClient.getOutboundSessionJson(
-      bobClient.contact.address,
+      // The VoodooContact is looked up from a topic
+      bob.address,
       aliceMessage
     )
 
     // Have bob receive the initial message, starting the session and also decrypting it
     const bobInboundPlaintext = await bobClient.processInboundSessionJson(
-      aliceClient.contact.address,
+      alice.address,
       outboundJson
     )
 


### PR DESCRIPTION
## Overview

Uses https://github.com/xmtp/libxmtp/pull/40 to publish a contact bundle and fetch it without verification.

## Changes

- Add publishing and fetching of contacts from the network using Voodoo-topics in VoodooClient.ts

## Test Plan

- Change the roundtrip test to use the new contacts, instead of passing the contacts around inside the test itself