### PR TITLE
Pre Signature Notifications

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -63,6 +63,7 @@ export type SendOptions = {
 }
 
 export type XmtpEnv = keyof typeof ApiUrls
+export type PreEventNotifier = () => Promise<void>
 
 /**
  * Network startup options
@@ -141,12 +142,35 @@ export type LegacyOptions = {
   publishLegacyContact?: boolean
 }
 
+export type PreEventNotifierOptions = {
+  /**
+   * preCreateIdentityNotifier will be called immediately before a Create Identity
+   * wallet signature is requested from the user.
+   *
+   * The provided function must return a Promise and will be awaited, allowing the
+   * developer to update the UI or insert a required delay before requesting a signature.
+   */
+  preCreateIdentityNotifier?: PreEventNotifier
+  /**
+   * preEnableIdentityNotifier will be called immediately before an Enable Identity
+   * wallet signature is requested from the user.
+   *
+   * The provided function must return a Promise and will be awaited, allowing the
+   * developer to update the UI or insert a required delay before requesting a signature.
+   */
+  preEnableIdentityNotifier?: PreEventNotifier
+}
+
 /**
  * Aggregate type for client options. Optional properties are used when the default value is calculated on invocation, and are computed
  * as needed by each function. All other defaults are specified in defaultOptions.
  */
 export type ClientOptions = Flatten<
