### PR TITLE
Add group chat content types

### DIFF
--- a/src/codecs/GroupChatMemberAdded.ts
+++ b/src/codecs/GroupChatMemberAdded.ts
@@ -1,0 +1,39 @@
+import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
+
+export const ContentTypeGroupChatMemberAdded: ContentTypeId = {
+  typeId: 'groupChatMemberAdded',
+  authorityId: 'pat.xmtp.com',
+  versionMajor: 1,
+  versionMinor: 0,
+  sameAs(id) {
+    return (
+      this.typeId === id.typeId &&
+      this.authorityId === id.authorityId &&
+      this.versionMajor === id.versionMajor &&
+      this.versionMinor === id.versionMinor
+    )
+  },
+}
+
+export type GroupChatMemberAdded = {
+  member: string
+}
+
+export class GroupChatMemberAddedCodec
+  implements ContentCodec<GroupChatMemberAdded>
+{
+  contentType = ContentTypeGroupChatMemberAdded
+
+  encode(content: GroupChatMemberAdded): EncodedContent {
+    return {
+      type: ContentTypeGroupChatMemberAdded,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    }
+  }
+
+  decode(encodedContent: EncodedContent): GroupChatMemberAdded {
+    const json = new TextDecoder().decode(encodedContent.content)
+    return JSON.parse(json)
+  }
+}

--- a/src/codecs/GroupChatMemberNicknameChanged.ts
+++ b/src/codecs/GroupChatMemberNicknameChanged.ts
@@ -1,0 +1,40 @@
+import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
+
+export const ContentTypeGroupChatMemberNicknameChanged: ContentTypeId = {
+  typeId: 'groupChatMemberNicknameChanged',
+  authorityId: 'pat.xmtp.com',
+  versionMajor: 1,
+  versionMinor: 0,
+  sameAs(id) {
+    return (
+      this.typeId === id.typeId &&
+      this.authorityId === id.authorityId &&
+      this.versionMajor === id.versionMajor &&
+      this.versionMinor === id.versionMinor
+    )
+  },
+}
+
+export type GroupChatMemberNicknameChanged = {
+  // The new title
+  newNickname: string
+}
+
+export class GroupChatMemberNicknameChangedCodec
+  implements ContentCodec<GroupChatMemberNicknameChanged>
+{
+  contentType = ContentTypeGroupChatMemberNicknameChanged
+
+  encode(content: GroupChatMemberNicknameChanged): EncodedContent {
+    return {
+      type: ContentTypeGroupChatMemberNicknameChanged,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    }
+  }
+
+  decode(encodedContent: EncodedContent): GroupChatMemberNicknameChanged {
+    const json = new TextDecoder().decode(encodedContent.content)
+    return JSON.parse(json)
+  }
+}

