### PR TITLE
fix: topics must be ascii

### DIFF
--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -29,6 +29,7 @@ import { Persistence } from './persistence'
 import LocalAuthenticator from '../authn/LocalAuthenticator'
 import { hmacSha256Sign } from '../crypto/ecies'
 import crypto from '../crypto/crypto'
+import { bytesToHex } from '../crypto/utils'
 const { ErrorCode } = keystore
 
 // Constant, 32 byte salt
@@ -289,9 +290,9 @@ export default class InMemoryKeystore implements Keystore {
 
       const msgBytes = new TextEncoder().encode(msgString)
 
-      const topic = (
+      const topic = bytesToHex(
         await hmacSha256Sign(Buffer.from(secret), Buffer.from(msgBytes))
-      ).toString()
+      )
 
       const infoString = [
         '0', // sequence number

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -510,6 +510,8 @@ describe('InMemoryKeystore', () => {
       const firstResponse: CreateInviteResponse = responses[0]
       const topicName = firstResponse.conversation!.topic
 
+      expect(topicName).toMatch(/^[\x00-\x7F]+$/)
+
       expect(
         responses.filter((response, index, array) => {
           return response.conversation!.topic === topicName


### PR DESCRIPTION
Without this change, topics were being stored as mangled utf-8 (probably?).

<img width="493" alt="image" src="https://github.com/xmtp/xmtp-js/assets/483/774ab3cf-c54b-431c-92e7-861ec5ab652a">

I think this got introduced during the deterministic topic changes.