### PR TITLE
Docs: Remove conversation ID info, update status to Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Build with `xmtp-js` to provide messaging between blockchain wallet addresses, d
 
 To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
 
-## Quickstart and example apps built with `xmtp-js`
+## Playground and example apps built with `xmtp-js`
 
-- Use the [XMTP React quickstart app](https://github.com/xmtp/xmtp-quickstart-react) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
+- Use the [XMTP React playground app](https://github.com/xmtp/xmtp-react-playground) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
 
 - Use the [XMTP Inbox Web example app](https://github.com/xmtp-labs/xmtp-inbox-web) as a reference implementation to understand how to implement features following developer and user experience best practices.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Test](https://github.com/xmtp/xmtp-js/actions/workflows/test.yml/badge.svg)
 ![Lint](https://github.com/xmtp/xmtp-js/actions/workflows/lint.yml/badge.svg)
 ![Build](https://github.com/xmtp/xmtp-js/actions/workflows/build.yml/badge.svg)
-![Status](https://img.shields.io/badge/Project_Status-General_Availability-brightgreen)
+![Status](https://img.shields.io/badge/Project_Status-Production-brightgreen)
 
 ![x-red-sm](https://user-images.githubusercontent.com/510695/163488403-1fb37e86-c673-4b48-954e-8460ae4d4b05.png)
 
@@ -15,17 +15,17 @@ Build with `xmtp-js` to provide messaging between blockchain wallet addresses, d
 
 `xmtp-js` was included in a [security assessment](https://xmtp.org/assets/files/REP-final-20230207T000355Z-3825cbc68c115f4ec81f3b1d53a24fce.pdf) prepared by [Certik](https://www.certik.com/company/about).
 
-To learn more about XMTP and get answers to frequently asked questions, see [FAQ about XMTP](https://xmtp.org/docs/dev-concepts/faq).
+To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
 
-## Example apps built with `xmtp-js`
+## Quickstart and example apps built with `xmtp-js`
 
-- [XMTP Quickstart React app](https://github.com/xmtp/xmtp-quickstart-react): Provides a basic messaging app demonstrating core capabilities of the SDK. The app is intentionally built with lightweight code to help make it easier to parse and start learning to build with XMTP.
+- Use the [XMTP React quickstart app](https://github.com/xmtp/xmtp-quickstart-react) as a tool to start building an app with XMTP. This basic messaging app has an intentionally unopinionated UI to help make it easier for you to build with.
 
-- [XMTP Inbox app](https://github.com/xmtp-labs/xmtp-inbox-web): Provides a messaging app demonstrating core and advanced capabilities of the SDK. The app aims to showcase innovative ways of building with XMTP.
+- Use the [XMTP Inbox Web example app](https://github.com/xmtp-labs/xmtp-inbox-web) as a reference implementation to understand how to implement features following developer and user experience best practices.
 
 ## Reference docs
 
-Access the `xmtp-js` client SDK [reference documentation](https://xmtp.org/docs/client-sdk/javascript/reference/classes/Ciphertext).
+Access the `xmtp-js` client SDK [reference documentation](https://xmtp-js.pages.dev/modules).
 
 ## Install
 
@@ -60,7 +60,7 @@ webpack: (config, { isServer }) => {
 
 ## Usage
 
-The [XMTP message API](https://xmtp.org/docs/dev-concepts/architectural-overview#network-layer) revolves around a network client that allows retrieving and sending messages to other network participants. A client must be connected to a wallet on startup. If this is the very first time the client is created, the client will generate a [key bundle](https://xmtp.org/docs/dev-concepts/key-generation-and-usage) that is used to [encrypt and authenticate messages](https://xmtp.org/docs/dev-concepts/invitation-and-message-encryption). The key bundle persists encrypted in the network using a [wallet signature](https://xmtp.org/docs/dev-concepts/account-signatures). The public side of the key bundle is also regularly advertised on the network to allow parties to establish shared encryption keys. All this happens transparently, without requiring any additional code.
+The [XMTP message API](https://xmtp.org/docs/concepts/architectural-overview#network-layer) revolves around a network client that allows retrieving and sending messages to other network participants. A client must be connected to a wallet on startup. If this is the very first time the client is created, the client will generate a [key bundle](https://xmtp.org/docs/concepts/key-generation-and-usage) that is used to [encrypt and authenticate messages](https://xmtp.org/docs/concepts/invitation-and-message-encryption). The key bundle persists encrypted in the network using a [wallet signature](https://xmtp.org/docs/concepts/account-signatures). The public side of the key bundle is also regularly advertised on the network to allow parties to establish shared encryption keys. All this happens transparently, without requiring any additional code.
 
 ```ts
 import { Client } from '@xmtp/xmtp-js'
@@ -93,7 +93,8 @@ A client is created with `Client.create(wallet: Signer): Promise<Client>` that r
 1. To sign the newly generated key bundle. This happens only the very first time when key bundle is not found in storage.
 2. To sign a random salt used to encrypt the key bundle in storage. This happens every time the client is started (including the very first time).
 
-**Important:** The client connects to the XMTP `dev` environment by default. [Use `ClientOptions`](#configure-the-client) to change this and other parameters of the network connection.
+> **Important**
+> The client connects to the XMTP `dev` environment by default. [Use `ClientOptions`](#configure-the-client) to change this and other parameters of the network connection.
 
 ```ts
 import { Client } from '@xmtp/xmtp-js'
@@ -115,8 +116,8 @@ The client's network connection and key storage method can be configured with th
 | skipContactPublishing     | `false`                                                                           | Do not publish the user's contact bundle to the network on client creation. Designed to be used in cases where the client session is short-lived (for example, decrypting a push notification), and where it is known that a client instance has been instantiated with this flag set to false at some point in the past.                                                                                                                |
 | codecs                    | `[TextCodec]`                                                                     | Add codecs to support additional content types.                                                                                                                                                                                                                                                                                                                                                                                          |
 | maxContentSize            | `100M`                                                                            | Maximum message content size in bytes.                                                                                                                                                                                                                                                                                                                                                                                                   |
-| preCreateIdentityCallback | `undefined`                                                                       | `preCreateIdentityCallback` is a function that will be called immediately before a [Create Identity wallet signature](https://xmtp.org/docs/dev-concepts/account-signatures#sign-to-create-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                 |
-| preEnableIdentityCallback | `undefined`                                                                       | `preEnableIdentityCallback` is a function that will be called immediately before an [Enable Identity wallet signature](https://xmtp.org/docs/dev-concepts/account-signatures#sign-to-enable-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                |
+| preCreateIdentityCallback | `undefined`                                                                       | `preCreateIdentityCallback` is a function that will be called immediately before a [Create Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-create-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                     |
+| preEnableIdentityCallback | `undefined`                                                                       | `preEnableIdentityCallback` is a function that will be called immediately before an [Enable Identity wallet signature](https://xmtp.org/docs/concepts/account-signatures#sign-to-enable-an-xmtp-identity) is requested from the user.                                                                                                                                                                                                    |
 
 ### Conversations
 
@@ -142,15 +143,14 @@ for (const conversation of allConversations) {
 }
 ```
 
-These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of an [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
-
-You might choose to provide an additional filtered view of conversations. To learn more, see [Handle multiple conversations with the same blockchain address](#handle-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of an [interoperable inbox](https://xmtp.org/docs/concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
 
 #### Listen for new conversations
 
 You can also listen for new conversations being started in real-time. This will allow applications to display incoming messages from new contacts.
 
-_Warning: this stream will continue infinitely. To end the stream you can either break from the loop, or call `await stream.return()`_
+> **Warning**
+> This stream will continue infinitely. To end the stream you can either break from the loop, or call `await stream.return()`.
 
 ```ts
 const stream = await xmtp.conversations.stream()
@@ -175,7 +175,7 @@ const newConversation = await xmtp.conversations.newConversation(
 
 #### Send messages
 
-To be able to send a message, the recipient must have already started their client at least once and consequently advertised their key bundle on the network. Messages are addressed using wallet addresses. The message payload can be a plain string, but other types of content can be supported through the use of `SendOptions` (see [Different types of content](#different-types-of-content) for more details)
+To be able to send a message, the recipient must have already started their client at least once and consequently advertised their key bundle on the network. Messages are addressed using wallet addresses. The message payload can be a plain string, but other types of content can be supported through the use of `SendOptions` (see [Different types of content](#handle-different-types-of-content) for more details)
 
 ```ts
 const conversation = await xmtp.conversations.newConversation(
@@ -245,7 +245,8 @@ for await (const message of await conversation.streamMessages()) {
 
 To listen for any new messages from _all_ conversations, use `conversations.streamAllMessages()`.
 
-**Note:** There is a chance this stream can miss messages if multiple new conversations are received in the time it takes to update the stream to include a new conversation.
+> **Note**
+> There is a chance this stream can miss messages if multiple new conversations are received in the time it takes to update the stream to include a new conversation.
 
 ```ts
 for await (const message of await xmtp.conversations.streamAllMessages()) {
@@ -273,59 +274,12 @@ const isOnProdNetwork = await Client.canMessage(
 )
 ```
 
-#### Handle multiple conversations with the same blockchain address
-
-With XMTP, you can have multiple ongoing conversations with the same blockchain address. For example, you might want to have a conversation scoped to your particular application, or even a conversation scoped to a particular item in your application.
-
-To accomplish this, just set the `conversationId` when you are creating a conversation. We recommend conversation IDs start with a domain, to help avoid unwanted collisions between your application and other apps on the XMTP network.
-
-```ts
-// Start a scoped conversation with ID mydomain.xyz/foo
-const conversation1 = await xmtp.conversations.newConversation(
-  '0x3F11b27F323b62B159D2642964fa27C46C841897',
-  {
-    conversationId: 'mydomain.xyz/foo',
-  }
-)
-
-// Start a scoped conversation with ID mydomain.xyz/bar. And add some metadata
-const conversation2 = await xmtp.conversations.newConversation(
-  '0x3F11b27F323b62B159D2642964fa27C46C841897',
-  {
-    conversationId: 'mydomain.xyz/bar',
-    metadata: {
-      title: 'Bar conversation',
-    },
-  }
-)
-
-// Get all the conversations
-const conversations = await xmtp.conversations.list()
-// Filter for the ones from your application
-const myAppConversations = conversations.filter(
-  (convo) =>
-    convo.context?.conversationId &&
-    convo.context.conversationId.startsWith('mydomain.xyz/')
-)
-
-for (const conversation of myAppConversations) {
-  const conversationId = conversation.context?.conversationId
-  if (conversationId === 'mydomain.xyz/foo') {
-    await conversation.send('foo')
-  }
-  if (conversationId === 'mydomain.xyz/bar') {
-    await conversation.send('bar')
-    console.log(conversation.context?.metadata.title)
-  }
-}
-```
-
 ### Send a broadcast message
 
 You can send a broadcast message (1:many message or announcement) with XMTP. The recipient sees the message as a DM from the sending wallet address.
 
 > **Note**  
-> If your app stores a signature to read and send XMTP messages on behalf of a user, be sure to let users know. As a best practice, your app should also provide a way for a user to delete their signature. For example disclosure text and UI patterns, see [Disclose signature storage](https://xmtp.org/docs/dev-concepts/start-building#disclose-signature-storage).
+> If your app stores a signature to read and send XMTP messages on behalf of a user, be sure to let users know. As a best practice, your app should also provide a way for a user to delete their signature. For example disclosure text and UI patterns, see [Disclose signature storage](https://xmtp.org/docs/tutorials/broadcast#disclose-signature-storage).
 
 1. Use the bulk query `canMessage` method to identify the wallet addresses that are activated on the XMTP network.
 2. Send the message to all of the activated wallet addresses.
@@ -368,7 +322,7 @@ main()
 
 All send functions support `SendOptions` as an optional parameter. The `contentType` option allows specifying different types of content than the default simple string standard content type, which is identified with content type identifier `ContentTypeText`.
 
-To learn more about content types, see [Content types with XMTP](https://xmtp.org/docs/dev-concepts/content-types).
+To learn more about content types, see [Content types with XMTP](https://xmtp.org/docs/concepts/content-types).
 
 Support for other types of content can be added by registering additional `ContentCodecs` with the `Client`. Every codec is associated with a content type identifier, `ContentTypeId`, which is used to signal to the client which codec should be used to process the content that is being sent or received.
 
@@ -395,7 +349,7 @@ import { CompositeCodec } from '@xmtp/xmtp-js'
 const xmtp = Client.create(wallet, { codecs: [new CompositeCodec()] })
 ```
 
-To learn more about how to build a custom content type, see [Build a custom content type](https://xmtp.org/docs/client-sdk/javascript/tutorials/use-content-types#build-a-custom-content-type).
+To learn more about how to build a custom content type, see [Build a custom content type](https://xmtp.org/docs/concepts/content-types#build-a-custom-content-type).
 
 Custom codecs and content types may be proposed as interoperable standards through XRCs. To learn about the custom content type proposal process, see [XIP-5](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-5-message-content-types.md).
 


### PR DESCRIPTION
- Remove conversation ID guidance
- Update repo status from General Availability to Production
- State that contenFallback is required
- Link to broadcast message best practices
- Other cleanup