### PR TITLE
feat: add `fromString` to ContentTypeId class

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test:cov": "jest --coverage --no-cache --runInBand",
     "lint": "prettier --check . && eslint .",
     "autolint": "prettier --write . && eslint --fix .",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "typecheck": "tsc"
   },
   "publishConfig": {
     "access": "public",

--- a/src/MessageContent.ts
+++ b/src/MessageContent.ts
@@ -18,6 +18,18 @@ export class ContentTypeId {
     return `${this.authorityId}/${this.typeId}:${this.versionMajor}.${this.versionMinor}`
   }
 
+  static fromString(contentTypeString: string): ContentTypeId {
+    const [idString, versionString] = contentTypeString.split(':')
+    const [authorityId, typeId] = idString.split('/')
+    const [major, minor] = versionString.split('.')
+    return new ContentTypeId({
+      authorityId,
+      typeId,
+      versionMajor: Number(major),
+      versionMinor: Number(minor),
+    })
+  }
+
   sameAs(id: ContentTypeId): boolean {
     return this.authorityId === id.authorityId && this.typeId === id.typeId
   }

--- a/test/MessageContent.test.ts
+++ b/test/MessageContent.test.ts
@@ -1,0 +1,55 @@
+import { ContentTypeId } from '../src/MessageContent'
+
+describe('ContentTypeId', () => {
+  it('creates a new content type', () => {
+    const contentType = new ContentTypeId({
+      authorityId: 'foo',
+      typeId: 'bar',
+      versionMajor: 1,
+      versionMinor: 0,
+    })
+
+    expect(contentType.authorityId).toEqual('foo')
+    expect(contentType.typeId).toEqual('bar')
+    expect(contentType.versionMajor).toEqual(1)
+    expect(contentType.versionMinor).toEqual(0)
+  })
+
+  it('creates a string from a content type', () => {
+    const contentType = new ContentTypeId({
+      authorityId: 'foo',
+      typeId: 'bar',
+      versionMajor: 1,
+      versionMinor: 0,
+    })
+
+    expect(contentType.toString()).toEqual('foo/bar:1.0')
+  })
+
+  it('creates a content type from a string', () => {
+    const contentType = ContentTypeId.fromString('foo/bar:1.0')
+
+    expect(contentType.authorityId).toEqual('foo')
+    expect(contentType.typeId).toEqual('bar')
+    expect(contentType.versionMajor).toEqual(1)
+    expect(contentType.versionMinor).toEqual(0)
+  })
+
+  it('compares two content types', () => {
+    const contentType1 = new ContentTypeId({
+      authorityId: 'foo',
+      typeId: 'bar',
+      versionMajor: 1,
+      versionMinor: 0,
+    })
+    const contentType2 = new ContentTypeId({
+      authorityId: 'baz',
+      typeId: 'qux',
+      versionMajor: 1,
+      versionMinor: 0,
+    })
+
+    expect(contentType1.sameAs(contentType2)).toBe(false)
+    expect(contentType1.sameAs(contentType1)).toBe(true)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
+    "noEmit": true /* Do not emit outputs. */,
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     "downlevelIteration": true /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */,
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */


### PR DESCRIPTION
The motivation behind this change is to allow for storing a content type in the parameters of a codec. Codec parameters are limited to string values, so this enables working with a content type stored as a string value.

This work unblocks the Reply content type, which requires storing the content type of a reply so that it can be encoded/decoded properly.