### PR TITLE
fix: release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - name: Use latest NPM
-        # Ensure we are using the latest version of NPM to get support for provenance
-        run: npm i -g npm
       - name: Install dependencies
         run: npm ci
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -559,7 +559,10 @@ describe('InMemoryKeystore', () => {
           )
         ).v1!
       )
-      bobKeystore = await InMemoryKeystore.create(bobKeys)
+      bobKeystore = await InMemoryKeystore.create(
+        bobKeys,
+        InMemoryPersistence.create()
+      )
 
       expect(await aliceKeystore.getAccountAddress()).toEqual(
         '0xF56d1F3b1290204441Cb3843C2Cac1C2f5AEd690'


### PR DESCRIPTION
we shouldn't be upgrading NPM node 18.14 should come with npm 9

failures here: https://github.com/xmtp/xmtp-js/actions/runs/6043549180