### PR TITLE
Add validation for private key public key match

### DIFF
--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -155,6 +155,14 @@ export class SignedPrivateKey
     return privateKey.SignedPrivateKey.encode(this).finish()
   }
 
+  validatePublicKey(): boolean {
+    const generatedPublicKey = secp.getPublicKey(this.secp256k1.bytes)
+    return equalBytes(
+      generatedPublicKey,
+      this.publicKey.secp256k1Uncompressed.bytes
+    )
+  }
+
   // Decode key from bytes.
   static fromBytes(bytes: Uint8Array): SignedPrivateKey {
     return new SignedPrivateKey(privateKey.SignedPrivateKey.decode(bytes))

--- a/src/crypto/PrivateKey.ts
+++ b/src/crypto/PrivateKey.ts
@@ -273,6 +273,14 @@ export class PrivateKey implements privateKey.PrivateKey {
     return this.publicKey.equals(key)
   }
 
+  validatePublicKey(): boolean {
+    const generatedPublicKey = secp.getPublicKey(this.secp256k1.bytes)
+    return equalBytes(
+      generatedPublicKey,
+      this.publicKey.secp256k1Uncompressed.bytes
+    )
+  }
+
   // Encode this key into bytes.
   toBytes(): Uint8Array {
     return privateKey.PrivateKey.encode(this).finish()

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -200,6 +200,14 @@ export class PrivateKeyBundleV1 implements proto.PrivateKeyBundleV1 {
     return this._publicKeyBundle
   }
 
+  validatePublicKeys(): boolean {
+    if (!this.identityKey.validatePublicKey()) {
+      return false
+    }
+
+    return this.preKeys.every((key) => key.validatePublicKey())
+  }
+
   // sharedSecret derives a secret from peer's key bundles using a variation of X3DH protocol
   // where the sender's ephemeral key pair is replaced by the sender's pre-key.
   // @peer is the peer's public key bundle

--- a/src/crypto/PrivateKeyBundle.ts
+++ b/src/crypto/PrivateKeyBundle.ts
@@ -113,6 +113,14 @@ export class PrivateKeyBundleV2 implements proto.PrivateKeyBundleV2 {
     }).finish()
   }
 
+  validatePublicKeys(): boolean {
+    if (!this.identityKey.validatePublicKey()) {
+      return false
+    }
+
+    return this.preKeys.every((key) => key.validatePublicKey())
+  }
+
   equals(other: this): boolean {
     if (this.preKeys.length !== other.preKeys.length) {
       return false

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -48,6 +48,23 @@ describe('Crypto', function () {
       assert.ok(true)
     })
   })
+
+  describe('PrivateKey', () => {
+    it('validates true for valid keys', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV1.generate(wallet)
+      expect(bundle.identityKey.validatePublicKey()).toBe(true)
+    })
+
+    it('fails validation when private key does not match public key', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV1.generate(wallet)
+      const otherBundle = await PrivateKeyBundleV1.generate(newWallet())
+      bundle.identityKey.publicKey = otherBundle.identityKey.publicKey
+      expect(bundle.identityKey.validatePublicKey()).toBe(false)
+    })
+  })
+
   describe('SignedPublicKeyBundle', () => {
     it('legacy roundtrip', async function () {
       const wallet = newWallet()

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -65,6 +65,22 @@ describe('Crypto', function () {
     })
   })
 
+  describe('SignedPrivateKey', () => {
+    it('validates true for valid keys', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV2.generate(wallet)
+      expect(bundle.identityKey.validatePublicKey()).toBe(true)
+    })
+
+    it('fails validation when private key does not match public key', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV2.generate(wallet)
+      const otherBundle = await PrivateKeyBundleV2.generate(newWallet())
+      bundle.identityKey.publicKey = otherBundle.identityKey.publicKey
+      expect(bundle.identityKey.validatePublicKey()).toBe(false)
+    })
+  })
+
   describe('SignedPublicKeyBundle', () => {
     it('legacy roundtrip', async function () {
       const wallet = newWallet()

--- a/test/crypto/PrivateKeyBundle.test.ts
+++ b/test/crypto/PrivateKeyBundle.test.ts
@@ -47,6 +47,20 @@ describe('Crypto', function () {
       assert.equal(actual, expected)
       assert.ok(true)
     })
+
+    it('validates true for valid keys', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV1.generate(wallet)
+      expect(bundle.validatePublicKeys()).toBe(true)
+    })
+
+    it('fails validation when private key does not match public key', async () => {
+      const wallet = newWallet()
+      const bundle = await PrivateKeyBundleV1.generate(wallet)
+      const otherBundle = await PrivateKeyBundleV1.generate(newWallet())
+      bundle.preKeys[0].publicKey = otherBundle.preKeys[0].publicKey
+      expect(bundle.validatePublicKeys()).toBe(false)
+    })
   })
 
   describe('PrivateKey', () => {


### PR DESCRIPTION
## Summary

Our `PrivateKey` proto types embed the associated public key. We haven't historically had a lot of need to validate `PrivateKey`s, because they are either freshly generated or are coming from an encrypted payload. 

In the context of the Snap, I would like to validate that the private keys coming from the application have matching public keys. Otherwise a malicious app could construct a malicious private key using the publicly available signed public key (from a contact topic) and a different private key. We should detect and reject those types of keys.

## Note
I haven't included a step to validate these keys when we extract them from `EncryptedPrivateKeyBundle` but we may want to do that as well just as an additional safety check. Maybe we even want to include this in the constructor. I'll leave that for another PR