### PR TITLE
Add ContentTypeReaction

### DIFF
--- a/src/MessageContent.ts
+++ b/src/MessageContent.ts
@@ -24,9 +24,9 @@ export class ContentTypeId {
 }
 
 // Represents proto.EncodedContent
-export interface EncodedContent {
+export type EncodedContent<Parameters = Record<string, string>> = {
   type: ContentTypeId
-  parameters: Record<string, string>
+  parameters: Parameters
   fallback?: string
   compression?: number
   content: Uint8Array

--- a/src/codecs/Reaction.ts
+++ b/src/codecs/Reaction.ts
@@ -1,0 +1,60 @@
+import { ContentTypeId, ContentCodec, EncodedContent } from '../MessageContent'
+
+// xmtp.org/text
+//
+// This content type is used for a plain text content represented by a simple string
+export const ContentTypeReaction = new ContentTypeId({
+  authorityId: 'xmtp.org',
+  typeId: 'reaction',
+  versionMajor: 1,
+  versionMinor: 0,
+})
+
+export type Reaction = {
+  /**
+   * The message ID for the message that is being reacted to
+   */
+  reference: string
+  /**
+   * The action of the reaction
+   */
+  action: 'added' | 'removed'
+  /**
+   * The content of the reaction
+   */
+  content: string
+}
+
+export type ReactionParameters = Pick<Reaction, 'action' | 'reference'> & {
+  encoding: 'UTF-8'
+}
+
+export class ReactionCodec implements ContentCodec<Reaction> {
+  get contentType(): ContentTypeId {
+    return ContentTypeReaction
+  }
+
+  encode(content: Reaction): EncodedContent<ReactionParameters> {
+    return {
+      type: ContentTypeReaction,
+      parameters: {
+        encoding: 'UTF-8',
+        action: content.action,
+        reference: content.reference,
+      },
+      content: new TextEncoder().encode(content.content),
+    }
+  }
+
+  decode(content: EncodedContent<ReactionParameters>): Reaction {
+    const encoding = content.parameters.encoding
+    if (encoding && encoding !== 'UTF-8') {
+      throw new Error(`unrecognized encoding ${encoding}`)
+    }
+    return {
+      action: content.parameters.action,
+      reference: content.parameters.reference,
+      content: new TextDecoder().decode(content.content),
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ export {
   ContentTypeTypingNotification,
 } from './codecs/TypingNotification'
 export {
+  Reaction,
+  ReactionCodec,
+  ReactionParameters,
+  ContentTypeReaction,
+} from './codecs/Reaction'
+export {
   Composite,
   CompositeCodec,
   ContentTypeComposite,


### PR DESCRIPTION
Proposal: https://github.com/orgs/xmtp/discussions/36
Issue: https://github.com/xmtp-labs/hq/issues/1030

This PR adds the reaction content type with adjustments from the proposal as outlined in the comments of the issue.

TL;DR on the changes from the proposal:

* `emoji` => `content`, to be interpreted by client to allow for custom reactions
* added `action`, to allow for removing a reaction