### PR TITLE
Add isGroup to Conversation interface

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -59,6 +59,12 @@ export interface Conversation {
    * Timestamp the conversation was created at
    */
   createdAt: Date
+
+  /**
+   * Is this conversation a group chat
+   */
+  isGroup: boolean
+
   /**
    * Optional field containing the `conversationId` and `metadata` for V2 conversations.
    * Will always be undefined on V1 conversations
@@ -148,6 +154,7 @@ export class ConversationV1 implements Conversation {
   peerAddress: string
   createdAt: Date
   context = undefined
+  isGroup = false
   private client: Client
 
   constructor(client: Client, address: string, createdAt: Date) {
@@ -423,6 +430,7 @@ export class ConversationV2 implements Conversation {
   peerAddress: string
   createdAt: Date
   context?: InvitationContext
+  isGroup = false
 
   constructor(
     client: Client,

--- a/src/conversations/GroupConversation.ts
+++ b/src/conversations/GroupConversation.ts
@@ -11,6 +11,7 @@ export class GroupConversation extends ConversationV2 implements Conversation {
   topic: string
   createdAt: Date
   memberAddresses: string[] = []
+  isGroup = true
 
   constructor(
     client: Client,
@@ -31,10 +32,19 @@ export class GroupConversation extends ConversationV2 implements Conversation {
 
   static from(
     conversation: Conversation,
-    memberAddresses: string[]
+    members?: string[]
   ): GroupConversation {
     if (!(conversation instanceof ConversationV2)) {
       throw new Error('Conversation is not a V2 conversation')
+    }
+
+    const memberAddresses =
+      members ||
+      conversation.context?.metadata?.initialMembers?.split(',') ||
+      []
+
+    if (memberAddresses.length === 0) {
+      throw new Error('Conversation has no member addresses')
     }
 
     return new GroupConversation(

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -119,6 +119,7 @@ describe('conversations', () => {
       const bobConversations3 = await bob.conversations.list()
       expect(bobConversations3).toHaveLength(2)
       expect(bobConversations3[0].topic).toBe(groupConvo.topic)
+      expect(bobConversations3[0].isGroup).toBe(true)
     })
 
     it('caches results and updates the latestSeen date', async () => {


### PR DESCRIPTION
This change makes it easier for clients to determine whether or not conversations they get back from `conversations.list()` are for group chats. Prior to this, they'd have to look at `conversation.context?.metadata?.initialMembers?.split(',').length > 0`.

This PR also removes some redundant passing around of member lists when we can avoid it.