### PR TITLE
Add preEnableIdentityCallback to KeyGenerator

### DIFF
--- a/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
+++ b/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
@@ -31,7 +31,8 @@ export default class KeyGeneratorKeystoreProvider implements KeystoreProvider {
     const bundle = await PrivateKeyBundleV1.generate(wallet)
     const manager = new NetworkKeyManager(
       wallet,
-      new TopicPersistence(apiClient)
+      new TopicPersistence(apiClient),
+      opts.preEnableIdentityCallback
     )
     await manager.storePrivateKeyBundle(bundle)
 

--- a/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
+++ b/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
@@ -57,5 +57,5 @@ describe('KeyGeneratorKeystoreProvider', () => {
     )
     expect(keystore).toBeDefined()
     expect(preEnableIdentityCallback).toHaveBeenCalledTimes(1)
-  }
+  })
 })

--- a/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
+++ b/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
@@ -46,4 +46,16 @@ describe('KeyGeneratorKeystoreProvider', () => {
     expect(keystore).toBeDefined()
     expect(preCreateIdentityCallback).toHaveBeenCalledTimes(1)
   })
+
+  it('calls preEnableIdentityCallback when supplied', async () => {
+    const provider = new KeyGeneratorKeystoreProvider()
+    const preEnableIdentityCallback = jest.fn()
+    const keystore = await provider.newKeystore(
+      { ...testProviderOptions(), preEnableIdentityCallback },
+      apiClient,
+      wallet
+    )
+    expect(keystore).toBeDefined()
+    expect(preEnableIdentityCallback).toHaveBeenCalledTimes(1)
+  }
 })


### PR DESCRIPTION
## Summary

@rygine noticed that the `preCreateIdentityCallback` was being called for a new account, but not the `preEnableIdentityCallback`. This fixes that bug and adds a test.