### PR TITLE
Add onConnectionLost callback to all Stream methods

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -240,6 +240,10 @@ export default class ApiClient {
           if (new Date().getTime() - startTime < 1000) {
             await sleep(1000)
           }
+
+          if (onConnectionLost) {
+            onConnectionLost()
+          }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           if (isAbortError(err) || abortController.signal.aborted) {
@@ -249,11 +253,13 @@ export default class ApiClient {
             'Stream connection closed. Resubscribing',
             err.toString()
           )
-          if (onConnectionLost) {
-            onConnectionLost()
-          }
+
           if (new Date().getTime() - startTime < 1000) {
             await sleep(1000)
+          }
+
+          if (onConnectionLost) {
+            onConnectionLost()
           }
         }
       }

--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -241,9 +241,7 @@ export default class ApiClient {
             await sleep(1000)
           }
 
-          if (onConnectionLost) {
-            onConnectionLost()
-          }
+          onConnectionLost?.()
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           if (isAbortError(err) || abortController.signal.aborted) {
@@ -258,9 +256,7 @@ export default class ApiClient {
             await sleep(1000)
           }
 
-          if (onConnectionLost) {
-            onConnectionLost()
-          }
+          onConnectionLost?.()
         }
       }
     }

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -25,21 +25,21 @@ export default class Stream<T> {
 
   unsubscribeFn?: UnsubscribeFn
 
-  onConnectionLostCallback?: OnConnectionLostCallback
+  onConnectionLost?: OnConnectionLostCallback
 
   constructor(
     client: Client,
     topics: string[],
     decoder: MessageDecoder<T>,
     contentTopicUpdater?: ContentTopicUpdater<T>,
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ) {
     this.messages = []
     this.resolvers = []
     this.topics = topics
     this.client = client
     this.callback = this.newMessageCallback(decoder, contentTopicUpdater)
-    this.onConnectionLostCallback = onConnectionLostCallback
+    this.onConnectionLost = onConnectionLost
   }
 
   // returns new closure to handle incoming messages
@@ -92,7 +92,7 @@ export default class Stream<T> {
         if (!this.callback) return
         await this?.callback(env)
       },
-      this.onConnectionLostCallback
+      this.onConnectionLost
     )
   }
 
@@ -101,14 +101,14 @@ export default class Stream<T> {
     topics: string[],
     decoder: MessageDecoder<T>,
     contentTopicUpdater?: ContentTopicUpdater<T>,
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<T>> {
     const stream = new Stream(
       client,
       topics,
       decoder,
       contentTopicUpdater,
-      onConnectionLostCallback
+      onConnectionLost
     )
     await stream.start()
     return stream
@@ -169,7 +169,7 @@ export default class Stream<T> {
         if (!this.callback) return
         await this?.callback(env)
       },
-      this.onConnectionLostCallback
+      this.onConnectionLost
     )
   }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -265,14 +265,14 @@ export class ConversationV1 implements Conversation {
    * Returns a Stream of any new messages to/from the peerAddress
    */
   streamMessages(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.topic],
       async (env: messageApi.Envelope) => this.decodeMessage(env),
       undefined,
-      onConnectionLostCallback
+      onConnectionLost
     )
   }
 
@@ -298,14 +298,14 @@ export class ConversationV1 implements Conversation {
   }
 
   streamEphemeral(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
       undefined,
-      onConnectionLostCallback
+      onConnectionLost
     )
   }
 
@@ -483,14 +483,14 @@ export class ConversationV2 implements Conversation {
   }
 
   streamEphemeral(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
       undefined,
-      onConnectionLostCallback
+      onConnectionLost
     )
   }
 
