### PR TITLE
feat: full NxN prototype in xmtp-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "siwe": "^2.1.3",
-        "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx-use-fallback-key-instead"
+        "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -14484,7 +14484,7 @@
     },
     "node_modules/xmtpv3_wasm": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#fe7733055d6d73ec9b1112b9d8daed10d9343b05",
+      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#aceec5156d1631dd85c9234f54463058e1e45416",
       "license": "MIT",
       "dependencies": {
         "@xmtp/proto": "^3.18.0"
@@ -25349,8 +25349,8 @@
       "dev": true
     },
     "xmtpv3_wasm": {
-      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#fe7733055d6d73ec9b1112b9d8daed10d9343b05",
-      "from": "xmtpv3_wasm@xmtp/libxmtp#michaelx-use-fallback-key-instead",
+      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#aceec5156d1631dd85c9234f54463058e1e45416",
+      "from": "xmtpv3_wasm@xmtp/libxmtp#vodozemac_dev",
       "requires": {
         "@xmtp/proto": "^3.18.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ethers": "^5.5.3",
         "long": "^5.2.0",
         "siwe": "^2.1.3",
-        "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
+        "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx-use-fallback-key-instead"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.1.0",
@@ -14484,7 +14484,7 @@
     },
     "node_modules/xmtpv3_wasm": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#97b948140ec611678b24df981abaa7e7b02835af",
+      "resolved": "git+ssh://git@github.com/xmtp/libxmtp.git#fe7733055d6d73ec9b1112b9d8daed10d9343b05",
       "license": "MIT",
       "dependencies": {
         "@xmtp/proto": "^3.18.0"
@@ -25349,8 +25349,8 @@
       "dev": true
     },
     "xmtpv3_wasm": {
-      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#97b948140ec611678b24df981abaa7e7b02835af",
-      "from": "xmtpv3_wasm@github:xmtp/libxmtp#vodozemac_dev",
+      "version": "git+ssh://git@github.com/xmtp/libxmtp.git#fe7733055d6d73ec9b1112b9d8daed10d9343b05",
+      "from": "xmtpv3_wasm@xmtp/libxmtp#michaelx-use-fallback-key-instead",
       "requires": {
         "@xmtp/proto": "^3.18.0"
       },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "siwe": "^2.1.3",
-    "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx-use-fallback-key-instead"
+    "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ethers": "^5.5.3",
     "long": "^5.2.0",
     "siwe": "^2.1.3",
-    "xmtpv3_wasm": "github:xmtp/libxmtp#vodozemac_dev"
+    "xmtpv3_wasm": "github:xmtp/libxmtp#michaelx-use-fallback-key-instead"
   },
   "devDependencies": {
     "@commitlint/cli": "^16.1.0",

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -231,11 +231,16 @@ export default class VoodooClient {
   }
 
   private async ensureUserContactPublished(): Promise<void> {
-    const bundle = await this.getUserContactFromNetwork(this.address)
+    // Check the multibundle, see if our contact is in there
+    const multibundle = await this.getUserContactMultiBundle(this.address)
     // NOTE: other devices for this wallet could have published bundles, this is expected
     // TODO: we only avoid republishing our own bundle if the account is the same
-    if (!!bundle && bundle.voodooInstance === this.voodooInstance) {
-      return
+    if (multibundle) {
+      for (const contact of multibundle.contacts) {
+        if (this.contactInstanceIsMe(contact)) {
+          return
+        }
+      }
     }
     await this.publishUserContact()
   }

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -231,7 +231,8 @@ export default class VoodooClient {
     }
   }
 
-  private async ensureUserContactPublished(): Promise<void> {
+  // PRIVATE: left open for testing purposes
+  async ensureUserContactPublished(): Promise<void> {
     // Check the multibundle, see if our contact is in there
     const multibundle = await this.getUserContactMultiBundle(this.address)
     // NOTE: other devices for this wallet could have published bundles, this is expected

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -66,10 +66,7 @@ export default class VoodooClient {
   }
 
   get contact(): VoodooContact {
-    return {
-      address: this.address,
-      voodooInstance: this.voodooInstance,
-    }
+    return new VoodooContact(this.address, this.voodooInstance)
   }
 
   async newVoodooInvite(
@@ -83,9 +80,9 @@ export default class VoodooClient {
     return this.newVoodooInviteForContact(contactInstance, peerAddress, topic)
   }
 
-  // TODO: terrible abstraction for equality
+  // TODO: terrible abstraction for equality, uses handles currently
   contactInstanceIsMe(contact: VoodooContact): boolean {
-    // Check if this.voodooInstance.handle is the same as contact.voodooInstance.handle
+    // Check if this.voodooInstance is the same as contact.voodooInstance
     return this.voodooInstance.handle === contact.voodooInstance.handle
   }
 
@@ -133,7 +130,6 @@ export default class VoodooClient {
         if (this.contactInstanceIsMe(contactInstance)) {
           continue
         }
-        console.log(`Trying contact`, contactInstance, 'self?', this.contact)
         const invite = await this.processVoodooInviteForContact(
           contactInstance,
           encryptedInvite

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -291,7 +291,7 @@ export default class VoodooClient {
   ): Promise<VoodooMultiBundle | undefined> {
     const stream = this.apiClient.queryIterator(
       { contentTopic: buildVoodooUserContactTopic(peerAddress) },
-      { pageSize: 25, direction: SortDirection.SORT_DIRECTION_DESCENDING }
+      { pageSize: 100, direction: SortDirection.SORT_DIRECTION_DESCENDING }
     )
 
     // Get a list of all valid contacts

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -12,7 +12,6 @@ import {
   EncryptedVoodooMessage,
   VoodooMessage,
   VoodooMultiBundle,
-  VoodooInvite,
 } from './types'
 const { b64Decode } = fetcher
 

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -92,14 +92,6 @@ export default class VoodooClient {
     otherUserAddress: string,
     topic: string
   ): Promise<EncryptedVoodooMessage> {
-    console.log(
-      'Creating new Voodoo invite for contact',
-      contactInstance,
-      otherUserAddress,
-      topic
-    )
-    console.log('my voodoo instance', this.voodooInstance)
-    console.log('equals?', this.contactInstanceIsMe(contactInstance))
     const outboundSessionResult: SessionResult =
       await this.voodooInstance.createOutboundSession(
         contactInstance.voodooInstance,

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -310,7 +310,6 @@ export default class VoodooClient {
     return {
       address: peerAddress,
       contacts: listContacts,
-      timestamp: new Date().getTime(),
     }
   }
 

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -130,6 +130,10 @@ export default class VoodooClient {
     // Try all contacts
     for (const contactInstance of possibleContacts) {
       try {
+        if (this.contactInstanceIsMe(contactInstance)) {
+          continue
+        }
+        console.log(`Trying contact`, contactInstance, 'self?', this.contact)
         const invite = await this.processVoodooInviteForContact(
           contactInstance,
           encryptedInvite

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -72,6 +72,17 @@ export default class VoodooClient {
     }
   }
 
+  async newVoodooInvite(
+    peerAddress: string,
+    topic: string
+  ): Promise<EncryptedVoodooMessage> {
+    const contactInstance = await this.getUserContactFromNetwork(peerAddress)
+    if (!contactInstance) {
+      throw new Error('No contact found for address')
+    }
+    return this.newVoodooInviteForContact(contactInstance, peerAddress, topic)
+  }
+
   // Create a new Voodoo invite (vmac outbound session with plaintext = topic) for a contact
   async newVoodooInviteForContact(
     contactInstance: VoodooContact,

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -127,7 +127,8 @@ export default class VoodooClient {
         )
         return [contactInstance, invite]
       } catch (err) {
-        console.warn(`Error processing invite for contact`, err)
+        // NOTE: expect many errors here, so don't log
+        // console.warn(`Error processing invite for contact`, err)
       }
     }
     throw new Error(`No contacts could decrypt invite`)

--- a/src/voodoo/VoodooClient.ts
+++ b/src/voodoo/VoodooClient.ts
@@ -83,12 +83,26 @@ export default class VoodooClient {
     return this.newVoodooInviteForContact(contactInstance, peerAddress, topic)
   }
 
+  // TODO: terrible abstraction for equality
+  contactInstanceIsMe(contact: VoodooContact): boolean {
+    // Check if this.voodooInstance.handle is the same as contact.voodooInstance.handle
+    return this.voodooInstance.handle === contact.voodooInstance.handle
+  }
+
   // Create a new Voodoo invite (vmac outbound session with plaintext = topic) for a contact
   async newVoodooInviteForContact(
     contactInstance: VoodooContact,
     otherUserAddress: string,
     topic: string
   ): Promise<EncryptedVoodooMessage> {
+    console.log(
+      'Creating new Voodoo invite for contact',
+      contactInstance,
+      otherUserAddress,
+      topic
+    )
+    console.log('my voodoo instance', this.voodooInstance)
+    console.log('equals?', this.contactInstanceIsMe(contactInstance))
     const outboundSessionResult: SessionResult =
       await this.voodooInstance.createOutboundSession(
         contactInstance.voodooInstance,

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -3,6 +3,13 @@ import { VoodooMessage, VoodooMultiBundle, VoodooMultiSession } from '../types'
 import Stream from '../../Stream'
 import { messageApi } from '@xmtp/proto'
 
+/**
+ * This class represents a conversation between two users.
+ * It needs to manage various 1:1 messaging sessions between devices that
+ * comprise this conversation.
+ * - 1:1s between my current VoodooInstance and my other ones (on other devices possibly)
+ * - 1:1s between my current VoodooInstance and my peer's VoodooInstances
+ */
 export default class VoodooConversation {
   peerAddress: string
   createdAt: number
@@ -13,7 +20,8 @@ export default class VoodooConversation {
     client: VoodooClient,
     peerAddress: string,
     createdAt: number,
-    multibundle: VoodooMultiBundle,
+    myMultiBundle: VoodooMultiBundle,
+    otherMultiBundle: VoodooMultiBundle,
     sessionIds: string[],
     topics: string[]
   ) {
@@ -25,13 +33,34 @@ export default class VoodooConversation {
       messages.set(sessionId, [])
     })
     this.multiSession = {
-      address: multibundle.address,
-      multiBundle: multibundle,
+      otherAddress: peerAddress,
+      myMultiBundle,
+      otherMultiBundle,
+      establishedContacts: [],
       sessionIds,
       messages,
       myMessages: [],
       topics,
     }
+  }
+
+  // Helper function to get a new empty conversation
+  static newEmptyConversation(
+    client: VoodooClient,
+    myMultiBundle: VoodooMultiBundle,
+    otherMultiBundle: VoodooMultiBundle,
+    peerAddress: string
+  ): VoodooConversation {
+    const createdAt = Date.now()
+    return new VoodooConversation(
+      client,
+      peerAddress,
+      createdAt,
+      myMultiBundle,
+      otherMultiBundle,
+      [],
+      []
+    )
   }
 
   get clientAddress(): string {

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -33,7 +33,7 @@ export default class VoodooConversation {
       messages.set(sessionId, [])
     })
     this.multiSession = {
-      otherAddress: otherAddress,
+      otherAddress,
       myMultiBundle,
       otherMultiBundle,
       establishedContacts: [],

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -11,14 +11,14 @@ import { messageApi } from '@xmtp/proto'
  * - 1:1s between my current VoodooInstance and my peer's VoodooInstances
  */
 export default class VoodooConversation {
-  peerAddress: string
+  otherAddress: string
   createdAt: number
   multiSession: VoodooMultiSession
   private client: VoodooClient
 
   constructor(
     client: VoodooClient,
-    peerAddress: string,
+    otherAddress: string,
     createdAt: number,
     myMultiBundle: VoodooMultiBundle,
     otherMultiBundle: VoodooMultiBundle,
@@ -26,14 +26,14 @@ export default class VoodooConversation {
     topics: string[]
   ) {
     this.client = client
-    this.peerAddress = peerAddress
+    this.otherAddress = otherAddress
     this.createdAt = createdAt
     const messages = new Map<string, VoodooMessage[]>()
     sessionIds.forEach((sessionId) => {
       messages.set(sessionId, [])
     })
     this.multiSession = {
-      otherAddress: peerAddress,
+      otherAddress: otherAddress,
       myMultiBundle,
       otherMultiBundle,
       establishedContacts: [],
@@ -49,12 +49,12 @@ export default class VoodooConversation {
     client: VoodooClient,
     myMultiBundle: VoodooMultiBundle,
     otherMultiBundle: VoodooMultiBundle,
-    peerAddress: string
+    otherAddress: string
   ): VoodooConversation {
     const createdAt = Date.now()
     return new VoodooConversation(
       client,
-      peerAddress,
+      otherAddress,
       createdAt,
       myMultiBundle,
       otherMultiBundle,

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -23,6 +23,23 @@ import {
  * comprise this conversation.
  * - 1:1s between my current VoodooInstance and my other ones (on other devices possibly)
  * - 1:1s between my current VoodooInstance and my peer's VoodooInstances
+ *
+ * The VoodooMultiSession object holds most of this state, but some invariants are only captured
+ * in code.
+ * - A VoodooConversation only adds more 1:1 sessions upon sending a message. This is just a design
+ *   choice to avoid churn i.e. if B receives an invite from A, and sends per-device invites back to all of B and A devices.
+ *   This could happen all at once for all online devices causing a bit of a thundering herd problem.
+ * - A VoodooConversation only sends to one given session per contact. Even though multiple sessions may exist between
+ *   two contacts e.g. if both devices send invites to each other at the same time
+ * - sessionIds, topics, and establishedContacts are all in the same order
+ * - Messages sent by this specific VoodooInstance are stored in myMessages
+ * - Messages sent by other VoodooInstances are stored in the messages map in the VoodooMultiSession
+ * - When compiling all messages, all sessions must be checked and messages sorted appropriately after combining with
+ *   myMessages
+ *
+ * NOTE: One major gap is the lack of invite-refreshing when receiving. Right now this is handled by VoodooConversations.list()
+ * but should be handled by the VoodooConversation itself. The tricky bit is that we end up needing to pull all invites
+ * across all possible conversations, rearranging and filtering, etc.
  */
 export default class VoodooConversation {
   otherAddress: string

--- a/src/voodoo/conversations/VoodooConversation.ts
+++ b/src/voodoo/conversations/VoodooConversation.ts
@@ -143,6 +143,9 @@ export default class VoodooConversation {
   // to the idea that each message only gets sent once per receiving device. This
   // invariant is enforced on send. If we have two sessions for the same contact,
   // we just send to the first one
+  // TODO: this only returns a complete list of messages if VoodooConversations.list()
+  // has been called first. That method adds any sessionIds we missed from invites that
+  // have been added. Ideally, this should happen each time we call messages() or something.
   async messages(): Promise<VoodooMessage[]> {
     // Go through and call messagesPerSession for each session
     let allMessages: VoodooMessage[] = []
@@ -202,8 +205,6 @@ export default class VoodooConversation {
       this.multiSession.otherMultiBundle
     )
 
-    console.log(this)
-
     // Go through and call sendToSession for each session
     let sentMessage: VoodooMessage | undefined
     const alreadyMessagedContacts: VoodooContact[] = []
@@ -215,7 +216,6 @@ export default class VoodooConversation {
       alreadyMessagedContacts.push(contact)
       const sessionId = this.multiSession.sessionIds[i]
       const topic = this.multiSession.topics[i]
-      console.log('Sending to session', sessionId, topic)
       sentMessage = await this.sendToSession(topic, sessionId, content)
     }
     if (!sentMessage) {
@@ -337,8 +337,6 @@ export default class VoodooConversation {
 
     // Need to publish all of the encryptedInvites
     await this.client.publishEnvelopes(encryptedInviteEnvelopes)
-
-    console.log('SENT INVITES TO', newContacts)
 
     // Add the sessions, topics, and establishedContacts to the existing VoodooConversation.multiSession
     this.multiSession.establishedContacts.push(...newContacts)

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -97,9 +97,9 @@ export default class VoodooConversations {
           }
         } catch (e) {
           // Too noisy to log since we expect failures
-          console.log(
-            `Could not process invite from ${envelopeSenderAddress}: ${e}`
-          )
+          // console.log(
+          //   `Could not process invite from ${envelopeSenderAddress}: ${e}`
+          // )
         }
       }
 

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -49,7 +49,7 @@ export default class VoodooConversations {
         const envelopeSenderAddress = encryptedInvite.senderAddress
         peers.add(envelopeSenderAddress)
       }
-      // Peers add self too
+      // Add self to peers too
       peers.add(this.client.address)
 
       console.log(`Found ${peers.size} peers`)
@@ -396,8 +396,13 @@ export default class VoodooConversations {
         continue
       }
       // Check if we already have a session with this contact
+      // Merge newContacts and establishedContacts
+      const allContacts = [
+        ...convo.multiSession.establishedContacts,
+        ...newContacts,
+      ]
       if (
-        convo.multiSession.establishedContacts.find(
+        allContacts.find(
           (c: VoodooContact) => c.voodooInstance === contact.voodooInstance
         )
       ) {

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -4,17 +4,14 @@ import VoodooClient from '../VoodooClient'
 import {
   VoodooContact,
   EncryptedVoodooMessage,
-  VoodooMessage,
   VoodooMultiBundle,
   OneToOneSession,
   VoodooInvite,
 } from '../types'
 import VoodooConversation from './VoodooConversation'
-import { utils } from '../../crypto'
 
 import {
   buildVoodooUserInviteTopic,
-  buildVoodooDirectMessageTopic,
 } from '../utils'
 
 export default class VoodooConversations {
@@ -208,6 +205,9 @@ export default class VoodooConversations {
    * And aggregating all the topics/sessionIds into a single VoodooConversation.
    */
   async newConversation(otherAddress: string): Promise<VoodooConversation> {
+    // Call a list first to refresh conversations that might be incoming
+    await this.list()
+
     const otherMultiBundle = await this.client.getUserContactMultiBundle(
       otherAddress
     )

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -148,8 +148,9 @@ export default class VoodooConversations {
             peerAddress
           )
           if (!myMultiBundle || !otherMultiBundle) {
+            console.log(this.conversations)
             console.log(
-              `Could not get multibundle for ${peerAddress} or myself`
+              `Could not get multibundle for ${peerAddress} or ${this.client.address}`
             )
             continue
           }
@@ -190,7 +191,7 @@ export default class VoodooConversations {
         const otherMultiBundle = peerToMultiBundle.get(convo.peerAddress)
         if (!myMultiBundle || !otherMultiBundle) {
           console.log(
-            `Could not get multibundle for ${convo.peerAddress} or myself`
+            `Could not get multibundle for ${convo.peerAddress} or ${this.client.address}`
           )
           continue
         }

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -7,6 +7,7 @@ import {
   VoodooMessage,
   VoodooMultiBundle,
   OneToOneSession,
+  VoodooInvite,
 } from '../types'
 import VoodooConversation from './VoodooConversation'
 import { utils } from '../../crypto'
@@ -35,42 +36,154 @@ export default class VoodooConversations {
         inviteTopic,
         async (e) => e
       )
-      const sessionsFromInvites = await this.client.listEnvelopes(
-        inviteTopic,
-        this.processInvite.bind(this)
-      )
 
-      // Aggregate these one-to-one sessions into a map of lists keyed by peerAddress
-      const sessionsByPeer = new Map<string, OneToOneSession[]>()
-      for (const session of sessionsFromInvites) {
-        if (session) {
-          const peerAddress = session.senderAddress
-          if (sessionsByPeer.has(peerAddress)) {
-            sessionsByPeer.get(peerAddress)?.push(session)
-          } else {
-            sessionsByPeer.set(peerAddress, [session])
+      // Go through all invites and obtain a list of peers we have conversations with
+      // some of these invites will be for ourselves which is expected. We'll
+      // extract the participants from the invite after decryption
+      const peers = new Set<string>()
+      for (const env of rawInvites) {
+        const encryptedInvite: EncryptedVoodooMessage =
+          await this.client.decodeEnvelope(env)
+        const peerAddress = encryptedInvite.senderAddress
+        peers.add(peerAddress)
+      }
+
+      // Create a map of peer to multibundle via this.client.getUserContactMultiBundle
+      const peerToMultiBundle = new Map<string, VoodooMultiBundle>()
+      for (const peer of peers) {
+        const multibundle = await this.client.getUserContactMultiBundle(peer)
+        if (!multibundle) {
+          console.log(`Could not get multibundle for ${peer}`)
+          continue
+        }
+        peerToMultiBundle.set(peer, multibundle)
+      }
+
+      // Now we can go through each invite and attempt to process with a list of Contacts
+      // obtained by looking up the multibundle per peer
+      const sessionsFromInvites: OneToOneSession[] = []
+      const sessionContacts: VoodooContact[] = []
+      for (const env of rawInvites) {
+        const encryptedInvite: EncryptedVoodooMessage =
+          await this.client.decodeEnvelope(env)
+        const peerAddress = encryptedInvite.senderAddress
+        const multibundle = peerToMultiBundle.get(peerAddress)
+        if (!multibundle) {
+          console.log(`Could not get multibundle for ${peerAddress}`)
+          continue
+        }
+        const contacts: VoodooContact[] = multibundle.contacts
+        try {
+          const [deducedContact, decryptedInvite] =
+            await this.client.processVoodooInviteGuessContact(
+              contacts,
+              encryptedInvite
+            )
+          // Parse the text as a JSON-serialized VoodooInvite
+          const invite: VoodooInvite = JSON.parse(decryptedInvite.plaintext)
+
+          if (decryptedInvite) {
+            const session = {
+              participantAddresses: invite.participantAddresses,
+              sessionId: decryptedInvite.sessionId,
+              // the plaintext of the invite message is the new convo topic
+              topic: invite.topic,
+              timestamp: decryptedInvite.timestamp,
+            }
+            sessionsFromInvites.push(session)
+            sessionContacts.push(deducedContact)
           }
+        } catch (e) {
+          // Too noisy to log since we expect failures
+          // console.log(`Could not process invite from ${peerAddress}: ${e}`)
         }
       }
+
+      // Aggregate these one-to-one sessions into a map of lists keyed by peerAddress
+      // keeping the order the same between the two lists
+      const sessionsByPeer = new Map<string, OneToOneSession[]>()
+      const contactsByPeer = new Map<string, VoodooContact[]>()
+      for (let i = 0; i < sessionsFromInvites.length; i++) {
+        const session = sessionsFromInvites[i]
+        const contact = sessionContacts[i]
+        if (!session || !contact) {
+          continue
+        }
+        const peerAddress = contact.address
+        if (!sessionsByPeer.has(peerAddress)) {
+          sessionsByPeer.set(peerAddress, [])
+          contactsByPeer.set(peerAddress, [])
+        }
+        sessionsByPeer.get(peerAddress)?.push(session)
+        contactsByPeer.get(peerAddress)?.push(contact)
+      }
+
+      // For each of these peer addresses, check if we have a conversation for it.
+      // If not, then create a new empty VoodooConversation
+      // 1) Add any new invite sessions to the conversation
+      // 2) Send out new invites as necessary by invoking updateConversationAndSendInvitesIfNeeded
 
       // For each of these peer addresses, skip if we already have a conversation for it
       // otherwise we need to resolve the multibundle and construct a new conversation
       for (const [peerAddress, sessions] of sessionsByPeer) {
-        if (!this.conversations.has(peerAddress)) {
-          const multibundle = await this.client.getUserContactMultiBundle(
+        let convo = this.conversations.get(peerAddress)
+        if (!convo) {
+          // Get my multibundle, get other multibundle
+          const myMultiBundle = await this.client.getUserContactMultiBundle(
+            this.client.address
+          )
+          const otherMultiBundle = await this.client.getUserContactMultiBundle(
             peerAddress
           )
-          if (multibundle) {
-            const convo = new VoodooConversation(
-              this.client,
-              peerAddress,
-              new Date().getTime(),
-              multibundle,
-              sessions.map((s) => s.sessionId),
-              sessions.map((s) => s.topic)
+          if (!myMultiBundle || !otherMultiBundle) {
+            console.log(
+              `Could not get multibundle for ${peerAddress} or myself`
             )
-            this.conversations.set(peerAddress, convo)
+            continue
           }
+          // Construct a new conversation
+          convo = VoodooConversation.newEmptyConversation(
+            this.client,
+            myMultiBundle,
+            otherMultiBundle,
+            peerAddress
+          )
+        }
+        const contacts = contactsByPeer.get(peerAddress)
+        if (!contacts || !sessions) {
+          console.log(`Could not get contacts or sessions for ${peerAddress}`)
+          continue
+        }
+        // Add any new invite sessions to the conversation
+        for (let i = 0; i < sessions.length; i++) {
+          const session = sessions[i]
+          const contact = contacts[i]
+          if (!convo.multiSession.sessionIds.includes(session.sessionId)) {
+            convo.multiSession.sessionIds.push(session.sessionId)
+            convo.multiSession.topics.push(session.topic)
+            convo.multiSession.establishedContacts.push(contact)
+          }
+        }
+      }
+
+      // Finally, update all conversations and send out invites as necessary
+      for (const convo of this.conversations.values()) {
+        const myMultiBundle = peerToMultiBundle.get(this.client.address)
+        const otherMultiBundle = peerToMultiBundle.get(convo.peerAddress)
+        if (!myMultiBundle || !otherMultiBundle) {
+          console.log(
+            `Could not get multibundle for ${convo.peerAddress} or myself`
+          )
+          continue
+        }
+        const updatedConvo =
+          await this.updateConversationAndSendInvitesIfNeeded(
+            convo,
+            myMultiBundle,
+            otherMultiBundle
+          )
+        if (updatedConvo) {
+          this.conversations.set(convo.peerAddress, updatedConvo)
         }
       }
       return Array.from(this.conversations.values())
@@ -79,43 +192,11 @@ export default class VoodooConversations {
     }
   }
 
-  // Must be locked by convoMutex
-  // TODO: this method currently looks up the other party's multibundle for NxN fanout
-  // we may want to carry this information in the invite itself otherwise there could be
-  // a mismatch on the initial set of devices and the set we resolve in this method
-  async processInvite(
-    env: messageApi.Envelope
-  ): Promise<OneToOneSession | undefined> {
-    const encryptedInvite: EncryptedVoodooMessage =
-      await this.client.decodeEnvelope(env)
-    const peerAddress = encryptedInvite.senderAddress
-    // Check if we have a session for this peer
-    if (this.conversations.has(peerAddress)) {
-      // Return undefined so nothing is added to the map
-      console.log(`Already have a conversation with ${peerAddress}`)
-      return
-    }
-
-    try {
-      const decryptedInvite: VoodooMessage =
-        await this.client.processVoodooInvite(peerAddress, encryptedInvite)
-      if (decryptedInvite) {
-        return {
-          senderAddress: decryptedInvite.senderAddress,
-          recipientAddress: this.client.address,
-          sessionId: decryptedInvite.sessionId,
-          // the plaintext of the invite message is the new convo topic
-          topic: decryptedInvite.plaintext,
-          timestamp: decryptedInvite.timestamp,
-        }
-      }
-    } catch (e) {
-      // TODO: can log this, but this is expected since only the invite for our device will decrypt correctly
-    }
-  }
-
   /**
-   * Creates a new single OneToOneSession for the given contact. Does nto publish the invite envelope.
+   * Creates a new single OneToOneSession for the given contact. Does not publish the invite envelope.
+   *
+   * NOTE: we have to very explicit about what this session is. It's a session between two VoodooInstances,
+   * but the two addresses participating could be the same.
    *
    * Currently, we generate a random topic for the session, and send an Olm PreKey Message
    * where the encrypted ciphertext is just the random topic. This is the "invite" message.
@@ -123,18 +204,14 @@ export default class VoodooConversations {
    * creates their own VoodooConversation from the derived session and the included topic.
    */
   private async newSingleSession(
+    // the otherAddress is the wallet address of the other party in the conversation, not necessarily
+    // the other party of this session e.g. Me1 sending my messages in convo to Me2
+    otherAddress: string,
     contact: VoodooContact
   ): Promise<OneToOneSession> {
-    const peerAddress = contact.address
-    if (!contact) {
-      throw new Error(
-        `Voodoo recipient ${peerAddress} is not on the XMTP network`
-      )
-    }
-
     // Better be a VoodooContact type
     if (!contact.voodooInstance) {
-      throw new Error(`Voodoo recipient ${peerAddress} is not a Voodoo contact`)
+      throw new Error(`Voodoo recipient is not a Voodoo contact`)
     }
 
     const timestamp = new Date().getTime()
@@ -154,6 +231,7 @@ export default class VoodooConversations {
     const encryptedInvite: EncryptedVoodooMessage =
       await this.client.newVoodooInviteForContact(
         contact,
+        otherAddress,
         generatedSessionTopic
       )
 
@@ -161,8 +239,7 @@ export default class VoodooConversations {
       throw new Error('Could not create outbound session')
     }
     return {
-      senderAddress: this.client.address,
-      recipientAddress: peerAddress,
+      participantAddresses: [this.client.address, otherAddress],
       sessionId: encryptedInvite.sessionId,
       topic: generatedSessionTopic,
       encryptedInvite,
@@ -175,17 +252,30 @@ export default class VoodooConversations {
    * And aggregating all the topics/sessionIds into a single VoodooConversation.
    */
   async newConversation(peerAddress: string): Promise<VoodooConversation> {
-    const multibundle = await this.client.getUserContactMultiBundle(peerAddress)
-    if (!multibundle) {
+    const otherMultiBundle = await this.client.getUserContactMultiBundle(
+      peerAddress
+    )
+    if (
+      !otherMultiBundle ||
+      !otherMultiBundle.contacts ||
+      otherMultiBundle.contacts.length === 0
+    ) {
       throw new Error(
         `Voodoo recipient ${peerAddress} is not on the XMTP network`
       )
     }
 
-    const contacts = multibundle.contacts
-    if (!contacts || contacts.length === 0) {
-      throw new Error(`Voodoo recipient ${peerAddress} is not a Voodoo contact`)
+    const myMultiBundle = await this.client.getUserContactMultiBundle(
+      this.client.address
+    )
+    if (
+      !myMultiBundle ||
+      !myMultiBundle.contacts ||
+      myMultiBundle.contacts.length === 0
+    ) {
+      throw new Error(`Voodoo sender not on the XMTP network`)
     }
+
     // TODO: add more context eventually
     const matcherFn = (convo: VoodooConversation) =>
       convo.peerAddress === peerAddress
@@ -196,44 +286,79 @@ export default class VoodooConversations {
     return this.convoMutex.runExclusive(async () => {
       const existing = Array.from(this.conversations.values())
       const existingMatch = existing.find(matcherFn)
+      let convo: VoodooConversation
       if (existingMatch) {
-        return existingMatch
+        convo = existingMatch
+      } else {
+        // Create an initial conversation that is empty
+        convo = new VoodooConversation(
+          this.client,
+          peerAddress,
+          new Date().getTime(),
+          myMultiBundle,
+          otherMultiBundle,
+          [],
+          []
+        )
       }
-
-      const sessions: OneToOneSession[] = []
-      for (const contact of contacts) {
-        if (!contact.voodooInstance) {
-          throw new Error(
-            `Voodoo recipient ${peerAddress} is not a Voodoo contact`
-          )
-        }
-        const session = await this.newSingleSession(contact)
-        sessions.push(session)
-      }
-
-      const sessionIds = sessions.map((s) => s.sessionId)
-      const topics = sessions.map((s) => s.topic)
-      const encryptedInviteEnvelopes = sessions
-        .map((s) => ({
-          contentTopic: buildVoodooUserInviteTopic(peerAddress),
-          message: Buffer.from(JSON.stringify(s.encryptedInvite)),
-          timestamp: new Date(s.timestamp),
-        }))
-        .filter((e) => e !== undefined)
-
-      // Need to publish all of the encryptedInvites
-      await this.client.publishEnvelopes(encryptedInviteEnvelopes)
-      // Create a new VoodooConversation
-      const convo = new VoodooConversation(
-        this.client,
-        peerAddress,
-        new Date().getTime(),
-        multibundle,
-        sessionIds,
-        topics
+      const updatedConvo = await this.updateConversationAndSendInvitesIfNeeded(
+        convo,
+        myMultiBundle,
+        otherMultiBundle
       )
-      this.conversations.set(peerAddress, convo)
+      this.conversations.set(peerAddress, updatedConvo)
       return convo
     })
+  }
+
+  // Given a VoodooConversation, check to make sure that all of the instances in my multibundle
+  // and the other's multibundle are stored in the VoodooConversation
+  async updateConversationAndSendInvitesIfNeeded(
+    convo: VoodooConversation,
+    myMultiBundle: VoodooMultiBundle,
+    otherMultiBundle: VoodooMultiBundle
+  ): Promise<VoodooConversation> {
+    // Look at sessions with myself
+    const sessions: OneToOneSession[] = []
+    const newContacts: VoodooContact[] = []
+    // Combine all the contacts from my multibundle and the other's multibundle
+    const allContacts = [
+      ...myMultiBundle.contacts,
+      ...otherMultiBundle.contacts,
+    ]
+    // We know which contact corresponds to self and other because we have both multibundles stored
+    // in the coversation
+    for (const contact of allContacts) {
+      // Check if we already have a session with this contact
+      if (
+        convo.multiSession.establishedContacts.find(
+          (c: VoodooContact) => c.voodooInstance === contact.voodooInstance
+        )
+      ) {
+        continue
+      }
+      const session = await this.newSingleSession(convo.peerAddress, contact)
+      sessions.push(session)
+      newContacts.push(contact)
+    }
+
+    const sessionIds = sessions.map((s) => s.sessionId)
+    const topics = sessions.map((s) => s.topic)
+    const encryptedInviteEnvelopes = sessions
+      .map((s) => ({
+        contentTopic: buildVoodooUserInviteTopic(convo.peerAddress),
+        message: Buffer.from(JSON.stringify(s.encryptedInvite)),
+        timestamp: new Date(s.timestamp),
+      }))
+      .filter((e) => e !== undefined)
+
+    // Need to publish all of the encryptedInvites
+    await this.client.publishEnvelopes(encryptedInviteEnvelopes)
+
+    // Add the sessions, topics, and establishedContacts to the existing VoodooConversation.multiSession
+    convo.multiSession.establishedContacts.push(...newContacts)
+    convo.multiSession.sessionIds.push(...sessionIds)
+    convo.multiSession.topics.push(...topics)
+    return convo
   }
 }

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -158,6 +158,10 @@ export default class VoodooConversations {
         for (let i = 0; i < sessions.length; i++) {
           const session = sessions[i]
           const contact = contacts[i]
+          // Cannot open a session with ourselves
+          if (this.client.contactInstanceIsMe(contact)) {
+            continue
+          }
           if (!convo.multiSession.sessionIds.includes(session.sessionId)) {
             convo.multiSession.sessionIds.push(session.sessionId)
             convo.multiSession.topics.push(session.topic)
@@ -329,6 +333,10 @@ export default class VoodooConversations {
     // We know which contact corresponds to self and other because we have both multibundles stored
     // in the coversation
     for (const contact of allContacts) {
+      // Skip if this is the same contact as myself
+      if (this.client.contactInstanceIsMe(contact)) {
+        continue
+      }
       // Check if we already have a session with this contact
       if (
         convo.multiSession.establishedContacts.find(

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -37,8 +37,6 @@ export default class VoodooConversations {
         async (e) => e
       )
 
-      console.log(`Found ${rawInvites.length} invites`)
-
       // Go through all invites and obtain a list of peers we have conversations with
       // some of these invites will be for ourselves which is expected. We'll
       // extract the participants from the invite after decryption
@@ -52,8 +50,6 @@ export default class VoodooConversations {
       // Add self to peers too
       peers.add(this.client.address)
 
-      console.log(`Found ${peers.size} peers`)
-
       // Create a map of peer to multibundle via this.client.getUserContactMultiBundle
       const peerToMultiBundle = new Map<string, VoodooMultiBundle>()
       for (const peer of peers) {
@@ -64,8 +60,6 @@ export default class VoodooConversations {
         }
         peerToMultiBundle.set(peer, multibundle)
       }
-
-      console.log(`Found ${peerToMultiBundle.size} multibundles`)
 
       // Now we can go through each invite and attempt to process with a list of Contacts
       // obtained by looking up the multibundle per peer
@@ -102,9 +96,6 @@ export default class VoodooConversations {
             }
             sessionsFromInvites.push(session)
             sessionContacts.push(deducedContact)
-            console.log(
-              `Processed invite from ${envelopeSenderAddress} with session ${session.sessionId} and deduced contact ${deducedContact.address}`
-            )
           }
         } catch (e) {
           // Too noisy to log since we expect failures
@@ -156,8 +147,6 @@ export default class VoodooConversations {
         sessionsByOtherAddress.get(otherAddress)?.push(session)
         contactsByOtherAddress.get(otherAddress)?.push(contact)
       }
-      console.log(`Found ${sessionsByOtherAddress.size} peers with sessions`)
-      console.log(`Found ${contactsByOtherAddress.size} peers with contacts`)
 
       // For each of these peer addresses, check if we have a conversation for it.
       // If not, then create a new empty VoodooConversation
@@ -177,10 +166,6 @@ export default class VoodooConversations {
             otherAddress
           )
           if (!myMultiBundle || !otherMultiBundle) {
-            console.log(this.conversations)
-            console.log(
-              `Could not get multibundle in session aggregation for ${otherAddress} or ${this.client.address}`
-            )
             continue
           }
           // Construct a new conversation
@@ -191,7 +176,6 @@ export default class VoodooConversations {
             otherAddress
           )
         }
-        console.log(`conversation for ${otherAddress} is ${convo}`)
         const contacts = contactsByOtherAddress.get(otherAddress)
         if (!contacts || !sessions) {
           console.log(`Could not get contacts or sessions for ${otherAddress}`)

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -37,6 +37,8 @@ export default class VoodooConversations {
         async (e) => e
       )
 
+      console.log(`Found ${rawInvites.length} invites`)
+
       // Go through all invites and obtain a list of peers we have conversations with
       // some of these invites will be for ourselves which is expected. We'll
       // extract the participants from the invite after decryption
@@ -48,6 +50,8 @@ export default class VoodooConversations {
         peers.add(peerAddress)
       }
 
+      console.log(`Found ${peers.size} peers`)
+
       // Create a map of peer to multibundle via this.client.getUserContactMultiBundle
       const peerToMultiBundle = new Map<string, VoodooMultiBundle>()
       for (const peer of peers) {
@@ -58,6 +62,8 @@ export default class VoodooConversations {
         }
         peerToMultiBundle.set(peer, multibundle)
       }
+
+      console.log(`Found ${peerToMultiBundle.size} multibundles`)
 
       // Now we can go through each invite and attempt to process with a list of Contacts
       // obtained by looking up the multibundle per peer
@@ -92,10 +98,11 @@ export default class VoodooConversations {
             }
             sessionsFromInvites.push(session)
             sessionContacts.push(deducedContact)
+            console.log(`Processed invite from ${peerAddress} with session ${session.sessionId} and deduced contact ${deducedContact.address}`)
           }
         } catch (e) {
           // Too noisy to log since we expect failures
-          // console.log(`Could not process invite from ${peerAddress}: ${e}`)
+          console.log(`Could not process invite from ${peerAddress}: ${e}`)
         }
       }
 
@@ -117,6 +124,8 @@ export default class VoodooConversations {
         sessionsByPeer.get(peerAddress)?.push(session)
         contactsByPeer.get(peerAddress)?.push(contact)
       }
+      console.log(`Found ${sessionsByPeer.size} peers with sessions`)
+      console.log(`Found ${contactsByPeer.size} peers with contacts`)
 
       // For each of these peer addresses, check if we have a conversation for it.
       // If not, then create a new empty VoodooConversation
@@ -149,6 +158,7 @@ export default class VoodooConversations {
             peerAddress
           )
         }
+        console.log(`conversation for ${peerAddress} is ${convo}`)
         const contacts = contactsByPeer.get(peerAddress)
         if (!contacts || !sessions) {
           console.log(`Could not get contacts or sessions for ${peerAddress}`)
@@ -168,6 +178,7 @@ export default class VoodooConversations {
             convo.multiSession.establishedContacts.push(contact)
           }
         }
+        this.conversations.set(peerAddress, convo)
       }
 
       // Finally, update all conversations and send out invites as necessary

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -10,9 +10,7 @@ import {
 } from '../types'
 import VoodooConversation from './VoodooConversation'
 
-import {
-  buildVoodooUserInviteTopic,
-} from '../utils'
+import { buildVoodooUserInviteTopic } from '../utils'
 
 export default class VoodooConversations {
   private client: VoodooClient
@@ -34,6 +32,9 @@ export default class VoodooConversations {
         async (e) => e
       )
 
+      // TODO: instead of one shared invite topic, should we do per-address-pairing invite topics?
+      // Seems easier but sacrifices privacy.
+      //
       // Go through all invites and obtain a list of peers we have conversations with
       // some of these invites will be for ourselves which is expected. We'll
       // extract the participants from the invite after decryption

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -49,6 +49,8 @@ export default class VoodooConversations {
         const envelopeSenderAddress = encryptedInvite.senderAddress
         peers.add(envelopeSenderAddress)
       }
+      // Peers add self too
+      peers.add(this.client.address)
 
       console.log(`Found ${peers.size} peers`)
 
@@ -177,7 +179,7 @@ export default class VoodooConversations {
           if (!myMultiBundle || !otherMultiBundle) {
             console.log(this.conversations)
             console.log(
-              `Could not get multibundle for ${otherAddress} or ${this.client.address}`
+              `Could not get multibundle in session aggregation for ${otherAddress} or ${this.client.address}`
             )
             continue
           }
@@ -203,7 +205,19 @@ export default class VoodooConversations {
           if (this.client.contactInstanceIsMe(contact)) {
             continue
           }
-          if (!convo.multiSession.sessionIds.includes(session.sessionId)) {
+          // Check that we don't already have this contact
+          let hasContact = false
+          for (const existingContact of convo.multiSession
+            .establishedContacts) {
+            if (existingContact.voodooInstance === contact.voodooInstance) {
+              hasContact = true
+              break
+            }
+          }
+          if (
+            !hasContact &&
+            !convo.multiSession.sessionIds.includes(session.sessionId)
+          ) {
             convo.multiSession.sessionIds.push(session.sessionId)
             convo.multiSession.topics.push(session.topic)
             convo.multiSession.establishedContacts.push(contact)
@@ -218,7 +232,7 @@ export default class VoodooConversations {
         const otherMultiBundle = peerToMultiBundle.get(convo.otherAddress)
         if (!myMultiBundle || !otherMultiBundle) {
           console.log(
-            `Could not get multibundle for ${convo.otherAddress} or ${this.client.address}`
+            `Could not get multibundle in session update for ${convo.otherAddress} or ${this.client.address}`
           )
           continue
         }

--- a/src/voodoo/conversations/VoodooConversations.ts
+++ b/src/voodoo/conversations/VoodooConversations.ts
@@ -205,19 +205,7 @@ export default class VoodooConversations {
           if (this.client.contactInstanceIsMe(contact)) {
             continue
           }
-          // Check that we don't already have this contact
-          let hasContact = false
-          for (const existingContact of convo.multiSession
-            .establishedContacts) {
-            if (existingContact.equals(contact)) {
-              hasContact = true
-              break
-            }
-          }
-          if (
-            !hasContact &&
-            !convo.multiSession.sessionIds.includes(session.sessionId)
-          ) {
+          if (!convo.multiSession.sessionIds.includes(session.sessionId)) {
             convo.multiSession.sessionIds.push(session.sessionId)
             convo.multiSession.topics.push(session.topic)
             convo.multiSession.establishedContacts.push(contact)

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -57,8 +57,6 @@ export type VoodooMultiBundle = {
   address: string
   // The bundles for each device
   contacts: VoodooContact[]
-  // Last refreshed timestamp
-  timestamp: number
 }
 
 // Helpful wrapper for wrapping a single one-to-one session, which

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -11,6 +11,11 @@ export class VoodooContact {
     this.address = address
     this.voodooInstance = voodooInstance
   }
+
+  // Is equal, check voodooInstance.handle
+  equals(other: VoodooContact): boolean {
+    return this.voodooInstance.handle === other.voodooInstance.handle
+  }
 }
 
 // Very simple message object which acts as the message type for all Voodoo envelopes

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -24,6 +24,15 @@ export type EncryptedVoodooMessage = {
   ciphertext: string
 }
 
+// The object to be JSON-serialized to form the body(plaintext) of the invite
+export type VoodooInvite = {
+  topic: string
+  // Addresses of the two wallets in the conversation
+  // not necessarily the two voodoo instances in a single 1:1 session
+  // e.g. Me1 sending my messages in convo to Me2
+  participantAddresses: string[]
+}
+
 export type VoodooMessage = {
   // All plaintext fields
   senderAddress: string
@@ -50,8 +59,8 @@ export type VoodooMultiBundle = {
 // Helpful wrapper for wrapping a single one-to-one session, which
 // later can be composed into a VoodooMultiSession
 export type OneToOneSession = {
-  senderAddress: string
-  recipientAddress: string
+  // The two addresses participating in the higher level conversation
+  participantAddresses: string[]
   sessionId: string
   topic: string
   timestamp: number
@@ -62,9 +71,11 @@ export type OneToOneSession = {
 // Contains all the information needed to send a message to a user
 export type VoodooMultiSession = {
   // The address of the user
-  address: string
+  otherAddress: string
+  myMultiBundle: VoodooMultiBundle
+  otherMultiBundle: VoodooMultiBundle
   // Keep the multi bundle around for convenience
-  multiBundle: VoodooMultiBundle
+  establishedContacts: VoodooContact[]
   // Session ids in the same order as the contacts
   sessionIds: string[]
   // Messages per session, so map sessionId to list of messages

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -61,6 +61,7 @@ export type VoodooMultiBundle = {
 export type OneToOneSession = {
   // The two addresses participating in the higher level conversation
   participantAddresses: string[]
+  envelopeReceiverAddress: string
   sessionId: string
   topic: string
   timestamp: number

--- a/src/voodoo/types.ts
+++ b/src/voodoo/types.ts
@@ -34,7 +34,9 @@ export type VoodooInvite = {
   topic: string
   // Addresses of the two wallets in the conversation
   // not necessarily the two voodoo instances in a single 1:1 session
-  // e.g. Me1 sending my messages in convo to Me2
+  // e.g. Me1 forwarding my messages in convo with You1 but to Me2
+  // participants would be [addr(me), addr(you)] but the 1:1 session
+  // is between Me1 and Me2
   participantAddresses: string[]
 }
 

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -1,7 +1,11 @@
 import assert from 'assert'
 import { newWallet } from '../helpers'
 import Client from '../../src/Client'
-import { VoodooMessage, EncryptedVoodooMessage } from '../../src/voodoo/types'
+import {
+  VoodooMessage,
+  EncryptedVoodooMessage,
+  VoodooInvite,
+} from '../../src/voodoo/types'
 
 describe('VoodooClient', () => {
   it('can create a client', async () => {
@@ -49,8 +53,13 @@ describe('VoodooClient', () => {
       encryptedInvite
     )
 
+    // Need to parse decryptedInvite.plaintext into a VoodooInvite via JSON deserialization
+    const invite: VoodooInvite = JSON.parse(decryptedInvite.plaintext)
+
     expect(decryptedInvite.sessionId).toEqual(encryptedInvite.sessionId)
-    expect(decryptedInvite.plaintext).toEqual(aliceTopic)
+    expect(invite.topic).toEqual(aliceTopic)
     expect(decryptedInvite.senderAddress).toEqual(alice.address)
+    expect(invite.participantAddresses).toContain(alice.address)
+    expect(invite.participantAddresses).toContain(bob.address)
   })
 })

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -6,6 +6,7 @@ import {
   EncryptedVoodooMessage,
   VoodooInvite,
 } from '../../src/voodoo/types'
+import { sleep } from '../../src/utils'
 
 describe('VoodooClient', () => {
   it('can create a client', async () => {
@@ -71,6 +72,10 @@ describe('VoodooClient', () => {
       alice.address
     )
     expect(aliceContactBundle).toBeTruthy()
+    await sleep(100)
+    aliceClient.publishUserContact()
+    aliceClient.publishUserContact()
+    aliceClient.publishUserContact()
     aliceClient.publishUserContact()
     const multibundle = await aliceClient.getUserContactMultiBundle(
       alice.address

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -62,4 +62,20 @@ describe('VoodooClient', () => {
     expect(invite.participantAddresses).toContain(alice.address)
     expect(invite.participantAddresses).toContain(bob.address)
   })
+
+  it('does not republish contact bundle if it already exists', async () => {
+    const alice = newWallet()
+    const aliceClient = await Client.createVoodoo(alice, { env: 'local' })
+    // Should get the contact bundle
+    const aliceContactBundle = await aliceClient.getUserContactFromNetwork(
+      alice.address
+    )
+    expect(aliceContactBundle).toBeTruthy()
+    aliceClient.publishUserContact()
+    const multibundle = await aliceClient.getUserContactMultiBundle(
+      alice.address
+    )
+    expect(multibundle).toBeTruthy()
+    expect(multibundle?.contacts.length).toEqual(1)
+  })
 })

--- a/test/voodoo/VoodooClient.test.ts
+++ b/test/voodoo/VoodooClient.test.ts
@@ -73,10 +73,11 @@ describe('VoodooClient', () => {
     )
     expect(aliceContactBundle).toBeTruthy()
     await sleep(100)
-    aliceClient.publishUserContact()
-    aliceClient.publishUserContact()
-    aliceClient.publishUserContact()
-    aliceClient.publishUserContact()
+    aliceClient.ensureUserContactPublished()
+    aliceClient.ensureUserContactPublished()
+    aliceClient.ensureUserContactPublished()
+    aliceClient.ensureUserContactPublished()
+    await sleep(100)
     const multibundle = await aliceClient.getUserContactMultiBundle(
       alice.address
     )

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -87,7 +87,6 @@ describe('conversation', () => {
       }
     })
 
-    /*
     it('1 to N fanout', async () => {
       // Setup alice
       alice = await newLocalHostVoodooClient()
@@ -147,6 +146,5 @@ describe('conversation', () => {
         expect(ams2[i].plaintext).toBe('hi back: ' + (i - 1))
       }
     })
-    */
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -377,7 +377,38 @@ describe('conversation', () => {
         const aliceConvo = aliceConvos[0]
         const bobConvo = bobConvos[0]
         await aliceConvo.send(plaintexts[i])
+        await sleep(50)
         await bobConvo.send(plaintexts[i])
+        await sleep(50)
+      }
+
+      // Check that all alices and bobs have the same messages in the same order
+      for (const a of allAlices) {
+        const acs = await a.conversations.list()
+        expect(acs).toHaveLength(1)
+        const ac = acs[0]
+        const ams = await ac.messages()
+        expect(ams).toHaveLength(20)
+        for (let i = 0; i < 20; i++) {
+          expect(ams[i].plaintext).toBe(plaintexts[Math.floor(i / 2)])
+          expect(ams[i].senderAddress).toBe(
+            i % 2 === 0 ? aliceAddress : bobAddress
+          )
+        }
+      }
+
+      for (const b of allBobs) {
+        const bcs = await b.conversations.list()
+        expect(bcs).toHaveLength(1)
+        const bc = bcs[0]
+        const bms = await bc.messages()
+        expect(bms).toHaveLength(20)
+        for (let i = 0; i < 20; i++) {
+          expect(bms[i].plaintext).toBe(plaintexts[Math.floor(i / 2)])
+          expect(bms[i].senderAddress).toBe(
+            i % 2 === 0 ? aliceAddress : bobAddress
+          )
+        }
       }
     })
   })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -194,6 +194,14 @@ describe('conversation', () => {
       // Create 5 bob clients
       const allBobs = await multipleLocalHostVoodooClients(5)
 
+      // Assert all have published their contact bundles
+      for (const a of allAlices) {
+        await waitForUserContact(a, a)
+      }
+      for (const b of allBobs) {
+        await waitForUserContact(b, b)
+      }
+
       const aliceAddress = allAlices[0].address
       const bobAddress = allBobs[0].address
 

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -177,7 +177,6 @@ describe('conversation', () => {
       expect(ams).toHaveLength(1)
       expect(ams[0].plaintext).toBe('hi')
 
-      /*
       // All bobs should also have one conversation and one message
       for (const b of allBobs) {
         const bcs = await b.conversations.list()
@@ -187,7 +186,6 @@ describe('conversation', () => {
         expect(bms).toHaveLength(1)
         expect(bms[0].plaintext).toBe('hi')
       }
-      */
     })
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -340,5 +340,45 @@ describe('conversation', () => {
         expect(bms[1].senderAddress).toBe(aliceAddress)
       }
     })
+
+    it('test NxN conversations with 5 clients more randomly', async () => {
+      // Create 5 alice clients
+      const allAlices = await multipleLocalHostVoodooClients(5)
+      // Create 5 bob clients
+      const allBobs = await multipleLocalHostVoodooClients(5)
+
+      // Assert all have published their contact bundles
+      for (const a of allAlices) {
+        await waitForUserContact(a, a)
+      }
+      for (const b of allBobs) {
+        await waitForUserContact(b, b)
+      }
+
+      const aliceAddress = allAlices[0].address
+      const bobAddress = allBobs[0].address
+
+      // Have alice 1 start a conversation and bob 1 start a conversation with no wait
+      const alice1convo = await allAlices[1].conversations.newConversation(
+        bobAddress
+      )
+      const bob1convo = await allBobs[1].conversations.newConversation(
+        aliceAddress
+      )
+
+      const plaintexts = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+
+      // Pick random alices and bobs and have them send messages
+      for (let i = 0; i < 10; i++) {
+        const alice = allAlices[Math.floor(Math.random() * allAlices.length)]
+        const bob = allBobs[Math.floor(Math.random() * allBobs.length)]
+        const aliceConvos = await alice.conversations.list()
+        const bobConvos = await bob.conversations.list()
+        const aliceConvo = aliceConvos[0]
+        const bobConvo = bobConvos[0]
+        await aliceConvo.send(plaintexts[i])
+        await bobConvo.send(plaintexts[i])
+      }
+    })
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -273,6 +273,13 @@ describe('conversation', () => {
         const ams = await ac.messages()
         console.log(a)
         console.log(ac)
+        // Print all handles from ac.multiSession.establishedContacts
+        console.log(
+          ac.multiSession.establishedContacts.map((c) => c.voodooInstance.handle).join(', ')
+        )
+        console.log(
+          ac.multiSession.establishedContacts.map((c) => c.address).join(', ')
+        )
         expect(ams).toHaveLength(5)
         for (let i = 0; i < 5; i++) {
           expect(ams[i].plaintext).toBe(expected_plaintexts[i])

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -236,20 +236,21 @@ describe('conversation', () => {
       const bob5convos = await allBobs[4].conversations.list()
       const bob5convo = bob5convos[0]
       await bob5convo.send('hi back 1')
-      await sleep(100)
+      await sleep(500)
       await bob5convo.send('hi back 2')
-      await sleep(100)
+      await sleep(500)
 
       const bob2convos = await allBobs[2].conversations.list()
       const bob2convo = bob2convos[0]
       await bob2convo.send('hi back 3')
-      await sleep(100)
+      await sleep(500)
 
       // Now have alice 2 send a message
       const alice2convos = await allAlices[2].conversations.list()
       const alice2convo = alice2convos[0]
+      console.log('ALICE 2 SAYING HI')
       await alice2convo.send('final high from alice')
-      await sleep(100)
+      await sleep(500)
 
       // Assert that everyone has the same message history
       const expected_plaintexts = [
@@ -266,8 +267,10 @@ describe('conversation', () => {
         bobAddress,
         aliceAddress,
       ]
+
       for (const a of allAlices) {
         const acs = await a.conversations.list()
+        await sleep(100)
         expect(acs).toHaveLength(1)
         const ac = acs[0]
         const ams = await ac.messages()
@@ -275,7 +278,9 @@ describe('conversation', () => {
         console.log(ac)
         // Print all handles from ac.multiSession.establishedContacts
         console.log(
-          ac.multiSession.establishedContacts.map((c) => c.voodooInstance.handle).join(', ')
+          ac.multiSession.establishedContacts
+            .map((c) => c.voodooInstance.handle)
+            .join(', ')
         )
         console.log(
           ac.multiSession.establishedContacts.map((c) => c.address).join(', ')
@@ -288,9 +293,21 @@ describe('conversation', () => {
       }
       for (const b of allBobs) {
         const bcs = await b.conversations.list()
+        await sleep(100)
         expect(bcs).toHaveLength(1)
         const bc = bcs[0]
         const bms = await bc.messages()
+        console.log(b)
+        console.log(bc)
+        // Print all handles from ac.multiSession.establishedContacts
+        console.log(
+          bc.multiSession.establishedContacts
+            .map((c) => c.voodooInstance.handle)
+            .join(', ')
+        )
+        console.log(
+          bc.multiSession.establishedContacts.map((c) => c.address).join(', ')
+        )
         expect(bms).toHaveLength(5)
         for (let i = 0; i < 5; i++) {
           expect(bms[i].plaintext).toBe(expected_plaintexts[i])

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -236,20 +236,20 @@ describe('conversation', () => {
       const bob5convos = await allBobs[4].conversations.list()
       const bob5convo = bob5convos[0]
       await bob5convo.send('hi back 1')
-      await sleep(500)
+      await sleep(100)
       await bob5convo.send('hi back 2')
-      await sleep(500)
+      await sleep(100)
 
       const bob2convos = await allBobs[2].conversations.list()
       const bob2convo = bob2convos[0]
       await bob2convo.send('hi back 3')
-      await sleep(500)
+      await sleep(100)
 
       // Now have alice 2 send a message
       const alice2convos = await allAlices[2].conversations.list()
       const alice2convo = alice2convos[0]
       await alice2convo.send('final high from alice')
-      await sleep(500)
+      await sleep(100)
 
       // Assert that everyone has the same message history
       const expected_plaintexts = [

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -49,6 +49,7 @@ describe('conversation', () => {
 
       const bc = bcs[0]
 
+      /*
       // Alice sends a message
       await ac.send('hi')
       // This should show up in alice's inbox
@@ -85,8 +86,10 @@ describe('conversation', () => {
         expect(ams2[i].senderAddress).toBe(expected_senders[i])
         expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
       }
+      */
     })
 
+    /*
     it('1 to N fanout', async () => {
       // Setup alice
       alice = await newLocalHostVoodooClient()
@@ -146,5 +149,6 @@ describe('conversation', () => {
         expect(ams2[i].plaintext).toBe('hi back: ' + (i - 1))
       }
     })
+    */
   })
 })

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -248,7 +248,6 @@ describe('conversation', () => {
       // Now have alice 2 send a message
       const alice2convos = await allAlices[2].conversations.list()
       const alice2convo = alice2convos[0]
-      console.log('ALICE 2 SAYING HI')
       await alice2convo.send('final high from alice')
       await sleep(500)
 
@@ -270,21 +269,9 @@ describe('conversation', () => {
 
       for (const a of allAlices) {
         const acs = await a.conversations.list()
-        await sleep(100)
         expect(acs).toHaveLength(1)
         const ac = acs[0]
         const ams = await ac.messages()
-        console.log(a)
-        console.log(ac)
-        // Print all handles from ac.multiSession.establishedContacts
-        console.log(
-          ac.multiSession.establishedContacts
-            .map((c) => c.voodooInstance.handle)
-            .join(', ')
-        )
-        console.log(
-          ac.multiSession.establishedContacts.map((c) => c.address).join(', ')
-        )
         expect(ams).toHaveLength(5)
         for (let i = 0; i < 5; i++) {
           expect(ams[i].plaintext).toBe(expected_plaintexts[i])
@@ -293,21 +280,9 @@ describe('conversation', () => {
       }
       for (const b of allBobs) {
         const bcs = await b.conversations.list()
-        await sleep(100)
         expect(bcs).toHaveLength(1)
         const bc = bcs[0]
         const bms = await bc.messages()
-        console.log(b)
-        console.log(bc)
-        // Print all handles from ac.multiSession.establishedContacts
-        console.log(
-          bc.multiSession.establishedContacts
-            .map((c) => c.voodooInstance.handle)
-            .join(', ')
-        )
-        console.log(
-          bc.multiSession.establishedContacts.map((c) => c.address).join(', ')
-        )
         expect(bms).toHaveLength(5)
         for (let i = 0; i < 5; i++) {
           expect(bms[i].plaintext).toBe(expected_plaintexts[i])

--- a/test/voodoo/conversations/VoodooConversation.test.ts
+++ b/test/voodoo/conversations/VoodooConversation.test.ts
@@ -49,7 +49,6 @@ describe('conversation', () => {
 
       const bc = bcs[0]
 
-      /*
       // Alice sends a message
       await ac.send('hi')
       // This should show up in alice's inbox
@@ -86,7 +85,6 @@ describe('conversation', () => {
         expect(ams2[i].senderAddress).toBe(expected_senders[i])
         expect(ams2[i].senderAddress).toBe(bms2[i].senderAddress)
       }
-      */
     })
 
     /*

--- a/test/voodoo/helpers.ts
+++ b/test/voodoo/helpers.ts
@@ -18,7 +18,6 @@ export const multipleLocalHostVoodooClients = async (
   n: number,
   opts?: Partial<ClientOptions>
 ): Promise<VoodooClient[]> => {
-  const wallet = newWallet()
   return Client.createVoodooMulti(n, newWallet(), {
     env: 'local',
     ...opts,


### PR DESCRIPTION
## Overview

The code isn't ready for prime-time (aka PR yet) but by looking at the test case you can see that NxN fanout is happening.

Definitions:
- VoodooConversation is now a container between two participating addresses (no conversationId concept yet). It contains multiple sessions and associated contacts (VoodooContact aka Vodozemac Accounts). There can even be duplicated contacts if two devices send invites to each other simultaneously.
- VoodooContact aka Vodozemac account aka device. This is a Vodozemac identity key pair and contact bundle that is generated by VoodooClient upon creation. There can be multiple of these per wallet address, and between two VoodooContacts there can even be multiple sessions (Vodozemac messaging sessions) for the same conversation (two invites simultaneously from both directions).

There are a lot of gotchas and sharp edges to this process:
1) Invites to all peers are only sent out when `send` is invoked. At that point, a census is taken of current open sessions for that conversation and it is compared with what was in the contact bundles before
2) On `VoodooConversations.list()` the invite topic is re-scanned and any new invites to existing Conversations are populated aka `VoodooConversation.multiSession.sessionIds` etc is updated
3) On `conversation.messages()` all messages from all sessions are aggregated. There should not be duplicates, even if we're polling from multiple sessions between the same two devices. This is because on the send side, we only ever send to one device per VoodooContact.
4) This whole system relies upon fallback keys being used. Otherwise, multiple invites to a single VoodooContact cause decryption failures etc

## Test Plan
- See the very involved NxN unit test