### PR TITLE
fix: export typing notification types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,11 @@ export {
 } from './MessageContent'
 export { TextCodec, ContentTypeText } from './codecs/Text'
 export {
+  TypingNotification,
+  TypingNotificationCodec,
+  ContentTypeTypingNotification,
+} from './codecs/TypingNotification'
+export {
   Composite,
   CompositeCodec,
   ContentTypeComposite,


### PR DESCRIPTION
Actually export the types introduced in https://github.com/xmtp/xmtp-js/pull/321.