@@ -498,14 +498,14 @@ export class ConversationV2 implements Conversation {
    * Returns a Stream of any new messages to/from the peerAddress
    */
   streamMessages(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.topic],
       this.decodeMessage.bind(this),
       undefined,
-      onConnectionLostCallback
+      onConnectionLost
     )
   }
 

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -1,3 +1,4 @@
+import { OnConnectionLostCallback } from './../ApiClient'
 import {
   buildUserIntroTopic,
   buildDirectMessageTopic,
@@ -32,6 +33,7 @@ import { PreparedMessage } from '../PreparedMessage'
 import { sha256 } from '../crypto/encryption'
 import { buildDecryptV1Request, getResultOrThrow } from '../utils/keystore'
 import { ContentTypeText } from '../codecs/Text'
+import { OnceBlockable } from 'ethers/lib/utils'
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
@@ -262,11 +264,15 @@ export class ConversationV1 implements Conversation {
   /**
    * Returns a Stream of any new messages to/from the peerAddress
    */
-  streamMessages(): Promise<Stream<DecodedMessage>> {
+  streamMessages(
+    onConnectionLostCallback?: OnConnectionLostCallback
+  ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.topic],
-      async (env: messageApi.Envelope) => this.decodeMessage(env)
+      async (env: messageApi.Envelope) => this.decodeMessage(env),
+      undefined,
+      onConnectionLostCallback
     )
   }
 
@@ -291,11 +297,15 @@ export class ConversationV1 implements Conversation {
     return decoded
   }
 
-  streamEphemeral(): Promise<Stream<DecodedMessage>> {
+  streamEphemeral(
+    onConnectionLostCallback?: OnConnectionLostCallback
+  ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.ephemeralTopic],
-      this.decodeMessage.bind(this)
+      this.decodeMessage.bind(this),
+      undefined,
+      onConnectionLostCallback
     )
   }
 
@@ -472,22 +482,30 @@ export class ConversationV2 implements Conversation {
     return this.topic.replace('/xmtp/0/m', '/xmtp/0/mE')
   }
 
-  streamEphemeral(): Promise<Stream<DecodedMessage>> {
+  streamEphemeral(
+    onConnectionLostCallback?: OnConnectionLostCallback
+  ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.ephemeralTopic],
-      this.decodeMessage.bind(this)
+      this.decodeMessage.bind(this),
+      undefined,
+      onConnectionLostCallback
     )
   }
 
   /**
    * Returns a Stream of any new messages to/from the peerAddress
    */
-  streamMessages(): Promise<Stream<DecodedMessage>> {
+  streamMessages(
+    onConnectionLostCallback?: OnConnectionLostCallback
+  ): Promise<Stream<DecodedMessage>> {
     return Stream.create<DecodedMessage>(
       this.client,
       [this.topic],
-      this.decodeMessage.bind(this)
+      this.decodeMessage.bind(this),
+      undefined,
+      onConnectionLostCallback
     )
   }
 

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -240,7 +240,7 @@ export default class Conversations {
    * Does not dedupe any other previously seen conversations
    */
   async stream(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<Stream<Conversation>> {
     const seenPeers: Set<string> = new Set()
     const introTopic = buildUserIntroTopic(this.client.address)
@@ -280,7 +280,7 @@ export default class Conversations {
       [inviteTopic, introTopic],
       decodeConversation.bind(this),
       undefined,
-      onConnectionLostCallback
+      onConnectionLost
     )
   }
 
@@ -292,7 +292,7 @@ export default class Conversations {
    *
    */
   async streamAllMessages(
-    onConnectionLostCallback?: OnConnectionLostCallback
+    onConnectionLost?: OnConnectionLostCallback
   ): Promise<AsyncGenerator<DecodedMessage>> {
     const introTopic = buildUserIntroTopic(this.client.address)
     const inviteTopic = buildUserInviteTopic(this.client.address)
@@ -394,7 +394,7 @@ export default class Conversations {
       Array.from(topics.values()),
       decodeMessage,
       contentTopicUpdater,
-      onConnectionLostCallback
+      onConnectionLost
     )
 
     return (async function* generate() {

--- a/test/ApiClient.test.ts
+++ b/test/ApiClient.test.ts
@@ -295,10 +295,15 @@ describe('Subscribe', () => {
     const cb = (env: messageApi.Envelope) => {
       numEnvelopes++
     }
+    let numDisconnects = 0
+    let onDisconnect = () => {
+      numDisconnects++
+    }
     const req = { contentTopics: [CONTENT_TOPIC] }
-    const unsubscribeFn = client.subscribe(req, cb)
+    const unsubscribeFn = client.subscribe(req, cb, onDisconnect)
     await sleep(1200)
     expect(numEnvelopes).toBe(2)
+    expect(numDisconnects).toBe(1)
     // Resubscribing triggers an info log
     expect(consoleInfo).toBeCalledTimes(1)
     expect(subscribeMock).toBeCalledTimes(2)


### PR DESCRIPTION
## Summary

- Adds an optional onConnectionLost callback to all streaming methods to allow for callers to be notified when the stream is reconnecting. This can be used to fill in gaps in their message history.

## Fixes
https://github.com/xmtp/xmtp-js/issues/427