### PR TITLE
feat: refactor message content fallback

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -381,10 +381,9 @@ export class ConversationV1 implements Conversation {
     decrypted: Uint8Array,
     topic: string
   ): Promise<DecodedMessage> {
-    const { content, contentType, error } = await decodeContent(
-      decrypted,
-      this.client
-    )
+    const { content, contentType, error, contentFallback } =
+      await decodeContent(decrypted, this.client)
+
     return DecodedMessage.fromV1Message(
       message,
       content,
@@ -392,7 +391,8 @@ export class ConversationV1 implements Conversation {
       decrypted,
       topic,
       this,
-      error
+      error,
+      contentFallback
     )
   }
 
@@ -650,10 +650,8 @@ export class ConversationV2 implements Conversation {
       signed.sender
     ).walletSignatureAddress()
 
-    const { content, contentType, error } = await decodeContent(
-      signed.payload,
-      this.client
-    )
+    const { content, contentType, error, contentFallback } =
+      await decodeContent(signed.payload, this.client)
 
     return DecodedMessage.fromV2Message(
       msg,
@@ -663,7 +661,8 @@ export class ConversationV2 implements Conversation {
       signed.payload,
       this,
       senderAddress,
-      error
+      error,
+      contentFallback
     )
   }
 

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -241,7 +241,8 @@ describe('Message', function () {
         bobClient
       )
       expect(bobRestoredMessage.error).toBeTruthy()
-      expect(bobRestoredMessage.content).toEqual(fallback)
+      expect(bobRestoredMessage.content).toBeUndefined()
+      expect(bobRestoredMessage.contentFallback).toEqual(fallback)
     })
   })
 })

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -453,8 +453,9 @@ describe('conversation', () => {
         'unknown content type xmtp.test/public-key:1.0'
       )
       expect(bobMessage1.contentType).toBeTruthy()
-      expect(bobMessage1.contentType.sameAs(ContentTypeFallback))
-      expect(bobMessage1.content).toBe('this is a public key')
+      expect(bobMessage1.contentType.sameAs(ContentTypeTestKey))
+      expect(bobMessage1.content).toBeUndefined()
+      expect(bobMessage1.contentFallback).toBe('this is a public key')
 
       // both recognize the type
       bob.registerCodec(new TestKeyCodec())
@@ -689,8 +690,9 @@ describe('conversation', () => {
         'unknown content type xmtp.test/public-key:1.0'
       )
       expect(bobMessage1.contentType).toBeTruthy()
-      expect(bobMessage1.contentType.sameAs(ContentTypeFallback))
-      expect(bobMessage1.content).toBe('this is a public key')
+      expect(bobMessage1.contentType.sameAs(ContentTypeTestKey))
+      expect(bobMessage1.content).toBeUndefined()
+      expect(bobMessage1.contentFallback).toBe('this is a public key')
 
       // both recognize the type
       bob.registerCodec(new TestKeyCodec())


### PR DESCRIPTION
BREAKING CHANGE: This changes what the SDK returns for messages without a content codec, potentially breaking implementations that rely on the `ContentTypeFallback` content type.

That being said, we could potentially treat this is a minor bump.

### Why is the current implementation a problem?

There's an ongoing effort in our React SDK to make web apps local first, which means storing conversations and messages in a local DB that is treated as the source of truth. When a client doesn't support a content type, the JS SDK returns a fallback message that doesn't expose the original content type or content. Because of this, it's impossible to re-process messages that contain an unsupported content type without re-querying the network.

With this update, we'll be able to store the original `contentType` in the local DB so that the message can be decoded and processed properly once a client adds support for its content type.