### PR TITLE
Add back default permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
       id-token: write
       contents: write
       statuses: write
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
       - beta
+
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -11,7 +15,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      statuses: write
+      pull-requests: write
       issues: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
+      - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+        run: npm audit signatures
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

In https://github.com/xmtp/xmtp-js/pull/391 we added a new permission to the Github workflow, but in doing so lost the default permissions. This adds back a few of those permissions so that packages can publish properly. 

Also now audits the signatures for our dependencies.

## Notes

I found this [semantic release guide](https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions)