### PR TITLE
Add exports, `conversationVersion`, and `listFromCache`

### DIFF
--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -39,6 +39,7 @@ import { ContentTypeText } from '../codecs/Text'
  * Conversation represents either a V1 or V2 conversation with a common set of methods.
  */
 export interface Conversation {
+  conversationVersion: 'v1' | 'v2'
   /**
    * The wallet address connected to the client
    */
@@ -145,6 +146,7 @@ export interface Conversation {
  * ConversationV1 allows you to view, stream, and send messages to/from a peer address
  */
 export class ConversationV1 implements Conversation {
+  conversationVersion = 'v1' as const
   peerAddress: string
   createdAt: Date
   context = undefined
@@ -418,6 +420,7 @@ export class ConversationV1 implements Conversation {
  * ConversationV2
  */
 export class ConversationV2 implements Conversation {
+  conversationVersion = 'v2' as const
   client: Client
   topic: string
   peerAddress: string

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -64,6 +64,10 @@ export class ConversationCache {
 
     return [...this.conversations]
   }
+
+  list() {
+    return [...this.conversations]
+  }
 }
 
 /**
@@ -89,6 +93,19 @@ export default class Conversations {
       this.listV2Conversations(),
     ])
 
+    const conversations = v1Convos.concat(v2Convos)
+
+    conversations.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    return conversations
+  }
+
+  /**
+   * List all conversations stored in the client cache, which may not include
+   * conversations on the network.
+   */
+  async listFromCache(): Promise<Conversation[]> {
+    const v1Convos = this.v1Cache.list()
+    const v2Convos = await this.getV2ConversationsFromKeystore()
     const conversations = v1Convos.concat(v2Convos)
 
     conversations.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,12 @@ export {
   KeyStoreOptions,
   LegacyOptions,
 } from './Client'
-export { Conversations, Conversation } from './conversations'
+export {
+  Conversations,
+  Conversation,
+  ConversationV1,
+  ConversationV2,
+} from './conversations'
 export {
   CodecRegistry,
   ContentTypeId,

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -31,9 +31,12 @@ describe('conversation', () => {
       const aliceConversation = await alice.conversations.newConversation(
         bob.address
       )
+      expect(aliceConversation.conversationVersion).toBe('v1')
+
       const bobConversation = await bob.conversations.newConversation(
         alice.address
       )
+      expect(bobConversation.conversationVersion).toBe('v1')
 
       const startingMessages = await aliceConversation.messages()
       expect(startingMessages).toHaveLength(0)
@@ -499,6 +502,7 @@ describe('conversation', () => {
       )
 
       const ac = await alice.conversations.newConversation(bob.address)
+      expect(ac.conversationVersion).toBe('v2')
       if (!(ac instanceof ConversationV2)) {
         fail()
       }
@@ -508,6 +512,7 @@ describe('conversation', () => {
       const bcs = await bob.conversations.list()
       expect(bcs).toHaveLength(1)
       const bc = bcs[0]
+      expect(bc.conversationVersion).toBe('v2')
       if (!(bc instanceof ConversationV2)) {
         fail()
       }

--- a/test/conversations/Conversations.test.ts
+++ b/test/conversations/Conversations.test.ts
@@ -49,6 +49,47 @@ describe('conversations', () => {
       expect(bobConversations[0].peerAddress).toBe(alice.address)
     })
 
+    it('lists conversations from cache', async () => {
+      const aliceConversations = await alice.conversations.list()
+      expect(aliceConversations).toHaveLength(0)
+
+      const aliceConversationsFromCache =
+        await alice.conversations.listFromCache()
+      expect(aliceConversationsFromCache).toHaveLength(0)
+
+      const bobConversationsFromCache = await bob.conversations.listFromCache()
+      expect(bobConversationsFromCache).toHaveLength(0)
+
+      const aliceToBob = await alice.conversations.newConversation(bob.address)
+      await aliceToBob.send('gm')
+      await sleep(100)
+
+      expect(await alice.conversations.listFromCache()).toHaveLength(0)
+      expect(await bob.conversations.listFromCache()).toHaveLength(0)
+
+      const aliceConversationsAfterMessage = await alice.conversations.list()
+      expect(aliceConversationsAfterMessage).toHaveLength(1)
+      expect(aliceConversationsAfterMessage[0].peerAddress).toBe(bob.address)
+
+      const aliceConversationsFromCacheAfterMessage =
+        await alice.conversations.listFromCache()
+      expect(aliceConversationsFromCacheAfterMessage).toHaveLength(1)
+      expect(aliceConversationsFromCacheAfterMessage[0].peerAddress).toBe(
+        bob.address
+      )
+
+      const bobConversations = await bob.conversations.list()
+      expect(bobConversations).toHaveLength(1)
+      expect(bobConversations[0].peerAddress).toBe(alice.address)
+
+      const bobConversationsFromCacheAfterMessage =
+        await bob.conversations.listFromCache()
+      expect(bobConversationsFromCacheAfterMessage).toHaveLength(1)
+      expect(bobConversationsFromCacheAfterMessage[0].peerAddress).toBe(
+        alice.address
+      )
+    })
+
     it('resumes list with cache after new conversation is created', async () => {
       const aliceConversations1 = await alice.conversations.list()
       expect(aliceConversations1).toHaveLength(0)


### PR DESCRIPTION
This PR includes QoL changes that expose more internals of the JS SDK.

### Export `ConversationV1` and `ConversationV2` classes

This allows for working with these classes directly.

### Add a hardcoded `conversationVersion` key to conversation classes

This creates an easy way to determine the version of a conversation. This also aligns with the `messageVersion` key we use to determine the version of a message. While we can currently determine a conversation version with `instanceof`, this is just an easier way to check the version without the need for an additional import.

### Add `listFromCache` method to `Conversations`

This new method exposes the conversations stored in the client cache without hitting the XMTP network to check for new conversations. With conversations already stored in the XMTP client, being able to access them directly in this way may help to simplify client applications that would normally store conversations in memory.

Note: `listFromCache` may not be the best name for this method, open to suggestions.