### PR TITLE
Create + Register Read Receipt Codec

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -27,6 +27,7 @@ import {
   NetworkKeystoreProvider,
   StaticKeystoreProvider,
 } from './keystore/providers'
+import { ReadReceiptCodec } from './codecs/ReadReceipt'
 const { Compression } = proto
 const { b64Decode } = fetcher
 
@@ -183,7 +184,7 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
     privateKeyOverride: undefined,
     env: 'dev',
     apiUrl: undefined,
-    codecs: [new TextCodec()],
+    codecs: [new TextCodec(), new ReadReceiptCodec()],
     maxContentSize: MaxContentSize,
     persistConversations: true,
     skipContactPublishing: false,

--- a/src/Invitation.ts
+++ b/src/Invitation.ts
@@ -9,7 +9,7 @@ import { dateToNs, buildDirectMessageTopicV2 } from './utils'
 const { b64Decode } = fetcher
 
 export type InvitationContext = {
-  conversationId: string | null
+  conversationId: string
   metadata: { [k: string]: string }
 }
 

--- a/src/Invitation.ts
+++ b/src/Invitation.ts
@@ -9,7 +9,7 @@ import { dateToNs, buildDirectMessageTopicV2 } from './utils'
 const { b64Decode } = fetcher
 
 export type InvitationContext = {
-  conversationId: string
+  conversationId: string | null
   metadata: { [k: string]: string }
 }
 

--- a/src/codecs/ReadReceipt.ts
+++ b/src/codecs/ReadReceipt.ts
@@ -1,0 +1,37 @@
+import { ContentTypeId, ContentCodec, EncodedContent } from '../MessageContent'
+
+// This content type is used for read receipts
+export const ContentTypeReadReceipt = new ContentTypeId({
+  authorityId: 'xmtp.com',
+  typeId: 'readReceipt',
+  versionMajor: 1,
+  versionMinor: 0,
+})
+
+export type ReadReceipt = {
+  timestamp: Date
+}
+
+export class ReadReceiptCodec implements ContentCodec<ReadReceipt> {
+  get contentType(): ContentTypeId {
+    return ContentTypeReadReceipt
+  }
+
+  encode(content: ReadReceipt): EncodedContent {
+    return {
+      type: ContentTypeReadReceipt,
+      parameters: {
+        timestamp: content.timestamp.toISOString(),
+      },
+      content: new Uint8Array(),
+    }
+  }
+
+  decode(content: EncodedContent): ReadReceipt {
+    const timestamp = new Date(content.parameters.timestamp)
+
+    return {
+      timestamp,
+    }
+  }
+}


### PR DESCRIPTION
Initial codec for read receipts. Getting this PR up to test some UI reference implementation work based on this, but will add tests in a later PR.  