--- a/src/codecs/GroupChatTitleChanged.ts
+++ b/src/codecs/GroupChatTitleChanged.ts
@@ -1,0 +1,43 @@
+import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
+
+export const ContentTypeGroupChatTitleChanged: ContentTypeId = {
+  typeId: 'groupChatTitleChanged',
+  authorityId: 'pat.xmtp.com',
+  versionMajor: 1,
+  versionMinor: 0,
+  sameAs(id) {
+    return (
+      this.typeId === id.typeId &&
+      this.authorityId === id.authorityId &&
+      this.versionMajor === id.versionMajor &&
+      this.versionMinor === id.versionMinor
+    )
+  },
+}
+
+export type GroupChatTitleChanged = {
+  // The new title
+  newTitle: string
+
+  // The old title
+  oldTitle: string
+}
+
+export class GroupChatTitleChangedCodec
+  implements ContentCodec<GroupChatTitleChanged>
+{
+  contentType = ContentTypeGroupChatTitleChanged
+
+  encode(content: GroupChatTitleChanged): EncodedContent {
+    return {
+      type: ContentTypeGroupChatTitleChanged,
+      parameters: {},
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    }
+  }
+
+  decode(encodedContent: EncodedContent): GroupChatTitleChanged {
+    const json = new TextDecoder().decode(encodedContent.content)
+    return JSON.parse(json)
+  }
+}

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -454,7 +454,9 @@ export default class Conversations {
     const context = {
       conversationId: `xmtp.org/groups/${groupID}`,
       metadata: {
-        initialMembers: initialMembers.join(','),
+        initialMembers: [this.client.address, ...new Set(initialMembers)].join(
+          ','
+        ),
       },
     }
 

--- a/src/conversations/GroupChat.ts
+++ b/src/conversations/GroupChat.ts
@@ -1,0 +1,174 @@
+import {
+  Client,
+  Conversation,
+  GroupConversation,
+  SortDirection,
+} from '../index'
+import {
+  ContentTypeGroupChatMemberAdded,
+  GroupChatMemberAdded,
+  GroupChatMemberAddedCodec,
+} from '../codecs/GroupChatMemberAdded'
+import {
+  ContentTypeGroupChatTitleChanged,
+  GroupChatTitleChanged,
+  GroupChatTitleChangedCodec,
+} from '../codecs/GroupChatTitleChanged'
+import {
+  ContentTypeGroupChatMemberNicknameChanged,
+  GroupChatMemberNicknameChanged,
+  GroupChatMemberNicknameChangedCodec,
+} from '../codecs/GroupChatMemberNicknameChanged'
+
+type RebuildOptions = {
+  since: Date
+}
+
+export class GroupChat {
+  static contentTypes = [
+    ContentTypeGroupChatMemberAdded,
+    GroupChatTitleChangedCodec,
+    ContentTypeGroupChatMemberNicknameChanged,
+  ]
+
+  static codecs = [
+    new GroupChatMemberAddedCodec(),
+    new GroupChatTitleChangedCodec(),
+    new GroupChatMemberNicknameChangedCodec(),
+  ]
+
+  static registerCodecs(client: Client) {
+    for (const codec of GroupChat.codecs) {
+      client.registerCodec(codec)
+    }
+  }
+
+  title = ''
+  memberClient: Client
+  conversation: Conversation
+  _members: string[] = []
+  _memberConversation: Conversation | undefined
+  _nicknames: { [member: string]: string } = {}
+
+  get members(): string[] {
+    return [...new Set(this._members)]
+  }
+
+  set members(members: string[]) {
+    this._members = [...new Set(members)]
+  }
+
+  constructor(memberClient: Client, conversation: Conversation) {
+    this.memberClient = memberClient
+    this.conversation = conversation
+  }
+
+  static async fromConversation(
+    client: Client,
+    conversation: Conversation
+  ): Promise<GroupChat> {
+    const groupChat = new GroupChat(client, conversation)
+    await groupChat.rebuild()
+
+    return groupChat
+  }
+
+  async rebuild(opts?: RebuildOptions | undefined) {
+    const members =
+      this.conversation.context?.metadata.initialMembers.split(',')
+
+    if (!members) {
+      throw new Error('Conversation is not a group chat')
+    }
+
+    this._members = members
+
+    const startTime = opts?.since
+
+    const messages = startTime
+      ? await this.conversation.messages({
+          startTime,
+          direction: SortDirection.SORT_DIRECTION_ASCENDING,
+        })
+      : await this.conversation.messages()
+
+    for (const message of messages) {
+      if (message.contentType.sameAs(ContentTypeGroupChatMemberAdded)) {
+        const groupChatMemberAdded = message.content as GroupChatMemberAdded
+        this._members.push(groupChatMemberAdded.member)
+      } else if (message.contentType.sameAs(ContentTypeGroupChatTitleChanged)) {
+        const groupChatTitleChanged = message.content as GroupChatTitleChanged
+        this.title = groupChatTitleChanged.newTitle
+      } else if (
+        message.contentType.sameAs(ContentTypeGroupChatMemberNicknameChanged)
+      ) {
+        const nicknameChange = message.content as GroupChatMemberNicknameChanged
+        this._nicknames[message.senderAddress] = nicknameChange.newNickname
+      }
+    }
+  }
+
+  get memberNickname(): string {
+    return this._nicknames[this.memberClient.address] || ''
+  }
+
+  nicknameFor(address: string): string {
+    return this._nicknames[address] || address
+  }
+
+  async changeNickname(newNickname: string) {
+    const oldNickname =
+      this.memberNickname === ''
+        ? this.memberClient.address
+        : this.memberNickname
+    const nicknameChange: GroupChatMemberNicknameChanged = {
+      newNickname,
+    }
+
+    await this.conversation.send(nicknameChange, {
+      contentType: ContentTypeGroupChatMemberNicknameChanged,
+      contentFallback: `${oldNickname} changed their nickname to ${newNickname}`,
+    })
+  }
+
+  async changeTitle(newTitle: string) {
+    const titleChange: GroupChatTitleChanged = {
+      oldTitle: this.title,
+      newTitle,
+    }
+
+    await this.conversation.send(titleChange, {
+      contentType: ContentTypeGroupChatTitleChanged,
+      contentFallback: `${this.nicknameFor(
+        this.memberClient.address
+      )} changed the group title to ${newTitle}`,
+    })
+  }
+
+  async addMember(newMemberAddress: string) {
+    const memberAdded: GroupChatMemberAdded = {
+      member: newMemberAddress,
+    }
+
+    await this.conversation.send(memberAdded, {
+      contentType: ContentTypeGroupChatMemberAdded,
+      contentFallback: `${this.nicknameFor(
+        this.memberClient.address
+      )} added ${newMemberAddress} to the group`,
+    })
+
+    this._members.push(newMemberAddress)
+
+    const conversation = GroupConversation.from(this.conversation, this.members)
+    await conversation.addMember(newMemberAddress)
+  }
+
+  static async start(
+    creatorClient: Client,
+    initialMembers: string[]
+  ): Promise<Conversation> {
+    return await creatorClient.conversations.newGroupConversation(
+      initialMembers
+    )
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,3 +80,16 @@ export {
 } from './keystore/persistence'
 export { InvitationContext, SealedInvitation } from './Invitation'
 export { decodeContactBundle } from './ContactBundle'
+export { GroupChat } from './conversations/GroupChat'
+export {
+  GroupChatMemberAdded,
+  GroupChatMemberAddedCodec,
+} from './codecs/GroupChatMemberAdded'
+export {
+  GroupChatMemberNicknameChanged,
+  GroupChatMemberNicknameChangedCodec,
+} from './codecs/GroupChatMemberNicknameChanged'
+export {
+  GroupChatTitleChanged,
+  GroupChatTitleChangedCodec,
+} from './codecs/GroupChatTitleChanged'

--- a/test/conversations/GroupChat.test.ts
+++ b/test/conversations/GroupChat.test.ts
@@ -1,0 +1,243 @@
+import { newLocalHostClient, sleep, waitForUserContact } from './../helpers'
+import { Client, Conversation, DecodedMessage, GroupChat } from '../../src'
+
+describe('GroupChat', () => {
+  let alice: Client
+  let bob: Client
+  let charlie: Client
+
+  beforeEach(async () => {
+    alice = await newLocalHostClient({ publishLegacyContact: true })
+    bob = await newLocalHostClient({ publishLegacyContact: true })
+    charlie = await newLocalHostClient({ publishLegacyContact: true })
+    await waitForUserContact(alice, alice)
+    await waitForUserContact(bob, bob)
+    await waitForUserContact(charlie, charlie)
+  })
+
+  afterEach(async () => {
+    if (alice) await alice.close()
+    if (bob) await bob.close()
+    if (charlie) await charlie.close()
+  })
+
+  async function conversationFromTopic(
+    topic: string,
+    client: Client
+  ): Promise<Conversation | undefined> {
+    const conversations = await client.conversations.list()
+    return conversations.find((conversation) => {
+      if (conversation.topic === topic) {
+        return conversation
+      }
+    })
+  }
+
+  async function messages(
+    topic: string,
+    client: Client
+  ): Promise<DecodedMessage[]> {
+    const conversation = await conversationFromTopic(topic, client)
+
+    if (!conversation) {
+      throw new Error('no conversation found for topic: ' + topic)
+    }
+
+    return await conversation.messages()
+  }
+
+  it('can be started', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    const aliceGroupChat = await GroupChat.fromConversation(
+      alice,
+      aliceConversation
+    )
+
+    expect(aliceGroupChat.members.length).toBe(3)
+
+    const bobConversations = await bob.conversations.list()
+    const charlieConversations = await charlie.conversations.list()
+
+    expect(bobConversations.length).toBe(1)
+    expect(charlieConversations.length).toBe(1)
+  })
+
+  it('lets people chat', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    await aliceConversation.send('hi everyone')
+
+    const bobMessages = await messages(aliceConversation.topic, bob)
+    const charlieMessages = await messages(aliceConversation.topic, charlie)
+
+    expect(bobMessages.length).toBe(1)
+    expect(bobMessages[0].content).toBe('hi everyone')
+    expect(bobMessages[0].senderAddress).toBe(alice.address)
+
+    expect(charlieMessages.length).toBe(1)
+    expect(charlieMessages[0].content).toBe('hi everyone')
+    expect(charlieMessages[0].senderAddress).toBe(alice.address)
+
+    const charlieConversation = await conversationFromTopic(
+      aliceConversation.topic,
+      charlie
+    )
+
+    await charlieConversation!.send('hi nice to see u all')
+
+    const bobMessages2 = await messages(aliceConversation.topic, bob)
+    const aliceMessages = await messages(aliceConversation.topic, alice)
+
+    expect(bobMessages2.length).toBe(2)
+    expect(bobMessages2[1].content).toBe('hi nice to see u all')
+    expect(bobMessages2[1].senderAddress).toBe(charlie.address)
+
+    expect(aliceMessages.length).toBe(2)
+    expect(aliceMessages[1].content).toBe('hi nice to see u all')
+    expect(aliceMessages[1].senderAddress).toBe(charlie.address)
+  })
+
+  it('can have a title', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    const aliceGroupChat = new GroupChat(alice, aliceConversation)
+    expect(aliceGroupChat.title).toBe('')
+
+    await aliceGroupChat.changeTitle('the fun group')
+
+    const bobConversation = (await conversationFromTopic(
+      aliceConversation.topic,
+      bob
+    ))!
+
+    const bobGroupChat = await GroupChat.fromConversation(bob, bobConversation)
+    expect(bobGroupChat.title).toBe('the fun group')
+
+    const charlieConversation = (await conversationFromTopic(
+      aliceConversation.topic,
+      charlie
+    ))!
+
+    const charlieGroupChat = await GroupChat.fromConversation(
+      charlie,
+      charlieConversation
+    )
+    expect(charlieGroupChat.title).toBe('the fun group')
+  })
+
+  it('members can have nicknames', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    const aliceGroupChat = new GroupChat(alice, aliceConversation)
+    expect(aliceGroupChat.title).toBe('')
+
+    await aliceGroupChat.changeNickname('alice')
+
+    const bobConversation = (await conversationFromTopic(
+      aliceConversation.topic,
+      bob
+    ))!
+
+    const bobGroupChat = await GroupChat.fromConversation(bob, bobConversation)
+    expect(bobGroupChat.nicknameFor(alice.address)).toBe('alice')
+
+    const charlieConversation = (await conversationFromTopic(
+      aliceConversation.topic,
+      charlie
+    ))!
+
+    const charlieGroupChat = await GroupChat.fromConversation(
+      charlie,
+      charlieConversation
+    )
+    expect(charlieGroupChat.nicknameFor('alice')).toBe('alice')
+  })
+
+  it('can be rebuilt', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    const aliceGroupChat = new GroupChat(alice, aliceConversation)
+    expect(aliceGroupChat.title).toBe('')
+
+    await aliceGroupChat.changeNickname('alice')
+    await aliceGroupChat.changeTitle('the fun group')
+
+    const unbuiltGroupChat = new GroupChat(alice, aliceConversation)
+    expect(unbuiltGroupChat.title).toBe('')
+    expect(unbuiltGroupChat.nicknameFor(alice.address)).toBe(alice.address)
+
+    await unbuiltGroupChat.rebuild()
+
+    expect(unbuiltGroupChat.title).toBe('the fun group')
+    expect(unbuiltGroupChat.nicknameFor(alice.address)).toBe('alice')
+  })
+
+  it('can be rebuilt partially', async () => {
+    GroupChat.registerCodecs(alice)
+    GroupChat.registerCodecs(bob)
+    GroupChat.registerCodecs(charlie)
+
+    const aliceConversation = await GroupChat.start(alice, [
+      bob.address,
+      charlie.address,
+    ])
+
+    const aliceGroupChat = new GroupChat(alice, aliceConversation)
+    expect(aliceGroupChat.title).toBe('')
+
+    await aliceGroupChat.changeNickname('alice')
+
+    await sleep(1000)
+    const date = new Date()
+    await sleep(1000)
+
+    await aliceGroupChat.changeTitle('the fun group')
+
+    const unbuiltGroupChat = new GroupChat(alice, aliceConversation)
+    expect(unbuiltGroupChat.title).toBe('')
+    expect(unbuiltGroupChat.nicknameFor(alice.address)).toBe(alice.address)
+
+    await unbuiltGroupChat.rebuild({ since: date })
+
+    // We should only get the second update because the first one happened before
+    // our `since`
+    expect(unbuiltGroupChat.title).toBe('the fun group')
+    expect(unbuiltGroupChat.nicknameFor(alice.address)).toBe(alice.address)
+  })
+})

