### PR TITLE
feat: implement outgoing 1xN fanout and multibundle support in general

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -280,6 +280,28 @@ export default class Client {
   }
 
   /**
+   * Create multiple voodoo clients that share everything but the voodoo instance
+   */
+  static async createVoodooMulti(
+    numClients: number,
+    wallet: Signer | null,
+    opts?: Partial<ClientOptions>
+  ): Promise<VoodooClient[]> {
+    const options = defaultOptions(opts)
+    const apiClient = createApiClientFromOptions(options)
+    const keystore = await bootstrapKeystore(options, apiClient, wallet)
+    const publicKeyBundle = new PublicKeyBundle(
+      await keystore.getPublicKeyBundle()
+    )
+    const address = publicKeyBundle.walletSignatureAddress()
+    const clients = []
+    for (let i = 0; i < numClients; i++) {
+      clients.push(await VoodooClient.create(address, apiClient))
+    }
+    return clients
+  }
+
+  /**
    * Export the XMTP PrivateKeyBundle from the SDK as a `Uint8Array`.
    *
    * This bundle can then be provided as `privateKeyOverride` in a

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -239,7 +239,7 @@ export default class VoodooClient {
     )
 
     // Get a list of all valid contacts
-    let listContacts: VoodooContact[] = []
+    const listContacts: VoodooContact[] = []
 
     for await (const env of stream) {
       if (!env.message) {

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -186,8 +186,12 @@ export default class VoodooClient {
 
   private async ensureUserContactPublished(): Promise<void> {
     const bundle = await this.getUserContactFromNetwork(this.address)
-    // TODO: validate the bundle, not just check for presence
-    if (bundle) {
+    // NOTE: other devices for this wallet could have published bundles, this is expected
+    // TODO: we only avoid republishing our own bundle if the account is the same
+    if (!!bundle && bundle.voodooInstance === this.voodooInstance) {
+      console.log('Bundle account: ', bundle.voodooInstance)
+      console.log('This account: ', this.voodooInstance)
+      console.log('Skipping publishing user contact')
       return
     }
     await this.publishUserContact()
@@ -254,6 +258,7 @@ export default class VoodooClient {
         this.wasm.addOrGetPublicAccountFromJSON(voodooPublicJson)
       listContacts.push(new VoodooContact(peerAddress, voodooInstance))
     }
+    console.log(`Found ${listContacts.length} contacts for ${peerAddress}`)
     return {
       address: peerAddress,
       contacts: listContacts,

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -197,9 +197,6 @@ export default class VoodooClient {
     // NOTE: other devices for this wallet could have published bundles, this is expected
     // TODO: we only avoid republishing our own bundle if the account is the same
     if (!!bundle && bundle.voodooInstance === this.voodooInstance) {
-      console.log('Bundle account: ', bundle.voodooInstance)
-      console.log('This account: ', this.voodooInstance)
-      console.log('Skipping publishing user contact')
       return
     }
     await this.publishUserContact()
@@ -266,7 +263,6 @@ export default class VoodooClient {
         this.wasm.addOrGetPublicAccountFromJSON(voodooPublicJson)
       listContacts.push(new VoodooContact(peerAddress, voodooInstance))
     }
-    console.log(`Found ${listContacts.length} contacts for ${peerAddress}`)
     return {
       address: peerAddress,
       contacts: listContacts,

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -7,45 +7,11 @@ import { ListMessagesOptions } from '../Client'
 import { messageApi, fetcher } from '@xmtp/proto'
 
 import { VoodooConversations } from './conversations'
+import { VoodooContact, EncryptedVoodooMessage, VoodooMessage } from './types'
 const { b64Decode } = fetcher
 
-// TODO: this is a hacky wrapper class for a Voodoo contact,
-// currently represented by the entire contact's VoodooInstance
-// - should be changed to align with VoodooPublicAccount (or whatever)
-// it ends up being named in Rust
-export class VoodooContact {
-  address: string
-  // TODO: Replace this `any` by exporting appropriate type from xmtpv3 WASM binding package
-  voodooInstance: any
-
-  constructor(address: string, voodooInstance: any) {
-    this.address = address
-    this.voodooInstance = voodooInstance
-  }
-}
-
-// Very simple message object which acts as the message type for all Voodoo envelopes
-export type EncryptedVoodooMessage = {
-  // Plaintext fields
-  senderAddress: string
-  timestamp: number
-  // SessionId may be dropped in the future
-  sessionId: string
-  // Ciphertext fields
-  ciphertext: string
-}
-
-export type VoodooMessage = {
-  // All plaintext fields
-  senderAddress: string
-  timestamp: number
-  plaintext: string
-  // SessionId may be dropped in the future
-  sessionId: string
-}
-
 // TODO: currently mirrored from xmtpv3.ts - should be exported from there
-export type SessionResult = {
+type SessionResult = {
   sessionId: string
   payload: string
 }

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -3,19 +3,6 @@ import { VoodooMessage, VoodooMultiBundle, VoodooMultiSession } from '../types'
 import Stream from '../../Stream'
 import { messageApi } from '@xmtp/proto'
 
-// export type VoodooMultiSession = {
-//   // The address of the user
-//   address: string
-//   // Keep the multi bundle around for convenience
-//   multiBundle: VoodooMultiBundle
-//   // Session ids in the same order as the contacts
-//   sessionIds: string[]
-//   // Messages per session, so map sessionId to list of messages
-//   messages: Map<string, VoodooMessage[]>
-//   // Topics per session
-//   topics: string[]
-// }
-
 export default class VoodooConversation {
   peerAddress: string
   createdAt: number

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -1,4 +1,5 @@
-import VoodooClient, { VoodooMessage } from '../VoodooClient'
+import VoodooClient from '../VoodooClient'
+import { VoodooMessage } from '../types'
 import Stream from '../../Stream'
 import { messageApi } from '@xmtp/proto'
 

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -155,7 +155,10 @@ export default class VoodooConversations {
 
     // Create an outbound session with { sessionId: string, paylaod: string (encoded Olm PreKey Message) }
     const encryptedInvite: EncryptedVoodooMessage =
-      await this.client.newVoodooInvite(peerAddress, generatedSessionTopic)
+      await this.client.newVoodooInviteForContact(
+        contact,
+        generatedSessionTopic
+      )
 
     if (!encryptedInvite) {
       throw new Error('Could not create outbound session')

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -1,10 +1,11 @@
 import { messageApi } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
-import VoodooClient, {
+import VoodooClient from '../VoodooClient'
+import {
   VoodooContact,
   EncryptedVoodooMessage,
   VoodooMessage,
-} from '../VoodooClient'
+} from '../types'
 import VoodooConversation from './VoodooConversation'
 import { utils } from '../../crypto'
 

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -1,11 +1,7 @@
 import { messageApi } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
 import VoodooClient from '../VoodooClient'
-import {
-  VoodooContact,
-  EncryptedVoodooMessage,
-  VoodooMessage,
-} from '../types'
+import { VoodooContact, EncryptedVoodooMessage, VoodooMessage } from '../types'
 import VoodooConversation from './VoodooConversation'
 import { utils } from '../../crypto'
 

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -35,7 +35,6 @@ export default class VoodooConversations {
         inviteTopic,
         async (e) => e
       )
-      console.log('Got raw invites', rawInvites)
       const sessionsFromInvites = await this.client.listEnvelopes(
         inviteTopic,
         this.processInvite.bind(this)
@@ -87,7 +86,6 @@ export default class VoodooConversations {
   async processInvite(
     env: messageApi.Envelope
   ): Promise<OneToOneSession | undefined> {
-    console.log(`Processing invite envelope: ${env}`)
     const encryptedInvite: EncryptedVoodooMessage =
       await this.client.decodeEnvelope(env)
     const peerAddress = encryptedInvite.senderAddress
@@ -102,7 +100,6 @@ export default class VoodooConversations {
       const decryptedInvite: VoodooMessage =
         await this.client.processVoodooInvite(peerAddress, encryptedInvite)
       if (decryptedInvite) {
-        console.log(`Decrypted invite from ${peerAddress}`)
         return {
           senderAddress: decryptedInvite.senderAddress,
           recipientAddress: this.client.address,
@@ -113,7 +110,7 @@ export default class VoodooConversations {
         }
       }
     } catch (e) {
-      console.log(`Error processing invite from ${peerAddress}: ${e}`)
+      // TODO: can log this, but this is expected since only the invite for our device will decrypt correctly
     }
   }
 

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -1,7 +1,13 @@
 import { messageApi } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
 import VoodooClient from '../VoodooClient'
-import { VoodooContact, EncryptedVoodooMessage, VoodooMessage } from '../types'
+import {
+  VoodooContact,
+  EncryptedVoodooMessage,
+  VoodooMessage,
+  VoodooMultiBundle,
+  OneToOneSession,
+} from '../types'
 import VoodooConversation from './VoodooConversation'
 import { utils } from '../../crypto'
 
@@ -25,15 +31,42 @@ export default class VoodooConversations {
     try {
       // Check for new conversations in our invite topic
       const inviteTopic = buildVoodooUserInviteTopic(this.client.address)
-      const newConvosFromInvites = await this.client.listEnvelopes(
+      const sessionsFromInvites = await this.client.listEnvelopes(
         inviteTopic,
         this.processInvite.bind(this)
       )
 
-      // TODO: this will need to be updated to handle conversationId's
-      for (const convo of newConvosFromInvites) {
-        if (convo) {
-          this.conversations.set(convo.peerAddress, convo)
+      // Aggregate these one-to-one sessions into a map of lists keyed by peerAddress
+      const sessionsByPeer = new Map<string, OneToOneSession[]>()
+      for (const session of sessionsFromInvites) {
+        if (session) {
+          const peerAddress = session.senderAddress
+          if (sessionsByPeer.has(peerAddress)) {
+            sessionsByPeer.get(peerAddress)?.push(session)
+          } else {
+            sessionsByPeer.set(peerAddress, [session])
+          }
+        }
+      }
+
+      // For each of these peer addresses, skip if we already have a conversation for it
+      // otherwise we need to resolve the multibundle and construct a new conversation
+      for (const [peerAddress, sessions] of sessionsByPeer) {
+        if (!this.conversations.has(peerAddress)) {
+          const multibundle = await this.client.getUserContactMultiBundle(
+            peerAddress
+          )
+          if (multibundle) {
+            const convo = new VoodooConversation(
+              this.client,
+              peerAddress,
+              new Date().getTime(),
+              multibundle,
+              sessions.map((s) => s.sessionId),
+              sessions.map((s) => s.topic)
+            )
+            this.conversations.set(peerAddress, convo)
+          }
         }
       }
       return Array.from(this.conversations.values())
@@ -43,9 +76,12 @@ export default class VoodooConversations {
   }
 
   // Must be locked by convoMutex
+  // TODO: this method currently looks up the other party's multibundle for NxN fanout
+  // we may want to carry this information in the invite itself otherwise there could be
+  // a mismatch on the initial set of devices and the set we resolve in this method
   async processInvite(
     env: messageApi.Envelope
-  ): Promise<VoodooConversation | undefined> {
+  ): Promise<OneToOneSession | undefined> {
     const encryptedInvite: EncryptedVoodooMessage =
       await this.client.decodeEnvelope(env)
     const peerAddress = encryptedInvite.senderAddress
@@ -58,22 +94,29 @@ export default class VoodooConversations {
     const decryptedInvite: VoodooMessage =
       await this.client.processVoodooInvite(peerAddress, encryptedInvite)
     if (decryptedInvite) {
-      const conversation = new VoodooConversation(
-        this.client,
-        decryptedInvite.sessionId,
-        decryptedInvite.plaintext, // the plaintext of the invite message is the new convo topic
-        decryptedInvite.senderAddress,
-        decryptedInvite.timestamp
-      )
-      return conversation
+      return {
+        senderAddress: decryptedInvite.senderAddress,
+        recipientAddress: this.client.address,
+        sessionId: decryptedInvite.sessionId,
+        // the plaintext of the invite message is the new convo topic
+        topic: decryptedInvite.plaintext,
+        timestamp: decryptedInvite.timestamp,
+      }
     }
   }
 
   /**
-   * Creates a new VoodooConversation for the given address. Will throw an error if the peer is not found in the XMTP network
+   * Creates a new single OneToOneSession for the given contact. Does nto publish the invite envelope.
+   *
+   * Currently, we generate a random topic for the session, and send an Olm PreKey Message
+   * where the encrypted ciphertext is just the random topic. This is the "invite" message.
+   * The recipient processes the Olm PreKey Message and gets the random topic, and then
+   * creates their own VoodooConversation from the derived session and the included topic.
    */
