### PR TITLE
Add Provenance Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "semantic-release": "semantic-release"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "dist/index.cjs",


### PR DESCRIPTION
## Summary

- Publishes our NPM package using [Github NPM Package Provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/). This should increase trust in our published packages, since the package will display a badge assuring developers that the package they are installing really is built from the source code in our published repos.

## Notes
Once we get this working, we'll add provenance to our other NPM packages.