### PR TITLE
fix: export missing group chat content types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,8 +84,10 @@ export { GroupChat } from './conversations/GroupChat'
 export {
   GroupChatMemberAdded,
   GroupChatMemberAddedCodec,
+  ContentTypeGroupChatMemberAdded,
 } from './codecs/GroupChatMemberAdded'
 export {
   GroupChatTitleChanged,
   GroupChatTitleChangedCodec,
+  ContentTypeGroupChatTitleChanged,
 } from './codecs/GroupChatTitleChanged'


### PR DESCRIPTION
These content type definitions need to be exported.