### PR TITLE
Better MetaMask feature detection

### DIFF
--- a/src/keystore/snapHelpers.ts
+++ b/src/keystore/snapHelpers.ts
@@ -89,6 +89,17 @@ export type GetSnapsResponse = Record<string, Snap>
 // Inspired by https://github.com/Montoya/snap-connect-test/blob/main/index.html
 export async function hasMetamaskWithSnaps() {
   const ethereum = getEthereum()
+  // Naive way of detecting snaps support
+  if (ethereum?.isMetaMask) {
+    try {
+      await ethereum.request({
+        method: 'wallet_getSnaps',
+      })
+      return true
+    } catch {
+      // no-op
+    }
+  }
   if (
     typeof ethereum?.detected !== 'undefined' &&
     Array.isArray(ethereum.detected)


### PR DESCRIPTION
## Summary

I was following the [guide put out by the MetaMask team here](https://github.com/Montoya/snap-connect-test/blob/main/index.html) for how to detect support for MetaMask Snaps. Unfortunately, it doesn't seem to work for MetaMask Flask (to be seen if it will work for the publicly released version) now that I've been testing this in a real browser.

The more naive approach below does work, so I am going to leave it with both for now. Will consult with the MetaMask team on what the real best practices are.