-  async newConversation(peerAddress: string): Promise<VoodooConversation> {
-    const contact = await this.client.getUserContactFromNetwork(peerAddress)
+  private async newSingleSession(
+    contact: VoodooContact
+  ): Promise<OneToOneSession> {
+    const peerAddress = contact.address
     if (!contact) {
       throw new Error(
         `Voodoo recipient ${peerAddress} is not on the XMTP network`
@@ -85,31 +128,6 @@ export default class VoodooConversations {
       throw new Error(`Voodoo recipient ${peerAddress} is not a Voodoo contact`)
     }
 
-    // TODO: add more context eventually
-    const matcherFn = (convo: VoodooConversation) =>
-      convo.peerAddress === peerAddress
-
-    return this.convoMutex.runExclusive(async () => {
-      const existing = Array.from(this.conversations.values())
-      const existingMatch = existing.find(matcherFn)
-      if (existingMatch) {
-        return existingMatch
-      }
-
-      // Create a new VoodooConversation
-      const convo = await this.createConvo(contact as VoodooContact)
-      this.conversations.set(peerAddress, convo)
-      return convo
-    })
-  }
-
-  // Currently, we generate a random topic for the session, and send an Olm PreKey Message
-  // where the encrypted ciphertext is just the random topic. This is the "invite" message.
-  // The recipient processes the Olm PreKey Message and gets the random topic, and then
-  // creates their own VoodooConversation from the derived session and the included topic.
-  private async createConvo(
-    recipient: VoodooContact
-  ): Promise<VoodooConversation> {
     const timestamp = new Date().getTime()
 
     // Generate the random topic for the session and set it as the first
@@ -125,36 +143,85 @@ export default class VoodooConversations {
 
     // Create an outbound session with { sessionId: string, paylaod: string (encoded Olm PreKey Message) }
     const encryptedInvite: EncryptedVoodooMessage =
-      await this.client.newVoodooInvite(
-        recipient.address,
-        generatedSessionTopic
-      )
+      await this.client.newVoodooInvite(peerAddress, generatedSessionTopic)
 
     if (!encryptedInvite) {
       throw new Error('Could not create outbound session')
     }
+    return {
+      senderAddress: this.client.address,
+      recipientAddress: peerAddress,
+      sessionId: encryptedInvite.sessionId,
+      topic: generatedSessionTopic,
+      encryptedInvite,
+      timestamp,
+    }
+  }
 
-    // TODO: should derive this from wallet signature
-    const peerAddress = recipient.address
+  /**
+   * Creates a new VoodooConversation for a peerAddress by creating newSingleSessions for each VoodooContact found.
+   * And aggregating all the topics/sessionIds into a single VoodooConversation.
+   */
+  async newConversation(peerAddress: string): Promise<VoodooConversation> {
+    const multibundle = await this.client.getUserContactMultiBundle(peerAddress)
+    if (!multibundle) {
+      throw new Error(
+        `Voodoo recipient ${peerAddress} is not on the XMTP network`
+      )
+    }
 
-    // Only publish to the peer's inbox, store the conversation locally
-    await this.client.publishEnvelopes([
-      {
-        contentTopic: buildVoodooUserInviteTopic(peerAddress),
-        // The entire message is the encrypted invite
-        message: Buffer.from(JSON.stringify(encryptedInvite)),
-        // Date from timestamp
-        timestamp: new Date(timestamp),
-      },
-    ])
+    const contacts = multibundle.contacts
+    if (!contacts || contacts.length === 0) {
+      throw new Error(`Voodoo recipient ${peerAddress} is not a Voodoo contact`)
+    }
+    // TODO: add more context eventually
+    const matcherFn = (convo: VoodooConversation) =>
+      convo.peerAddress === peerAddress
 
-    const convo = new VoodooConversation(
-      this.client,
-      encryptedInvite.sessionId,
-      generatedSessionTopic,
-      peerAddress,
-      timestamp
-    )
-    return convo
+    // TODO: should we move some of this logic outside runExclusive? doing so
+    // could cause a race where the whole slew of duplicate invites are emitted
+    // from the same process
+    return this.convoMutex.runExclusive(async () => {
+      const existing = Array.from(this.conversations.values())
+      const existingMatch = existing.find(matcherFn)
+      if (existingMatch) {
+        return existingMatch
+      }
+
+      const sessions: OneToOneSession[] = []
+      for (const contact of contacts) {
+        if (!contact.voodooInstance) {
+          throw new Error(
+            `Voodoo recipient ${peerAddress} is not a Voodoo contact`
+          )
+        }
+        const session = await this.newSingleSession(contact)
+        sessions.push(session)
+      }
+
+      const sessionIds = sessions.map((s) => s.sessionId)
+      const topics = sessions.map((s) => s.topic)
+      const encryptedInviteEnvelopes = sessions
+        .map((s) => ({
+          contentTopic: buildVoodooUserInviteTopic(peerAddress),
+          message: Buffer.from(JSON.stringify(s.encryptedInvite)),
+          timestamp: new Date(s.timestamp),
+        }))
+        .filter((e) => e !== undefined)
+
+      // Need to publish all of the encryptedInvites
+      await this.client.publishEnvelopes(encryptedInviteEnvelopes)
+      // Create a new VoodooConversation
+      const convo = new VoodooConversation(
+        this.client,
+        peerAddress,
+        new Date().getTime(),
+        multibundle,
+        sessionIds,
+        topics
+      )
+      this.conversations.set(peerAddress, convo)
+      return convo
+    })
   }
 }

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -46,3 +46,31 @@ export type VoodooMultiBundle = {
   // Last refreshed timestamp
   timestamp: number
 }
+
+// Helpful wrapper for wrapping a single one-to-one session, which
+// later can be composed into a VoodooMultiSession
+export type OneToOneSession = {
+  senderAddress: string
+  recipientAddress: string
+  sessionId: string
+  topic: string
+  timestamp: number
+  // optional encryptedInvite
+  encryptedInvite?: EncryptedVoodooMessage
+}
+
+// Contains all the information needed to send a message to a user
+export type VoodooMultiSession = {
+  // The address of the user
+  address: string
+  // Keep the multi bundle around for convenience
+  multiBundle: VoodooMultiBundle
+  // Session ids in the same order as the contacts
+  sessionIds: string[]
+  // Messages per session, so map sessionId to list of messages
+  messages: Map<string, VoodooMessage[]>
+  // My messages TODO: will need to aggregate self-sessions here too
+  myMessages: VoodooMessage[]
+  // Topics per session
+  topics: string[]
+}

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -32,3 +32,17 @@ export type VoodooMessage = {
   // SessionId may be dropped in the future
   sessionId: string
 }
+
+// Contains multiple contact bundles that each represent a device that
+// the user has access to. We must send messages to all of these devices
+// in order to ensure that the user receives the message. Additionally, we
+// must consolidate messages from any of these devices into a single logical
+// stream deduplicated by address.
+export type VoodooMultiBundle = {
+  // The address of the user
+  address: string
+  // The bundles for each device
+  contacts: VoodooContact[]
+  // Last refreshed timestamp
+  timestamp: number
+}

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -1,0 +1,34 @@
+// TODO: this is a hacky wrapper class for a Voodoo contact,
+// currently represented by the entire contact's VoodooInstance
+// - should be changed to align with VoodooPublicAccount (or whatever)
+// it ends up being named in Rust
+export class VoodooContact {
+  address: string
+  // TODO: Replace this `any` by exporting appropriate type from xmtpv3 WASM binding package
+  voodooInstance: any
+
+  constructor(address: string, voodooInstance: any) {
+    this.address = address
+    this.voodooInstance = voodooInstance
+  }
+}
+
+// Very simple message object which acts as the message type for all Voodoo envelopes
+export type EncryptedVoodooMessage = {
+  // Plaintext fields
+  senderAddress: string
+  timestamp: number
+  // SessionId may be dropped in the future
+  sessionId: string
+  // Ciphertext fields
+  ciphertext: string
+}
+
+export type VoodooMessage = {
+  // All plaintext fields
+  senderAddress: string
+  timestamp: number
+  plaintext: string
+  // SessionId may be dropped in the future
+  sessionId: string
+}

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -4,7 +4,7 @@ import Client from '../../src/Client'
 import {
   VoodooMessage,
   EncryptedVoodooMessage,
-} from '../../src/voodoo/VoodooClient'
+} from '../../src/voodoo/types'
 
 describe('VoodooClient', () => {
   it('can create a client', async () => {

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 import { newWallet } from '../helpers'
 import Client from '../../src/Client'
-import {
-  VoodooMessage,
-  EncryptedVoodooMessage,
-} from '../../src/voodoo/types'
+import { VoodooMessage, EncryptedVoodooMessage } from '../../src/voodoo/types'
 
 describe('VoodooClient', () => {
   it('can create a client', async () => {

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -14,7 +14,11 @@ import {
 } from '../../../src/voodoo/conversations'
 import { SortDirection } from '../../../src/ApiClient'
 import { sleep } from '../../../src/utils'
-import { newLocalHostVoodooClient, waitForUserContact } from '../helpers'
+import {
+  multipleLocalHostVoodooClients,
+  newLocalHostVoodooClient,
+  waitForUserContact,
+} from '../helpers'
 
 describe('conversation', () => {
   let alice: VoodooClient
@@ -28,6 +32,7 @@ describe('conversation', () => {
       await waitForUserContact(bob, bob)
     })
 
+    /*
     it('v3 conversation', async () => {
       expect(await bob.getUserContactFromNetwork(alice.address)).toBeInstanceOf(
         VoodooContact
@@ -83,6 +88,82 @@ describe('conversation', () => {
         expect(ams2[i].senderAddress).toBe(expected_senders[i])
         expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
       }
+    })
+    */
+
+    it('1 to N fanout', async () => {
+      // Create 5 bob clients
+      const allBobs = await multipleLocalHostVoodooClients(5)
+      expect(await bob.getUserContactFromNetwork(alice.address)).toBeInstanceOf(
+        VoodooContact
+      )
+      expect(await alice.getUserContactFromNetwork(bob.address)).toBeInstanceOf(
+        VoodooContact
+      )
+
+      // Wait for all of the bobs to have published their contact bundles
+      for (const b of allBobs) {
+        await waitForUserContact(alice, b)
+      }
+
+      const bobOne = allBobs[0]
+
+      // This should create 5 invites
+      const ac = await alice.conversations.newConversation(bobOne.address)
+      if (!(ac instanceof VoodooConversation)) {
+        fail()
+      }
+
+      let bobConvos = []
+
+      // Check that invite is processed by bob
+      for (const b of allBobs) {
+        console.log(b)
+        const bcs = await b.conversations.list()
+        expect(bcs).toHaveLength(1)
+        bobConvos.push(bcs[0])
+      }
+
+      // Alice sends a message
+      await ac.send('hi')
+      // This should show up in alice's inbox
+      const ams = await ac.messages()
+      expect(ams).toHaveLength(1)
+      expect(ams[0].plaintext).toBe('hi')
+      await sleep(100)
+
+      // It should also show up in all Bob's inboxes
+      for (const bc of bobConvos) {
+        const bms = await bc.messages()
+        expect(bms).toHaveLength(1)
+        expect(bms[0].plaintext).toBe('hi')
+      }
+
+      /*
+      // Blast a few more messages from both sides
+      await bc.send('hi back')
+      await sleep(100)
+      await ac.send('hi back to you too')
+      await sleep(100)
+
+      // Check that they show up in both inboxes
+      const ams2 = await ac.messages()
+      const bms2 = await bc.messages()
+
+      expect(ams2).toHaveLength(3)
+      expect(bms2).toHaveLength(3)
+
+      const expected_plaintexts = ['hi', 'hi back', 'hi back to you too']
+      const expected_senders = [alice.address, bob.address, alice.address]
+
+      for (let i = 0; i < 3; i++) {
+        expect(ams2[i].plaintext).toBe(expected_plaintexts[i])
+        expect(ams2[i].plaintext).toBe(bms2[i].plaintext)
+
+        expect(ams2[i].senderAddress).toBe(expected_senders[i])
+        expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
+      }
+      */
     })
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -133,31 +133,18 @@ describe('conversation', () => {
         expect(bms[0].plaintext).toBe('hi')
       }
 
-      /*
-      // Blast a few more messages from both sides
-      await bc.send('hi back')
-      await sleep(100)
-      await ac.send('hi back to you too')
-      await sleep(100)
-
-      // Check that they show up in both inboxes
-      const ams2 = await ac.messages()
-      const bms2 = await bc.messages()
-
-      expect(ams2).toHaveLength(3)
-      expect(bms2).toHaveLength(3)
-
-      const expected_plaintexts = ['hi', 'hi back', 'hi back to you too']
-      const expected_senders = [alice.address, bob.address, alice.address]
-
-      for (let i = 0; i < 3; i++) {
-        expect(ams2[i].plaintext).toBe(expected_plaintexts[i])
-        expect(ams2[i].plaintext).toBe(bms2[i].plaintext)
-
-        expect(ams2[i].senderAddress).toBe(expected_senders[i])
-        expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
+      // Send a message from each bob with bob index
+      for (const [i, bc] of bobConvos.entries()) {
+        await bc.send('hi back: ' + i)
+        await sleep(100)
       }
-      */
+
+      // Expect Alice to have 6 messages
+      const ams2 = await ac.messages()
+      expect(ams2).toHaveLength(6)
+      for (let i = 1; i < 6; i++) {
+        expect(ams2[i].plaintext).toBe('hi back: ' + (i - 1))
+      }
     })
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -7,9 +7,9 @@ import {
   ContentTypeText,
 } from '../../../src'
 import {
-  VoodooContact,
   default as VoodooClient,
 } from '../../../src/voodoo/VoodooClient'
+import { VoodooContact } from '../../../src/voodoo/types'
 import {
   VoodooConversation,
   VoodooConversations,

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -25,15 +25,13 @@ describe('conversation', () => {
   let bob: VoodooClient
 
   describe('voodoo', () => {
-    beforeEach(async () => {
+    /*
+    it('v3 conversation', async () => {
       alice = await newLocalHostVoodooClient()
       bob = await newLocalHostVoodooClient()
       await waitForUserContact(alice, alice)
       await waitForUserContact(bob, bob)
-    })
 
-    /*
-    it('v3 conversation', async () => {
       expect(await bob.getUserContactFromNetwork(alice.address)).toBeInstanceOf(
         VoodooContact
       )
@@ -92,15 +90,14 @@ describe('conversation', () => {
     */
 
     it('1 to N fanout', async () => {
+      // Setup alice
+      alice = await newLocalHostVoodooClient()
+      await waitForUserContact(alice, alice)
       // Create 5 bob clients
       const allBobs = await multipleLocalHostVoodooClients(5)
-      expect(await bob.getUserContactFromNetwork(alice.address)).toBeInstanceOf(
-        VoodooContact
-      )
-      expect(await alice.getUserContactFromNetwork(bob.address)).toBeInstanceOf(
-        VoodooContact
-      )
-
+      expect(
+        await alice.getUserContactFromNetwork(alice.address)
+      ).toBeInstanceOf(VoodooContact)
       // Wait for all of the bobs to have published their contact bundles
       for (const b of allBobs) {
         await waitForUserContact(alice, b)

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -6,9 +6,7 @@ import {
   ContentTypeId,
   ContentTypeText,
 } from '../../../src'
-import {
-  default as VoodooClient,
-} from '../../../src/voodoo/VoodooClient'
+import { default as VoodooClient } from '../../../src/voodoo/VoodooClient'
 import { VoodooContact } from '../../../src/voodoo/types'
 import {
   VoodooConversation,

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -25,7 +25,6 @@ describe('conversation', () => {
   let bob: VoodooClient
 
   describe('voodoo', () => {
-    /*
     it('v3 conversation', async () => {
       alice = await newLocalHostVoodooClient()
       bob = await newLocalHostVoodooClient()
@@ -87,7 +86,6 @@ describe('conversation', () => {
         expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
       }
     })
-    */
 
     it('1 to N fanout', async () => {
       // Setup alice
@@ -115,7 +113,6 @@ describe('conversation', () => {
 
       // Check that invite is processed by bob
       for (const b of allBobs) {
-        console.log(b)
         const bcs = await b.conversations.list()
         expect(bcs).toHaveLength(1)
         bobConvos.push(bcs[0])

--- a/test/voodoo/helpers.ts
+++ b/test/voodoo/helpers.ts
@@ -1,5 +1,6 @@
 import { ClientOptions, Client } from '../../src'
-import VoodooClient, { VoodooContact } from '../../src/voodoo/VoodooClient'
+import VoodooClient from '../../src/voodoo/VoodooClient'
+import { VoodooContact } from '../../src/voodoo/types'
 import { pollFor, newWallet } from '../helpers'
 import assert from 'assert'
 

--- a/test/voodoo/helpers.ts
+++ b/test/voodoo/helpers.ts
@@ -13,6 +13,18 @@ export const newLocalHostVoodooClient = (
     ...opts,
   })
 
+// Used to simulate multiple clients with the same wallet
+export const multipleLocalHostVoodooClients = async (
+  n: number,
+  opts?: Partial<ClientOptions>
+): Promise<VoodooClient[]> => {
+  const wallet = newWallet()
+  return Client.createVoodooMulti(n, newWallet(), {
+    env: 'local',
+    ...opts,
+  })
+}
+
 export async function waitForUserContact(
   c1: VoodooClient,
   c2: VoodooClient


### PR DESCRIPTION
## Overview

After this PR, each `VoodooClient` will publish their own contact bundle, even if an existing one for the address is present in the contact topic. When messaging another user, the client downloads all contact bundles, aggregates them into a `VoodooMultiBundle` and then messages all of them.

We also perform `MultiSession` management in `VoodooConversation`. This PR does _not_ handle self-fanout of outgoing messages. That will be done next.

**Note:** Ideally we'd do more of this bookkeeping in Rust, but after we get NxN working in xmtp-js we can decide how much logic to shift back into Rust land.

## Changes
- Add `src/voodoo/types.ts` file with all types.
- Add new types for `OneToOneSession` (device to device session), `VoodooMultiBundle` (list of contacts) and `VoodooMultiSession` (list of sessions for user<>user convo)
- Implement multibundle support throughout
- Implement a unit test for 1xN fanout and also Nx1, but there isn't NxN (no self-messaging)

## Test Plan

- Unit tests