-  NetworkOptions & KeyStoreOptions & ContentOptions & LegacyOptions
+  NetworkOptions &
+    KeyStoreOptions &
+    ContentOptions &
+    LegacyOptions &
+    PreEventNotifierOptions
 >
 
 /**

--- a/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
+++ b/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
@@ -25,6 +25,9 @@ export default class KeyGeneratorKeystoreProvider implements KeystoreProvider {
         'Wallet required to generate new keys'
       )
     }
+    if (opts.preCreateIdentityNotifier) {
+      await opts.preCreateIdentityNotifier()
+    }
     const bundle = await PrivateKeyBundleV1.generate(wallet)
     const manager = new NetworkKeyManager(
       wallet,

--- a/src/keystore/providers/NetworkKeyManager.ts
+++ b/src/keystore/providers/NetworkKeyManager.ts
@@ -7,6 +7,7 @@ import {
   encrypt,
   PrivateKeyBundleV2,
 } from '../../crypto'
+import type { PreEventNotifier } from '../../Client'
 import { LocalAuthenticator } from '../../authn'
 import { bytesToHex, getRandomValues, hexToBytes } from '../../crypto/utils'
 import Ciphertext from '../../crypto/Ciphertext'
@@ -21,10 +22,16 @@ const KEY_BUNDLE_NAME = 'key_bundle'
 export default class NetworkKeyManager {
   private persistence: TopicPersistence
   private signer: Signer
+  private preEnableIdentityNotifier?: PreEventNotifier
 
-  constructor(signer: Signer, persistence: TopicPersistence) {
+  constructor(
+    signer: Signer,
+    persistence: TopicPersistence,
+    preEnableIdentityNotifier?: PreEventNotifier
+  ) {
     this.signer = signer
     this.persistence = persistence
+    this.preEnableIdentityNotifier = preEnableIdentityNotifier
   }
 
   private async getStorageAddress(name: string): Promise<string> {
@@ -80,7 +87,9 @@ export default class NetworkKeyManager {
     const wPreKey = getRandomValues(new Uint8Array(32))
     const input = storageSigRequestText(wPreKey)
     const walletAddr = await wallet.getAddress()
-
+    if (this.preEnableIdentityNotifier) {
+      await this.preEnableIdentityNotifier()
+    }
     let sig = await wallet.signMessage(input)
 
     // Check that the signature is correct, was created using the expected
@@ -122,6 +131,9 @@ export default class NetworkKeyManager {
       throw new Error('missing bundle ciphertext')
     }
 
+    if (this.preEnableIdentityNotifier) {
+      await this.preEnableIdentityNotifier()
+    }
     const secret = hexToBytes(
       await wallet.signMessage(storageSigRequestText(eBundle.walletPreKey))
     )

--- a/src/keystore/providers/NetworkKeystoreProvider.ts
+++ b/src/keystore/providers/NetworkKeystoreProvider.ts
@@ -23,7 +23,11 @@ export default class NetworkKeystoreProvider implements KeystoreProvider {
       throw new KeystoreProviderUnavailableError('No wallet provided')
     }
 
-    const loader = new NetworkKeyLoader(wallet, new TopicPersistence(apiClient))
+    const loader = new NetworkKeyLoader(
+      wallet,
+      new TopicPersistence(apiClient),
+      opts.preEnableIdentityNotifier
+    )
     const keys = await loader.loadPrivateKeyBundle()
     if (!keys) {
       throw new KeystoreProviderUnavailableError('No keys found')

--- a/src/keystore/providers/interfaces.ts
+++ b/src/keystore/providers/interfaces.ts
@@ -1,4 +1,4 @@
-import type { XmtpEnv } from '../../Client'
+import type { XmtpEnv, PreEventNotifierOptions } from '../../Client'
 import type ApiClient from '../../ApiClient'
 import type { Signer } from '../../types/Signer'
 import type { Keystore } from '../interfaces'
@@ -7,7 +7,7 @@ export type KeystoreProviderOptions = {
   env: XmtpEnv
   persistConversations: boolean
   privateKeyOverride?: Uint8Array
-}
+} & PreEventNotifierOptions
 
 /**
  * A Keystore Provider is responsible for either creating a Keystore instance or throwing a KeystoreUnavailableError

--- a/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
+++ b/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
@@ -1,0 +1,49 @@
+import ApiClient, { ApiUrls } from '../../../src/ApiClient'
+import {
+  KeyGeneratorKeystoreProvider,
+  KeystoreProviderUnavailableError,
+} from '../../../src/keystore/providers'
+import { Signer } from '../../../src/types/Signer'
+import { newWallet } from '../../helpers'
+import { testProviderOptions } from './helpers'
+
+describe('KeyGeneratorKeystoreProvider', () => {
+  let wallet: Signer
+  let apiClient: ApiClient
+  beforeEach(() => {
+    wallet = newWallet()
+    apiClient = new ApiClient(ApiUrls['local'])
+  })
+
+  it('creates a key when wallet supplied', async () => {
+    const provider = new KeyGeneratorKeystoreProvider()
+    const keystore = await provider.newKeystore(
+      testProviderOptions(),
+      apiClient,
+      wallet
+    )
+    expect(keystore).toBeDefined()
+  })
+
+  it('throws KeystoreProviderUnavailableError when no wallet supplied', async () => {
+    const provider = new KeyGeneratorKeystoreProvider()
+    const prom = provider.newKeystore(
+      testProviderOptions(),
+      apiClient,
+      undefined
+    )
+    expect(prom).rejects.toThrow(KeystoreProviderUnavailableError)
+  })
+
+  it('calls preCreateIdentityNotifier when supplied', async () => {
+    const provider = new KeyGeneratorKeystoreProvider()
+    const preCreateIdentityNotifier = jest.fn()
+    const keystore = await provider.newKeystore(
+      { ...testProviderOptions(), preCreateIdentityNotifier },
+      apiClient,
+      wallet
+    )
+    expect(keystore).toBeDefined()
+    expect(preCreateIdentityNotifier).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/keystore/providers/NetworkKeyManager.test.ts
+++ b/test/keystore/providers/NetworkKeyManager.test.ts
@@ -111,4 +111,12 @@ describe('NetworkKeyManager', () => {
     )
     expect(shouldBeDefined).toBeInstanceOf(PrefixedPersistence)
   })
+
+  it('calls notifier on store', async () => {
+    const mockNotifier = jest.fn()
+    const manager = new NetworkKeyManager(wallet, persistence, mockNotifier)
+    const bundle = await PrivateKeyBundleV1.generate(wallet)
+    await manager.storePrivateKeyBundle(bundle)
+    expect(mockNotifier).toHaveBeenCalledTimes(1)
+  })
 })

--- a/test/keystore/providers/NetworkKeystoreProvider.test.ts
+++ b/test/keystore/providers/NetworkKeystoreProvider.test.ts
@@ -79,4 +79,21 @@ describe('NetworkKeystoreProvider', () => {
     )
     expect(keystore).toBeDefined()
   })
+
+  it('correctly calls notifier on load', async () => {
+    const manager = new NetworkKeyManager(
+      wallet,
+      new TopicPersistence(apiClient)
+    )
+    await manager.storePrivateKeyBundle(bundle)
+
+    const provider = new NetworkKeystoreProvider()
+    const mockNotifier = jest.fn()
+    await provider.newKeystore(
+      { ...testProviderOptions(), preEnableIdentityNotifier: mockNotifier },
+      apiClient,
+      wallet
+    )
+    expect(mockNotifier).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary

This attempts to solve two issues 

1. Developers would like to know when we are prompting for signatures, so they can update their UI to show some explanatory text
2. WebViews on mobile have some hard limitations around multiple deep-links without user interaction (see below) that make it impossible to get both the `Create Identity` and `Enable Identity` signatures without a user interaction in between.

This feature allows developers to specify two callback functions that are invoked immediately before requesting either of these signatures. The callback functions are expected to return a Promise, which will be awaited in our code. This can allow developers to force some sort of user interaction before resolving the promise if desired, or to resolve immediately but update the UI in their code.

## Issues
- https://github.com/xmtp/xmtp-js/issues/275
- https://github.com/xmtp/xmtp-js/issues/264

## Notes
I was really unsure what to call this. I was torn between `callback`, `hook`, and `notification`. I settled on `notification` because the callback function doesn't get any arguments and has limited control over what happens next (although it can abort the whole process by throwing an error or rejecting the promise).

Open to changing if others feel strongly.