### PR TITLE
Upgrade NPM in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - name: Use latest NPM
+        # Ensure we are using the latest version of NPM to get support for provenance
         run: npm i -g npm
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Use latest NPM
+        run: npm i -g npm
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
## Summary

While we are now successfully publishing packages, I don't see the nice green badge next to the latest release.
<img width="173" alt="CleanShot 2023-06-08 at 13 50 20@2x" src="https://github.com/xmtp/xmtp-js/assets/65710/5dd6a81e-4e2c-41f6-b515-23a105347e27">

Other apps using provenance, like `@noble/hashes`, have a checkmark like this:
<img width="134" alt="CleanShot 2023-06-08 at 13 50 52@2x" src="https://github.com/xmtp/xmtp-js/assets/65710/a9063c73-3f4a-442a-be3e-9be675f513f8">

I don't really know what's wrong, but my hypothesis is that we need to upgrade to the latest version of NPM to take advantage of this relatively new feature. Both the [Noble Hashes](https://github.com/paulmillr/noble-hashes/blob/main/.github/workflows/publish-npm.yml) library, and the [provenance documentation](https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow) include a step to upgrade NPM.

This feels like a harmless change and will hopefully give us the badge we deserve.