### PR TITLE
fix: add `clientAddress` to `Conversation` type

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -39,6 +39,10 @@ import { ContentTypeText } from '../codecs/Text'
  */
 export interface Conversation {
   /**
+   * The wallet address connected to the client
+   */
+  clientAddress: string
+  /**
    * A unique identifier for a conversation. Each conversation is stored on the network on one topic
    */
   topic: string


### PR DESCRIPTION
The `Conversation` interface does not include the `clientAddress` property, which is present in both `ConversationV1` and `ConversationV2`.