--- a/test/conversations/GroupChat.test.ts
+++ b/test/conversations/GroupChat.test.ts
@@ -209,6 +209,11 @@ describe('GroupChat', () => {
 
     expect(bobGroupChat.members.length).toBe(4)
     expect(bobGroupChat.members[3]).toBe(carol.address)
+
+    await bobConversation!.send('hey carol')
+
+    const carolMessages = await messages(aliceConversation.topic, carol)
+    expect(carolMessages[carolMessages.length - 1].content).toBe('hey carol')
   })
 
   it('can be rebuilt', async () => {


### PR DESCRIPTION
The content types in this PR enable a more complete "group chat" experience like titles and nicknames.

### Adding a member

To add a member to a group, a member can call `keystore.createInviteFromTopic` to get an invite for a given recipient. They can send the invite to the recipient who will then be able to send/receive messages (this part is in this PR). The member adding should also send a message with content type `GroupChatMemberAdded` to the group so that other members can keep their member lists up to date.

### Updating the group title

Using the `GroupChatTitleChanged` content type, a group member can specify a new title for a group. Clients should keep track of the current title in their local persistence and update it accordingly when receiving these messages.

### Updating member nicknames 

Using the `GroupChatMemberNicknameChanged` content type, a group member can specify a new nickname for another address in the group. It's up to clients to verify that the sender of the message matches the address being changed (if that's the behavior that's desired.)