### PR TITLE
fix: ignore malformed v1 bundle in canMessage

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -682,8 +682,13 @@ async function getUserContactFromNetwork(
   for await (const env of stream) {
     if (!env.message) continue
     const keyBundle = decodeContactBundle(b64Decode(env.message.toString()))
+    let address: string | undefined
+    try {
+      address = await keyBundle?.walletSignatureAddress()
+    } catch (e) {
+      address = undefined
+    }
 
-    const address = await keyBundle?.walletSignatureAddress()
     if (address === peerAddress) {
       return keyBundle
     }


### PR DESCRIPTION
Resolves https://github.com/xmtp/xmtp-js/issues/371

This PR fixes an issue where an address had [both a v1 and v2 bundle](https://github.com/xmtp/xmtp-js/issues/371#issuecomment-1522116118), but the v1 bundle was malformed. This caused `canMessage` to throw an exception before it could get to the correctly formatted v2 bundle. By adding a try/catch around fetching the public key's wallet address, we will skip the malformed v1 bundle and return true because the v2 bundle's wallet address matches the peer address.

I also verified the iOS and Android SDKs return true for `canMessage` on this address so the exception is unique to how the JS SDK handles this malformed contact bundle.

### Test cases
- [x] Run `await Client.canMessage("0xC322E8Ec33e9b0a34c7cD185C616087D9842ad50", {env: "production"})` and ensure it returns `true`.