### PR TITLE
Pluggable persistence

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,6 +32,7 @@ import {
   NetworkKeystoreProvider,
   StaticKeystoreProvider,
 } from './keystore/providers'
+import { LocalStoragePersistence, Persistence } from './keystore/persistence'
 const { Compression } = proto
 const { b64Decode } = fetcher
 
@@ -144,6 +145,17 @@ export type KeyStoreOptions = {
    * A bundle can be retried using `Client.getKeys(...)`
    */
   privateKeyOverride?: Uint8Array
+
+  /**
+   * Override the base persistence provider.
+   * Defaults to LocalStoragePersistence, which is fine for most implementations
+   */
+  basePersistence: Persistence
+  /**
+   * Whether or not the persistence provider should encrypt the values.
+   * Only disable if you are using a secure datastore that already has encryption
+   */
+  disablePersistenceEncryption: boolean
 }
 
 export type LegacyOptions = {
@@ -195,10 +207,13 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
     maxContentSize: MaxContentSize,
     persistConversations: true,
     skipContactPublishing: false,
+    basePersistence: new LocalStoragePersistence(),
+    disablePersistenceEncryption: false,
     keystoreProviders: defaultKeystoreProviders(),
     apiClientFactory: (options: NetworkOptions) =>
       createApiClientFromOptions(options),
   }
+
   if (opts?.codecs) {
     opts.codecs = _defaultOptions.codecs.concat(opts.codecs)
   }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,11 +32,7 @@ import {
   NetworkKeystoreProvider,
   StaticKeystoreProvider,
 } from './keystore/providers'
