### PR TITLE
Latest Conversation Ordering

### DIFF
--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -118,11 +118,19 @@ export default class Conversations {
     return this.v2Mutex.runExclusive(async () => {
       // Get all conversations already in the KeyStore
       const existing = await this.getV2ConversationsFromKeystore()
-      const latestConversationTime = existing[existing.length - 1]?.createdAt
+      const latestConversation = existing.reduce(
+        (memo: ConversationV2 | undefined, curr: ConversationV2) => {
+          if (!memo || +curr.createdAt > +memo.createdAt) {
+            return curr
+          }
+          return memo
+        },
+        undefined
+      )
 
       // Load all conversations started after the newest conversation found
       const newConversations = await this.updateV2Conversations(
-        latestConversationTime
+        latestConversation?.createdAt
       )
 
       // Create a Set of all the existing topics to ensure no duplicates are added

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -66,6 +66,9 @@ describe('conversations', () => {
         metadata: {},
       })
       await sleep(100)
+      const fromKeystore = await alice.keystore.getV2Conversations()
+      expect(fromKeystore[1].context?.conversationId).toBe('bar')
+
       const aliceConversations3 = await alice.conversations.list()
       expect(aliceConversations3).toHaveLength(2)
     })

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -467,8 +467,11 @@ describe('InMemoryKeystore', () => {
       )
 
       const convos = await aliceKeystore.getV2Conversations()
+      let lastCreated = Long.fromNumber(0)
       for (let i = 0; i < convos.length; i++) {
         expect(convos[i].createdNs.equals(dateToNs(timestamps[i]))).toBeTruthy()
+        expect(convos[i].createdNs.greaterThanOrEqual(lastCreated)).toBeTruthy()
+        lastCreated = convos[i].createdNs
       }
     })
 


### PR DESCRIPTION
## Summary

Ensure that the latest conversation is used in the call to `updateV2Conversations` irrespective of ordering coming from the Keystore.

## Notes
This is a workaround to deal with some difficult-to-reproduce issue that is coming from the interaction of the Keystore and `Conversations` modules. I'm not sure why, but sometimes the Keystore is returning things in descending order despite there being multiple tests asserting it returns in ascending order. 
