### PR TITLE
Remove registry URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
       - name: Use latest NPM
         # Ensure we are using the latest version of NPM to get support for provenance
         run: npm i -g npm


### PR DESCRIPTION
## Summary

Builds to main are failing with an [Invalid NPM Token Error](https://github.com/xmtp/xmtp-js/actions/runs/5215833592/jobs/9413961068).

The last PR specified the NPM registry URL, and I'm wondering if that's the culprit.