### PR TITLE
Allow invite lookup

### DIFF
--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -361,4 +361,10 @@ export default class InMemoryKeystore implements Keystore {
     }
     return this.accountAddress
   }
+
+  // This method is not defined as part of the standard Keystore API, but is available
+  // on the InMemoryKeystore to support legacy use-cases.
+  lookupTopic(topic: string) {
+    return this.inviteStore.lookup(topic)
+  }
 }

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -518,4 +518,32 @@ describe('InMemoryKeystore', () => {
       expect(aliceAddress).toEqual(returnedAddress)
     })
   })
+
+  describe('lookupTopic', () => {
+    it('looks up a topic that exists', async () => {
+      const { created, sealed, invite } = await buildInvite()
+
+      const sealedBytes = sealed.toBytes()
+      const envelope = buildProtoEnvelope(sealedBytes, 'foo', created)
+
+      const {
+        responses: [aliceResponse],
+      } = await aliceKeystore.saveInvites({
+        requests: [envelope],
+      })
+      if (aliceResponse.error) {
+        throw aliceResponse
+      }
+
+      const lookupResult = aliceKeystore.lookupTopic(invite.topic)
+      expect(lookupResult?.invitation.aes256GcmHkdfSha256?.keyMaterial).toEqual(
+        invite.aes256GcmHkdfSha256.keyMaterial
+      )
+    })
+
+    it('returns undefined for non-existent topic', async () => {
+      const lookupResult = aliceKeystore.lookupTopic('foo')
+      expect(lookupResult).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

In attempting to roll out v8 to some select partners, one challenge is the lack of ability to export conversation data to allow interop between the JS SDK and mobile SDKs. In order to decrypt push notifications, these clients need to export key data from the JS SDK and store them in a place accessible by the mobile SDKs to be used in decryption.

I am proposing this as a narrowly scoped way to access to sensitive invite data from the `InMemoryKeystore` directly. There will be no similar functionality provided for other, more secure, keystores and it is not included as part of the standard Keystore API. This should not be a problem, as Webview based mobile applications are not likely to be compatible with the more secure future Keystore implementations like MM Snaps and are likely to continue using the `InMemoryKeystore`.

To use, you would do something like:
```ts
if (client.keystore instanceof InMemoryKeystore) {
   const data = client.keystore.lookupTopic(topic)
   ...
}
```

The hybrid web/mobile SDK usage is expected to go away as some of our more advanced apps switch to fully native implementations. If that does not happen, we may want to consider some sort of shared persistence layer between web and mobile SDKs where both can access the same key material securely.

## Notes
I think I prefer this method of exposing legacy functionality to the method I used for `getPrivateKeyBundle` (where I included it in the Keystore API spec and expect other implementations that don't support the method to throw errors). This requires an explicit type check of the Keystore. I'll move `getPrivateKeyBundle` over to work the same way in a separate PR for consistency.