### PR TITLE
Fix group chat content types and streaming

### DIFF
--- a/src/codecs/GroupChatMemberAdded.ts
+++ b/src/codecs/GroupChatMemberAdded.ts
@@ -1,19 +1,11 @@
 import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
 
-export const ContentTypeGroupChatMemberAdded: ContentTypeId = {
+export const ContentTypeGroupChatMemberAdded = new ContentTypeId({
   typeId: 'groupChatMemberAdded',
   authorityId: 'xmtp.org',
   versionMajor: 1,
   versionMinor: 0,
-  sameAs(id) {
-    return (
-      this.typeId === id.typeId &&
-      this.authorityId === id.authorityId &&
-      this.versionMajor === id.versionMajor &&
-      this.versionMinor === id.versionMinor
-    )
-  },
-}
+})
 
 export type GroupChatMemberAdded = {
   member: string

--- a/src/codecs/GroupChatMemberAdded.ts
+++ b/src/codecs/GroupChatMemberAdded.ts
@@ -1,4 +1,4 @@
-import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
+import { ContentTypeId, ContentCodec, EncodedContent } from '../MessageContent'
 
 export const ContentTypeGroupChatMemberAdded = new ContentTypeId({
   typeId: 'groupChatMemberAdded',

--- a/src/codecs/GroupChatTitleChanged.ts
+++ b/src/codecs/GroupChatTitleChanged.ts
@@ -1,19 +1,11 @@
 import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
 
-export const ContentTypeGroupChatTitleChanged: ContentTypeId = {
+export const ContentTypeGroupChatTitleChanged = new ContentTypeId({
   typeId: 'groupChatTitleChanged',
   authorityId: 'xmtp.org',
   versionMajor: 1,
   versionMinor: 0,
-  sameAs(id) {
-    return (
-      this.typeId === id.typeId &&
-      this.authorityId === id.authorityId &&
-      this.versionMajor === id.versionMajor &&
-      this.versionMinor === id.versionMinor
-    )
-  },
-}
+})
 
 export type GroupChatTitleChanged = {
   newTitle: string

--- a/src/codecs/GroupChatTitleChanged.ts
+++ b/src/codecs/GroupChatTitleChanged.ts
@@ -1,4 +1,4 @@
-import { ContentCodec, ContentTypeId, EncodedContent } from '../index'
+import { ContentTypeId, ContentCodec, EncodedContent } from '../MessageContent'
 
 export const ContentTypeGroupChatTitleChanged = new ContentTypeId({
   typeId: 'groupChatTitleChanged',

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -274,6 +274,7 @@ export default class Conversations {
     const seenPeers: Set<string> = new Set()
     const introTopic = buildUserIntroTopic(this.client.address)
     const inviteTopic = buildUserInviteTopic(this.client.address)
+    const groupInviteTopic = buildUserGroupInviteTopic(this.client.address)
 
     const newPeer = (peerAddress: string): boolean => {
       // Check if we have seen the peer already in this stream
@@ -301,12 +302,26 @@ export default class Conversations {
           return results[0]
         }
       }
+      if (env.contentTopic === groupInviteTopic) {
+        const results = await this.decodeInvites([env], true)
+        if (results.length) {
+          const result = results[0]
+          result.isGroup = true
+          return result
+        }
+      }
       throw new Error('unrecognized invite topic')
+    }
+
+    const topics = [introTopic, inviteTopic]
+
+    if (this.client.isGroupChatEnabled) {
+      topics.push(groupInviteTopic)
     }
 
     return Stream.create<Conversation>(
       this.client,
-      [inviteTopic, introTopic],
+      topics,
       decodeConversation.bind(this)
     )
   }


### PR DESCRIPTION
Fixes two issues:

- Content types weren't instances of ContentTypeId, they were just conforming which made them unclonable
- Group Conversations returned from `client.conversations.stream()` didn't have `isGroup` set to `true`.