-import {
-  LocalStoragePersistence,
-  Persistence,
-  PrefixedPersistence,
-} from './keystore/persistence'
+import { LocalStoragePersistence, Persistence } from './keystore/persistence'
 const { Compression } = proto
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -233,7 +233,6 @@ export default class Client {
   apiClient: ApiClient
   contacts: Set<string> // address which we have connected to
   publicKeyBundle: PublicKeyBundle
-  persistence: Persistence
   private knownPublicKeyBundles: Map<
     string,
     PublicKeyBundle | SignedPublicKeyBundle
@@ -249,8 +248,7 @@ export default class Client {
     publicKeyBundle: PublicKeyBundle,
     apiClient: ApiClient,
     backupClient: BackupClient,
-    keystore: Keystore,
-    persistence: Persistence
+    keystore: Keystore
   ) {
     this.contacts = new Set<string>()
     this.knownPublicKeyBundles = new Map<
@@ -261,7 +259,6 @@ export default class Client {
     this.keystore = keystore
     this.publicKeyBundle = publicKeyBundle
     this.address = publicKeyBundle.walletSignatureAddress()
-    this.persistence = persistence
     this._conversations = new Conversations(this)
     this._codecs = new Map()
     this._maxContentSize = MaxContentSize
@@ -303,16 +300,11 @@ export default class Client {
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
-    const persistence = new PrefixedPersistence(
-      `xmtp/${options.env}/${address}/`,
-      options.basePersistence
-    )
     const client = new Client(
       publicKeyBundle,
       apiClient,
       backupClient,
-      keystore,
-      persistence
+      keystore
     )
     await client.init(options)
     return client

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -32,7 +32,11 @@ import {
   NetworkKeystoreProvider,
   StaticKeystoreProvider,
 } from './keystore/providers'
-import { LocalStoragePersistence, Persistence } from './keystore/persistence'
+import {
+  LocalStoragePersistence,
+  Persistence,
+  PrefixedPersistence,
+} from './keystore/persistence'
 const { Compression } = proto
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types
@@ -229,6 +233,7 @@ export default class Client {
   apiClient: ApiClient
   contacts: Set<string> // address which we have connected to
   publicKeyBundle: PublicKeyBundle
+  persistence: Persistence
   private knownPublicKeyBundles: Map<
     string,
     PublicKeyBundle | SignedPublicKeyBundle
@@ -244,7 +249,8 @@ export default class Client {
     publicKeyBundle: PublicKeyBundle,
     apiClient: ApiClient,
     backupClient: BackupClient,
-    keystore: Keystore
+    keystore: Keystore,
+    persistence: Persistence
   ) {
     this.contacts = new Set<string>()
     this.knownPublicKeyBundles = new Map<
@@ -255,6 +261,7 @@ export default class Client {
     this.keystore = keystore
     this.publicKeyBundle = publicKeyBundle
     this.address = publicKeyBundle.walletSignatureAddress()
+    this.persistence = persistence
     this._conversations = new Conversations(this)
     this._codecs = new Map()
     this._maxContentSize = MaxContentSize
@@ -296,11 +303,16 @@ export default class Client {
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
+    const persistence = new PrefixedPersistence(
+      `xmtp/${options.env}/${address}/`,
+      options.basePersistence
+    )
     const client = new Client(
       publicKeyBundle,
       apiClient,
       backupClient,
-      keystore
+      keystore,
+      persistence
     )
     await client.init(options)
     return client

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export {
   SignedPublicKeyBundle,
   PrivateKey,
   PrivateKeyBundle,
+  PrivateKeyBundleV1,
+  PrivateKeyBundleV2,
   Signature,
   encrypt,
   decrypt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Authenticator } from './authn/interfaces'
 export {
   Message,
   DecodedMessage,
@@ -73,10 +72,11 @@ export {
   UnsubscribeFn,
   OnConnectionLostCallback,
 } from './ApiClient'
-export { Authenticator, AuthCache } from './authn'
+export { Authenticator, AuthCache, LocalAuthenticator } from './authn'
 export {
   nsToDate,
   dateToNs,
+  retry,
   fromNanoString,
   toNanoString,
   mapPaginatedStream,

--- a/src/keystore/providers/helpers.ts
+++ b/src/keystore/providers/helpers.ts
@@ -1,10 +1,6 @@
 import { PrivateKeyBundleV2 } from './../../crypto/PrivateKeyBundle'
 import { PrivateKeyBundleV1 } from '../../crypto/PrivateKeyBundle'
-import {
-  EncryptedPersistence,
-  LocalStoragePersistence,
-  PrefixedPersistence,
-} from '../persistence'
+import { EncryptedPersistence, PrefixedPersistence } from '../persistence'
 import { KeystoreProviderOptions } from './interfaces'
 
 export const buildPersistenceFromOptions = async (
@@ -16,9 +12,13 @@ export const buildPersistenceFromOptions = async (
   }
   const address = await keys.identityKey.publicKey.walletSignatureAddress()
   const prefix = `xmtp/${opts.env}/${address}/`
+  const basePersistence = opts.basePersistence
+  const shouldEncrypt = !opts.disablePersistenceEncryption
 
   return new PrefixedPersistence(
     prefix,
-    new EncryptedPersistence(new LocalStoragePersistence(), keys.identityKey)
+    shouldEncrypt
+      ? new EncryptedPersistence(basePersistence, keys.identityKey)
+      : basePersistence
   )
 }

--- a/src/keystore/providers/interfaces.ts
+++ b/src/keystore/providers/interfaces.ts
@@ -2,11 +2,14 @@ import type { XmtpEnv, PreEventCallbackOptions } from '../../Client'
 import type { Signer } from '../../types/Signer'
 import type { Keystore } from '../interfaces'
 import type { IApiClient } from '../../ApiClient'
+import { Persistence } from '../persistence'
 
 export type KeystoreProviderOptions = {
   env: XmtpEnv
   persistConversations: boolean
   privateKeyOverride?: Uint8Array
+  basePersistence: Persistence
+  disablePersistenceEncryption: boolean
 } & PreEventCallbackOptions
 
 /**

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -8,7 +8,13 @@ import {
 } from './helpers'
 import { buildUserContactTopic } from '../src/utils'
 import Client, { ClientOptions } from '../src/Client'
-import { ApiUrls, Compression, HttpApiClient, PublishParams } from '../src'
+import {
+  ApiUrls,
+  Compression,
+  HttpApiClient,
+  LocalStoragePersistence,
+  PublishParams,
+} from '../src'
 import NetworkKeyManager from '../src/keystore/providers/NetworkKeyManager'
 import TopicPersistence from '../src/keystore/persistence/TopicPersistence'
 import { PrivateKeyBundleV1 } from '../src/crypto'
@@ -334,6 +340,21 @@ describe('ClientOptions', () => {
         },
       })
       expect(c).rejects.toThrow(expectedError)
+    })
+  })
+
+  describe('pluggable persistence', () => {
+    it('allows for an override of the persistence engine', async () => {
+      class MyNewPersistence extends LocalStoragePersistence {
+        async getItem(key: string): Promise<Uint8Array | null> {
+          throw new Error('MyNewPersistence')
+        }
+      }
+
+      const c = newLocalHostClient({
+        basePersistence: new MyNewPersistence(),
+      })
+      expect(c).rejects.toThrow('MyNewPersistence')
     })
   })
 })

--- a/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
+++ b/test/keystore/providers/KeyGeneratorKeystoreProvider.test.ts
@@ -18,7 +18,7 @@ describe('KeyGeneratorKeystoreProvider', () => {
   it('creates a key when wallet supplied', async () => {
     const provider = new KeyGeneratorKeystoreProvider()
     const keystore = await provider.newKeystore(
-      testProviderOptions(),
+      testProviderOptions({}),
       apiClient,
       wallet
     )
@@ -28,7 +28,7 @@ describe('KeyGeneratorKeystoreProvider', () => {
   it('throws KeystoreProviderUnavailableError when no wallet supplied', async () => {
     const provider = new KeyGeneratorKeystoreProvider()
     const prom = provider.newKeystore(
-      testProviderOptions(),
+      testProviderOptions({}),
       apiClient,
       undefined
     )
@@ -39,7 +39,7 @@ describe('KeyGeneratorKeystoreProvider', () => {
     const provider = new KeyGeneratorKeystoreProvider()
     const preCreateIdentityCallback = jest.fn()
     const keystore = await provider.newKeystore(
-      { ...testProviderOptions(), preCreateIdentityCallback },
+      { ...testProviderOptions({}), preCreateIdentityCallback },
       apiClient,
       wallet
     )
@@ -51,7 +51,7 @@ describe('KeyGeneratorKeystoreProvider', () => {
     const provider = new KeyGeneratorKeystoreProvider()
     const preEnableIdentityCallback = jest.fn()
     const keystore = await provider.newKeystore(
-      { ...testProviderOptions(), preEnableIdentityCallback },
+      { ...testProviderOptions({}), preEnableIdentityCallback },
       apiClient,
       wallet
     )

--- a/test/keystore/providers/NetworkKeyManager.test.ts
+++ b/test/keystore/providers/NetworkKeyManager.test.ts
@@ -6,6 +6,7 @@ import { buildPersistenceFromOptions } from '../../../src/keystore/providers/hel
 import NetworkKeyManager from '../../../src/keystore/providers/NetworkKeyManager'
 import { Signer } from '../../../src/types/Signer'
 import { newWallet, pollFor, sleep, wrapAsLedgerWallet } from '../../helpers'
+import { testProviderOptions } from './helpers'
 
 describe('NetworkKeyManager', () => {
   let wallet: Signer
@@ -100,13 +101,13 @@ describe('NetworkKeyManager', () => {
   it('respects the options provided', async () => {
     const bundle = await PrivateKeyBundleV1.generate(wallet)
     const shouldBeUndefined = await buildPersistenceFromOptions(
-      { persistConversations: false, env: 'local' },
+      testProviderOptions({ persistConversations: false }),
       bundle
     )
     expect(shouldBeUndefined).toBeUndefined()
 
     const shouldBeDefined = await buildPersistenceFromOptions(
-      { persistConversations: true, env: 'local' },
+      testProviderOptions({ persistConversations: true }),
       bundle
     )
     expect(shouldBeDefined).toBeInstanceOf(PrefixedPersistence)

--- a/test/keystore/providers/NetworkKeystoreProvider.test.ts
+++ b/test/keystore/providers/NetworkKeystoreProvider.test.ts
@@ -28,7 +28,7 @@ describe('NetworkKeystoreProvider', () => {
   it('fails gracefully when no keys are found', async () => {
     const provider = new NetworkKeystoreProvider()
     expect(
-      provider.newKeystore(testProviderOptions(), apiClient, wallet)
+      provider.newKeystore(testProviderOptions({}), apiClient, wallet)
     ).rejects.toThrow(KeystoreProviderUnavailableError)
   })
 
@@ -41,7 +41,7 @@ describe('NetworkKeystoreProvider', () => {
 
     const provider = new NetworkKeystoreProvider()
     const keystore = await provider.newKeystore(
-      testProviderOptions(),
+      testProviderOptions({}),
       apiClient,
       wallet
     )
@@ -74,7 +74,7 @@ describe('NetworkKeystoreProvider', () => {
     // Now try and load it
     const provider = new NetworkKeystoreProvider()
     const keystore = await provider.newKeystore(
-      testProviderOptions(),
+      testProviderOptions({}),
       apiClient,
       wallet
     )
@@ -91,7 +91,7 @@ describe('NetworkKeystoreProvider', () => {
     const provider = new NetworkKeystoreProvider()
     const mockNotifier = jest.fn()
     await provider.newKeystore(
-      { ...testProviderOptions(), preEnableIdentityCallback: mockNotifier },
+      { ...testProviderOptions({}), preEnableIdentityCallback: mockNotifier },
       apiClient,
       wallet
     )

--- a/test/keystore/providers/StaticKeystoreProvider.test.ts
+++ b/test/keystore/providers/StaticKeystoreProvider.test.ts
@@ -1,6 +1,7 @@
 import { privateKey } from '@xmtp/proto'
 import { PrivateKeyBundleV1 } from '../../../src/crypto'
 import { newWallet } from '../../helpers'
+import { testProviderOptions } from './helpers'
 import StaticKeystoreProvider from '../../../src/keystore/providers/StaticKeystoreProvider'
 import { KeystoreProviderUnavailableError } from '../../../src/keystore/providers/errors'
 
@@ -14,31 +15,37 @@ describe('StaticKeystoreProvider', () => {
       v2: undefined,
     }).finish()
     const provider = new StaticKeystoreProvider()
-    const keystore = await provider.newKeystore({
-      privateKeyOverride: keyBytes,
-      env: ENV,
-      persistConversations: false,
-    })
+    const keystore = await provider.newKeystore(
+      testProviderOptions({
+        privateKeyOverride: keyBytes,
+        env: ENV,
+        persistConversations: false,
+      })
+    )
 
     expect(keystore).not.toBeNull()
   })
 
   it('throws with an unset key', async () => {
     expect(
-      new StaticKeystoreProvider().newKeystore({
-        env: ENV,
-        persistConversations: false,
-      })
+      new StaticKeystoreProvider().newKeystore(
+        testProviderOptions({
+          env: ENV,
+          persistConversations: false,
+        })
+      )
     ).rejects.toThrow(KeystoreProviderUnavailableError)
   })
 
   it('fails with an invalid key', async () => {
     expect(
-      new StaticKeystoreProvider().newKeystore({
-        privateKeyOverride: Uint8Array.from([1, 2, 3]),
-        env: ENV,
-        persistConversations: false,
-      })
+      new StaticKeystoreProvider().newKeystore(
+        testProviderOptions({
+          privateKeyOverride: Uint8Array.from([1, 2, 3]),
+          env: ENV,
+          persistConversations: false,
+        })
+      )
     ).rejects.toThrow()
   })
 })

--- a/test/keystore/providers/helpers.ts
+++ b/test/keystore/providers/helpers.ts
@@ -1,11 +1,13 @@
 import { LocalStoragePersistence } from '../../../src'
+import { KeystoreProviderOptions } from '../../../src/keystore/providers'
 
-export const testProviderOptions = (
+export const testProviderOptions = ({
   privateKeyOverride = undefined,
   persistConversations = false,
-  basePersistence = new LocalStoragePersistence()
-) => ({
-  env: 'local' as const,
+  basePersistence = new LocalStoragePersistence(),
+  env = 'local' as const,
+}: Partial<KeystoreProviderOptions>) => ({
+  env,
   persistConversations,
   privateKeyOverride,
   basePersistence,

--- a/test/keystore/providers/helpers.ts
+++ b/test/keystore/providers/helpers.ts
@@ -1,8 +1,13 @@
+import { LocalStoragePersistence } from '../../../src'
+
 export const testProviderOptions = (
   privateKeyOverride = undefined,
-  persistConversations = false
+  persistConversations = false,
+  basePersistence = new LocalStoragePersistence()
 ) => ({
   env: 'local' as const,
   persistConversations,
   privateKeyOverride,
+  basePersistence,
+  disablePersistenceEncryption: false,
 })


### PR DESCRIPTION
## Summary

- Allow for users of our SDK to provide alternative persistence engines for storing conversation keys. For example, a server-side app might want to store conversations on the filesystem or in a database.