### PR TITLE
fix: handle `walletEcdsaCompact` signatures for v1 keys

### DIFF
--- a/src/crypto/PublicKey.ts
+++ b/src/crypto/PublicKey.ts
@@ -225,7 +225,18 @@ export class PublicKey
       secp256k1Uncompressed: obj.secp256k1Uncompressed,
     })
     if (obj.signature) {
-      this.signature = new Signature(obj.signature)
+      // Handle a case where Flutter was publishing signatures with walletEcdsaCompact
+      // instead of ecdsaCompact for v1 keys.
+      if (!obj.signature.ecdsaCompact && obj.signature.walletEcdsaCompact) {
+        this.signature = new Signature({
+          ecdsaCompact: {
+            bytes: obj.signature.walletEcdsaCompact.bytes,
+            recovery: obj.signature.walletEcdsaCompact.recovery,
+          },
+        })
+      } else {
+        this.signature = new Signature(obj.signature)
+      }
     }
   }
 

--- a/src/crypto/Signature.ts
+++ b/src/crypto/Signature.ts
@@ -83,14 +83,22 @@ export default class Signature implements signature.Signature {
   // LEGACY: Return the public key that validates this signature given the provided digest.
   // Return undefined if the signature is malformed.
   getPublicKey(digest: Uint8Array): PublicKey | undefined {
-    if (!this.ecdsaCompact) {
-      throw new Error('invalid signature')
+    let bytes: Uint8Array | undefined
+    if (this.ecdsaCompact) {
+      bytes = secp.recoverPublicKey(
+        digest,
+        this.ecdsaCompact.bytes,
+        this.ecdsaCompact.recovery
+      )
+    } else if (this.walletEcdsaCompact) {
+      bytes = secp.recoverPublicKey(
+        digest,
+        this.walletEcdsaCompact.bytes,
+        this.walletEcdsaCompact.recovery
+      )
+    } else {
+      throw new Error('invalid v1 signature')
     }
-    const bytes = secp.recoverPublicKey(
-      digest,
-      this.ecdsaCompact.bytes,
-      this.ecdsaCompact.recovery
-    )
     return bytes
       ? new PublicKey({
           secp256k1Uncompressed: { bytes },

--- a/test/crypto/PublicKey.test.ts
+++ b/test/crypto/PublicKey.test.ts
@@ -7,6 +7,7 @@ import {
   SignedPrivateKey,
   WalletSigner,
   utils,
+  Signature,
 } from '../../src/crypto'
 import { Wallet } from 'ethers'
 import { hexToBytes, equalBytes } from '../../src/crypto/utils'
@@ -106,6 +107,33 @@ describe('Crypto', function () {
       const address = alice.publicKey.walletSignatureAddress()
       assert.equal(address, wallet.address)
     })
+
+    it('derives address from public key with malformed v1 signature', async function () {
+      // create a wallet using a generated key
+      const alice = PrivateKey.generate()
+      assert.ok(alice.secp256k1)
+      const wallet = new Wallet(alice.secp256k1.bytes)
+      // sanity check that we agree with the wallet about the address
+      assert.ok(wallet.address, alice.publicKey.getEthereumAddress())
+      // sign the public key using the wallet
+      await alice.publicKey.signWithWallet(wallet)
+      assert.ok(alice.publicKey.signature?.ecdsaCompact)
+
+      // distort the v1 signature to only have a walletEcdsaCompact signature
+      alice.publicKey.signature = new Signature({
+        walletEcdsaCompact: {
+          bytes: alice.publicKey.signature.ecdsaCompact.bytes,
+          recovery: alice.publicKey.signature.ecdsaCompact.recovery,
+        },
+      })
+      // create a new public key with the malformed signature
+      const publicKey = new PublicKey(alice.publicKey)
+      // validate the key signature and return wallet address
+      assert.ok(publicKey.signature?.ecdsaCompact)
+      const address = publicKey.walletSignatureAddress()
+      assert.equal(address, wallet.address)
+    })
+
     it('converts legacy keys to new keys', async function () {
       // Key signed by a wallet
       const wallet = newWallet()

--- a/test/crypto/Signature.test.ts
+++ b/test/crypto/Signature.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { PrivateKeyBundleV1 } from '../../src/crypto'
+import { PrivateKeyBundleV1, Signature } from '../../src/crypto'
 import { newWallet } from '../helpers'
 
 describe('Crypto', function () {
@@ -27,6 +27,25 @@ describe('Crypto', function () {
         maloryPub.identityKey.walletSignatureAddress(),
         malory.address
       )
+    })
+
+    it('returns wallet address for either ecdsaCompact or walletEcdsaCompact signatures', async function () {
+      const alice = newWallet()
+      const alicePri = await PrivateKeyBundleV1.generate(alice)
+      const alicePub = alicePri.getPublicKeyBundle()
+      assert.ok(alicePub.identityKey.signature?.ecdsaCompact)
+      assert.equal(alicePub.identityKey.walletSignatureAddress(), alice.address)
+
+      // create a malformed v1 signature
+      alicePub.identityKey.signature = new Signature({
+        walletEcdsaCompact: {
+          bytes: alicePub.identityKey.signature.ecdsaCompact.bytes,
+          recovery: alicePub.identityKey.signature.ecdsaCompact.recovery,
+        },
+      })
+      assert.ok(alicePub.identityKey.signature.walletEcdsaCompact)
+      assert.equal(alicePub.identityKey.signature.ecdsaCompact, undefined)
+      assert.equal(alicePub.identityKey.walletSignatureAddress(), alice.address)
     })
   })
 })


### PR DESCRIPTION
Follow-up to https://github.com/xmtp/xmtp-flutter/pull/67.

Resolves https://github.com/xmtp/xmtp-js/issues/374.

This PR updates our SDK to accept PublicKey signatures that only have a `walletEcdsaCompact` signature. I put a fix in the `PublicKey` constructor so that we fix the signature there and then I also added a fix where we were throwing the invalid signature in case a new PublicKey isn't always re-created. I tried to add tests to recreate this state as well.