### PR TITLE
Strongly typed client

### DIFF
--- a/bench/encode.ts
+++ b/bench/encode.ts
@@ -17,7 +17,7 @@ const encodeV1 = () => {
       const alice = await Client.create(newWallet(), { env: 'local' })
       const bobKeys = (await newPrivateKeyBundle()).getPublicKeyBundle()
 
-      const message = randomBytes(size)
+      const message = randomBytes(size).toString()
       const timestamp = new Date()
 
       // The returned function is the actual benchmark. Everything above is setup

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -246,6 +246,7 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
  * Client class initiates connection to the XMTP network.
  * Should be created with `await Client.create(options)`
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default class Client<T = any> {
   address: string
   keystore: Keystore
@@ -319,7 +320,7 @@ export default class Client<T = any> {
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
-    const client = new Client<ExtractDecodedType<[...U, TextCodec][number]>>(
+    const client = new Client(
       publicKeyBundle,
       apiClient,
       backupClient,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -307,6 +307,8 @@ export default class Client<T = any> {
    * @param wallet the wallet as a Signer instance
    * @param opts specify how to to connect to the network
    */
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async create<U extends ContentCodec<any>[]>(
     wallet: Signer | null,
     opts?: Partial<ClientOptions> & { codecs?: U }
@@ -745,8 +747,6 @@ export default class Client<T = any> {
     )
   }
 }
-
-export type AnyClient = Client<ContentCodec<any>[]>
 
 function createHttpApiClientFromOptions(options: NetworkOptions): ApiClient {
   const apiUrl = options.apiUrl || ApiUrls[options.env]

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -41,7 +41,6 @@ import {
 } from './keystore/persistence'
 import { hasMetamaskWithSnaps } from './keystore/snapHelpers'
 import { version as snapVersion, package as snapPackage } from './snapInfo.json'
-import { CompositeCodec } from './codecs/Composite'
 const { Compression } = proto
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -41,6 +41,7 @@ import {
 } from './keystore/persistence'
 import { hasMetamaskWithSnaps } from './keystore/snapHelpers'
 import { version as snapVersion, package as snapPackage } from './snapInfo.json'
+import { ExtractDecodedType } from './types/client'
 const { Compression } = proto
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types
@@ -203,8 +204,6 @@ export type ClientOptions = Flatten<
     PreEventCallbackOptions
 >
 
-export type ExtractDecodedType<C> = C extends ContentCodec<infer T> ? T : never
-
 /**
  * Provide a default client configuration. These settings can be used on their own, or as a starting point for custom configurations
  *
@@ -308,6 +307,7 @@ export default class Client<T = any> {
    * @param opts specify how to to connect to the network
    */
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async create<U extends ContentCodec<any>[] = []>(
     wallet: Signer | null,
     opts?: Partial<ClientOptions> & { codecs?: U }
@@ -600,10 +600,13 @@ export default class Client<T = any> {
    * messages of the given Content Type
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  registerCodec(codec: ContentCodec<any>): void {
+  registerCodec<Codec extends ContentCodec<any>>(
+    codec: Codec
+  ): Client<T | ExtractDecodedType<Codec>> {
     const id = codec.contentType
     const key = `${id.authorityId}/${id.typeId}`
     this._codecs.set(key, codec)
+    return this
   }
 
   /**
@@ -862,5 +865,3 @@ async function bootstrapKeystore(
   }
   throw new Error('No keystore providers available')
 }
-
-export type ClientReturnType<C> = C extends Client<infer T> ? T : never

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -865,20 +865,3 @@ async function bootstrapKeystore(
 }
 
 export type ClientReturnType<C> = C extends Client<infer T> ? T : never
-
-// async function stronglyTypedClient() {
-//   const c = await Client.create(null, {
-//     codecs: [new CompositeCodec(), new TextCodec()],
-//   })
-
-//   const convos = await c.conversations.list()
-//   convos[0].send('hello')
-//   convos[0].send(123)
-
-//   for await (const msg of await convos[0].streamMessages()) {
-//     // Let's see what content type this is?
-//     //
-//     //
-//     console.log(msg.content)
-//   }
-// }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -308,8 +308,7 @@ export default class Client<T = any> {
    * @param opts specify how to to connect to the network
    */
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  static async create<U extends ContentCodec<any>[]>(
+  static async create<U extends ContentCodec<any>[] = []>(
     wallet: Signer | null,
     opts?: Partial<ClientOptions> & { codecs?: U }
   ): Promise<Client<ExtractDecodedType<[...U, TextCodec][number]>>> {
@@ -322,7 +321,7 @@ export default class Client<T = any> {
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
-    const client = new Client(
+    const client = new Client<ExtractDecodedType<[...U, TextCodec][number]>>(
       publicKeyBundle,
       apiClient,
       backupClient,

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -311,7 +311,9 @@ export default class Client<T = any> {
   static async create<U extends ContentCodec<any>[] = []>(
     wallet: Signer | null,
     opts?: Partial<ClientOptions> & { codecs?: U }
-  ): Promise<Client<ExtractDecodedType<[...U, TextCodec][number]>>> {
+  ): Promise<
+    Client<ExtractDecodedType<[...U, TextCodec][number]> | undefined>
+  > {
     const options = defaultOptions(opts)
     const apiClient = options.apiClientFactory(options)
     const keystore = await bootstrapKeystore(options, apiClient, wallet)
@@ -321,12 +323,9 @@ export default class Client<T = any> {
     const address = publicKeyBundle.walletSignatureAddress()
     apiClient.setAuthenticator(new KeystoreAuthenticator(keystore))
     const backupClient = await Client.setupBackupClient(address, options.env)
-    const client = new Client<ExtractDecodedType<[...U, TextCodec][number]>>(
-      publicKeyBundle,
-      apiClient,
-      backupClient,
-      keystore
-    )
+    const client = new Client<
+      ExtractDecodedType<[...U, TextCodec][number]> | undefined
+    >(publicKeyBundle, apiClient, backupClient, keystore)
     await client.init(options)
     return client
   }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -220,7 +220,7 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
 
 export type Message = MessageV1 | MessageV2
 
-export class DecodedMessage<T = unknown> {
+export class DecodedMessage<T = any> {
   id: string
   messageVersion: 'v1' | 'v2'
   senderAddress: string

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -14,7 +14,7 @@ import { ContentTypeId } from './MessageContent'
 import { dateToNs, nsToDate } from './utils'
 import { Keystore } from './keystore'
 import { buildDecryptV1Request, getResultOrThrow } from './utils/keystore'
-import { ClientReturnType } from './Client'
+import { GetMessageContentTypeFromClient } from './types/client'
 
 const headerBytesAndCiphertext = (
   msg: proto.Message
@@ -279,7 +279,7 @@ export class DecodedMessage<T = any> {
   static async fromBytes<T>(
     data: Uint8Array,
     client: Client<T>
-  ): Promise<DecodedMessage<ClientReturnType<typeof client>>> {
+  ): Promise<DecodedMessage<T>> {
     const protoVal = proto.DecodedMessage.decode(data)
     const messageVersion = protoVal.messageVersion
 
@@ -342,7 +342,7 @@ export class DecodedMessage<T = any> {
 
   static fromV2Message<T>(
     message: MessageV2,
-    content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    content: T,
     contentType: ContentTypeId,
     contentTopic: string,
     contentBytes: Uint8Array,
@@ -372,7 +372,7 @@ export class DecodedMessage<T = any> {
 function conversationReferenceToConversation<T>(
   reference: conversationReference.ConversationReference,
   client: Client<T>,
-  version: DecodedMessage<ClientReturnType<typeof client>>['messageVersion']
+  version: DecodedMessage['messageVersion']
 ): Conversation<T> {
   if (version === 'v1') {
     return new ConversationV1(

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -230,7 +230,7 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
 
 export type Message = MessageV1 | MessageV2
 
-export class DecodedMessage<T> {
+export class DecodedMessage<T = unknown> {
   id: string
   messageVersion: 'v1' | 'v2'
   senderAddress: string

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -391,3 +391,7 @@ function conversationReferenceToConversation<T>(
   }
   throw new Error(`Unknown conversation version ${version}`)
 }
+
+export function decodeContent<T>(contentBytes: Uint8Array, client: Client<T>) {
+  return client.decodeContent(contentBytes)
+}

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -220,6 +220,7 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
 
 export type Message = MessageV1 | MessageV2
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class DecodedMessage<T = any> {
   id: string
   messageVersion: 'v1' | 'v2'

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -14,7 +14,6 @@ import { ContentTypeId } from './MessageContent'
 import { dateToNs, nsToDate } from './utils'
 import { Keystore } from './keystore'
 import { buildDecryptV1Request, getResultOrThrow } from './utils/keystore'
-import { GetMessageContentTypeFromClient } from './types/client'
 
 const headerBytesAndCiphertext = (
   msg: proto.Message

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -221,16 +221,16 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
 export type Message = MessageV1 | MessageV2
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class DecodedMessage<T = any> {
+export class DecodedMessage<ContentTypes = any> {
   id: string
   messageVersion: 'v1' | 'v2'
   senderAddress: string
   recipientAddress?: string
   sent: Date
   contentTopic: string
-  conversation: Conversation<T>
+  conversation: Conversation<ContentTypes>
   contentType: ContentTypeId
-  content: T // eslint-disable-line @typescript-eslint/no-explicit-any
+  content: ContentTypes
   error?: Error
   contentBytes: Uint8Array
   contentFallback?: string
@@ -248,7 +248,7 @@ export class DecodedMessage<T = any> {
     sent,
     error,
     contentFallback,
-  }: Omit<DecodedMessage<T>, 'toBytes'>) {
+  }: Omit<DecodedMessage<ContentTypes>, 'toBytes'>) {
     this.id = id
     this.messageVersion = messageVersion
     this.senderAddress = senderAddress
@@ -276,10 +276,10 @@ export class DecodedMessage<T = any> {
     }).finish()
   }
 
-  static async fromBytes<T>(
+  static async fromBytes<ContentTypes>(
     data: Uint8Array,
-    client: Client<T>
-  ): Promise<DecodedMessage<T>> {
+    client: Client<ContentTypes>
+  ): Promise<DecodedMessage<ContentTypes>> {
     const protoVal = proto.DecodedMessage.decode(data)
     const messageVersion = protoVal.messageVersion
 
@@ -310,16 +310,16 @@ export class DecodedMessage<T = any> {
     })
   }
 
-  static fromV1Message<T>(
+  static fromV1Message<ContentTypes>(
     message: MessageV1,
-    content: T, // eslint-disable-line @typescript-eslint/no-explicit-any
+    content: ContentTypes,
     contentType: ContentTypeId,
     contentBytes: Uint8Array,
     contentTopic: string,
-    conversation: Conversation<T>,
+    conversation: Conversation<ContentTypes>,
     error?: Error,
     contentFallback?: string
-  ): DecodedMessage<typeof content> {
+  ): DecodedMessage<ContentTypes> {
     const { id, senderAddress, recipientAddress, sent } = message
     if (!senderAddress) {
       throw new Error('Sender address is required')
@@ -340,17 +340,17 @@ export class DecodedMessage<T = any> {
     })
   }
 
-  static fromV2Message<T>(
+  static fromV2Message<ContentTypes>(
     message: MessageV2,
-    content: T,
+    content: ContentTypes,
     contentType: ContentTypeId,
     contentTopic: string,
     contentBytes: Uint8Array,
-    conversation: Conversation<T>,
+    conversation: Conversation<ContentTypes>,
     senderAddress: string,
     error?: Error,
     contentFallback?: string
-  ): DecodedMessage<typeof content> {
+  ): DecodedMessage<ContentTypes> {
     const { id, sent } = message
 
     return new DecodedMessage({
@@ -369,11 +369,11 @@ export class DecodedMessage<T = any> {
   }
 }
 
-function conversationReferenceToConversation<T>(
+function conversationReferenceToConversation<ContentTypes>(
   reference: conversationReference.ConversationReference,
-  client: Client<T>,
+  client: Client<ContentTypes>,
   version: DecodedMessage['messageVersion']
-): Conversation<T> {
+): Conversation<ContentTypes> {
   if (version === 'v1') {
     return new ConversationV1(
       client,
@@ -393,6 +393,9 @@ function conversationReferenceToConversation<T>(
   throw new Error(`Unknown conversation version ${version}`)
 }
 
-export function decodeContent<T>(contentBytes: Uint8Array, client: Client<T>) {
+export function decodeContent<ContentTypes>(
+  contentBytes: Uint8Array,
+  client: Client<ContentTypes>
+) {
   return client.decodeContent(contentBytes)
 }

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -4,27 +4,17 @@ import {
   ConversationV2,
 } from './conversations/Conversation'
 import type Client from './Client'
-import {
-  message as proto,
-  content as protoContent,
-  conversationReference,
-} from '@xmtp/proto'
+import { message as proto, conversationReference } from '@xmtp/proto'
 import Long from 'long'
 import Ciphertext from './crypto/Ciphertext'
 import { PublicKeyBundle, PublicKey } from './crypto'
 import { bytesToHex } from './crypto/utils'
 import { sha256 } from './crypto/encryption'
-import {
-  ContentCodec,
-  ContentTypeFallback,
-  ContentTypeId,
-  EncodedContent,
-} from './MessageContent'
+import { ContentTypeId } from './MessageContent'
 import { dateToNs, nsToDate } from './utils'
-import { decompress } from './Compression'
 import { Keystore } from './keystore'
 import { buildDecryptV1Request, getResultOrThrow } from './utils/keystore'
-import { AnyClient, ClientReturnType } from './Client'
+import { ClientReturnType } from './Client'
 
 const headerBytesAndCiphertext = (
   msg: proto.Message

--- a/src/Stream.ts
+++ b/src/Stream.ts
@@ -16,9 +16,10 @@ export type ContentTopicUpdater<M> = (msg: M) => string[] | undefined
  * Stream implements an Asynchronous Iterable over messages received from a topic.
  * As such can be used with constructs like for-await-of, yield*, array destructing, etc.
  */
-export default class Stream<T> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default class Stream<T, ClientType = any> {
   topics: string[]
-  client: Client
+  client: Client<ClientType>
   // queue of incoming Waku messages
   messages: T[]
   // queue of already pending Promises
@@ -32,7 +33,7 @@ export default class Stream<T> {
   onConnectionLost?: OnConnectionLostCallback
 
   constructor(
-    client: Client,
+    client: Client<ClientType>,
     topics: string[],
     decoder: MessageDecoder<T>,
     contentTopicUpdater?: ContentTopicUpdater<T>,
@@ -100,13 +101,13 @@ export default class Stream<T> {
     )
   }
 
-  static async create<T>(
-    client: Client,
+  static async create<T, ClientType = string>(
+    client: Client<ClientType>,
     topics: string[],
     decoder: MessageDecoder<T>,
     contentTopicUpdater?: ContentTopicUpdater<T>,
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<T>> {
+  ): Promise<Stream<T, ClientType>> {
     const stream = new Stream(
       client,
       topics,

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -36,7 +36,8 @@ import { ContentTypeText } from '../codecs/Text'
 /**
  * Conversation represents either a V1 or V2 conversation with a common set of methods.
  */
-export interface Conversation<T> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface Conversation<T = any> {
   conversationVersion: 'v1' | 'v2'
   /**
    * The wallet address connected to the client

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -102,7 +102,7 @@ export interface Conversation<T> {
    * }
    * ```
    */
-  streamMessages(): Promise<Stream<DecodedMessage<T>>>
+  streamMessages(): Promise<Stream<DecodedMessage<T>, T>>
   /**
    * Send a message into the conversation
    *
@@ -135,7 +135,7 @@ export interface Conversation<T> {
    * }
    * ```
    */
-  streamEphemeral(): Promise<Stream<DecodedMessage<T>>>
+  streamEphemeral(): Promise<Stream<DecodedMessage<T>, T>>
 }
 
 /**
@@ -260,8 +260,8 @@ export class ConversationV1<T> implements Conversation<T> {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>>> {
-    return Stream.create<DecodedMessage<T>>(
+  ): Promise<Stream<DecodedMessage<T>, T>> {
+    return Stream.create<DecodedMessage<T>, T>(
       this.client,
       [this.topic],
       async (env: messageApi.Envelope) => this.decodeMessage(env),
@@ -295,8 +295,8 @@ export class ConversationV1<T> implements Conversation<T> {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>>> {
-    return Stream.create<DecodedMessage<T>>(
+  ): Promise<Stream<DecodedMessage<T>, T>> {
+    return Stream.create<DecodedMessage<T>, T>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -477,8 +477,8 @@ export class ConversationV2<T> implements Conversation<T> {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>>> {
-    return Stream.create<DecodedMessage<T>>(
+  ): Promise<Stream<DecodedMessage<T>, T>> {
+    return Stream.create<DecodedMessage<T>, T>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -492,8 +492,8 @@ export class ConversationV2<T> implements Conversation<T> {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>>> {
-    return Stream.create<DecodedMessage<T>>(
+  ): Promise<Stream<DecodedMessage<T>, T>> {
+    return Stream.create<DecodedMessage<T>, T>(
       this.client,
       [this.topic],
       this.decodeMessage.bind(this),

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -112,7 +112,10 @@ export interface Conversation<T = any> {
    * await conversation.send('Hello world') // returns a `DecodedMessage` instance
    * ```
    */
-  send(content: T, options?: SendOptions): Promise<DecodedMessage<T>>
+  send(
+    content: Exclude<T, undefined>,
+    options?: SendOptions
+  ): Promise<DecodedMessage<T>>
 
   /**
    * Return a `PreparedMessage` that has contains the message ID
@@ -309,7 +312,10 @@ export class ConversationV1<T> implements Conversation<T> {
   /**
    * Send a message into the conversation.
    */
-  async send(content: T, options?: SendOptions): Promise<DecodedMessage<T>> {
+  async send(
+    content: Exclude<T, undefined>,
+    options?: SendOptions
+  ): Promise<DecodedMessage<T>> {
     let topics: string[]
     let recipient = await this.client.getUserContact(this.peerAddress)
     if (!recipient) {
@@ -506,7 +512,10 @@ export class ConversationV2<T> implements Conversation<T> {
   /**
    * Send a message into the conversation
    */
-  async send(content: T, options?: SendOptions): Promise<DecodedMessage<T>> {
+  async send(
+    content: Exclude<T, undefined>,
+    options?: SendOptions
+  ): Promise<DecodedMessage<T>> {
     const payload = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, options?.timestamp)
 

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -37,7 +37,7 @@ import { ContentTypeText } from '../codecs/Text'
  * Conversation represents either a V1 or V2 conversation with a common set of methods.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface Conversation<T = any> {
+export interface Conversation<ContentTypes = any> {
   conversationVersion: 'v1' | 'v2'
   /**
    * The wallet address connected to the client
@@ -79,18 +79,18 @@ export interface Conversation<T = any> {
    * })
    * ```
    */
-  messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]>
+  messages(opts?: ListMessagesOptions): Promise<DecodedMessage<ContentTypes>[]>
   /**
    * @deprecated
    */
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage<T>[]>
+  ): AsyncGenerator<DecodedMessage<ContentTypes>[]>
   /**
    * Takes a XMTP envelope as input and will decrypt and decode it
    * returning a `DecodedMessage` instance.
    */
-  decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>>
+  decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<ContentTypes>>
   /**
    * Return a `Stream` of new messages in this conversation.
    *
@@ -103,7 +103,7 @@ export interface Conversation<T = any> {
    * }
    * ```
    */
-  streamMessages(): Promise<Stream<DecodedMessage<T>, T>>
+  streamMessages(): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>>
   /**
    * Send a message into the conversation
    *
@@ -113,9 +113,9 @@ export interface Conversation<T = any> {
    * ```
    */
   send(
-    content: Exclude<T, undefined>,
+    content: Exclude<ContentTypes, undefined>,
     options?: SendOptions
-  ): Promise<DecodedMessage<T>>
+  ): Promise<DecodedMessage<ContentTypes>>
 
   /**
    * Return a `PreparedMessage` that has contains the message ID
@@ -139,20 +139,22 @@ export interface Conversation<T = any> {
    * }
    * ```
    */
-  streamEphemeral(): Promise<Stream<DecodedMessage<T>, T>>
+  streamEphemeral(): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>>
 }
 
 /**
  * ConversationV1 allows you to view, stream, and send messages to/from a peer address
  */
-export class ConversationV1<T> implements Conversation<T> {
+export class ConversationV1<ContentTypes>
+  implements Conversation<ContentTypes>
+{
   conversationVersion = 'v1' as const
   peerAddress: string
   createdAt: Date
   context = undefined
-  private client: Client<T>
+  private client: Client<ContentTypes>
 
-  constructor(client: Client<T>, address: string, createdAt: Date) {
+  constructor(client: Client<ContentTypes>, address: string, createdAt: Date) {
     this.peerAddress = utils.getAddress(address)
     this.client = client
     this.createdAt = createdAt
@@ -176,7 +178,9 @@ export class ConversationV1<T> implements Conversation<T> {
   /**
    * Returns a list of all messages to/from the peerAddress
    */
-  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]> {
+  async messages(
+    opts?: ListMessagesOptions
+  ): Promise<DecodedMessage<ContentTypes>[]> {
     const topic = buildDirectMessageTopic(this.peerAddress, this.client.address)
     const messages = await this.client.listEnvelopes(
       topic,
@@ -189,7 +193,7 @@ export class ConversationV1<T> implements Conversation<T> {
 
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage<T>[]> {
+  ): AsyncGenerator<DecodedMessage<ContentTypes>[]> {
     return this.client.listEnvelopesPaginated(
       this.topic,
       // This won't be performant once we start supporting a remote keystore
@@ -200,7 +204,9 @@ export class ConversationV1<T> implements Conversation<T> {
   }
 
   // decodeMessage takes an envelope and either returns a `DecodedMessage` or throws if an error occurs
-  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>> {
+  async decodeMessage(
+    env: messageApi.Envelope
+  ): Promise<DecodedMessage<ContentTypes>> {
     if (!env.contentTopic) {
       throw new Error('Missing content topic')
     }
@@ -264,8 +270,8 @@ export class ConversationV1<T> implements Conversation<T> {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>, T>> {
-    return Stream.create<DecodedMessage<T>, T>(
+  ): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>> {
+    return Stream.create<DecodedMessage<ContentTypes>, ContentTypes>(
       this.client,
       [this.topic],
       async (env: messageApi.Envelope) => this.decodeMessage(env),
@@ -299,8 +305,8 @@ export class ConversationV1<T> implements Conversation<T> {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>, T>> {
-    return Stream.create<DecodedMessage<T>, T>(
+  ): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>> {
+    return Stream.create<DecodedMessage<ContentTypes>, ContentTypes>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -313,9 +319,9 @@ export class ConversationV1<T> implements Conversation<T> {
    * Send a message into the conversation.
    */
   async send(
-    content: Exclude<T, undefined>,
+    content: Exclude<ContentTypes, undefined>,
     options?: SendOptions
-  ): Promise<DecodedMessage<T>> {
+  ): Promise<DecodedMessage<ContentTypes>> {
     let topics: string[]
     let recipient = await this.client.getUserContact(this.peerAddress)
     if (!recipient) {
@@ -363,14 +369,14 @@ export class ConversationV1<T> implements Conversation<T> {
     messages: MessageV1[],
     topic: string,
     throwOnError = false
-  ): Promise<DecodedMessage<T>[]> {
+  ): Promise<DecodedMessage<ContentTypes>[]> {
     const responses = (
       await this.client.keystore.decryptV1(
         buildDecryptV1Request(messages, this.client.publicKeyBundle)
       )
     ).responses
 
-    const out: DecodedMessage<T>[] = []
+    const out: DecodedMessage<ContentTypes>[] = []
     for (let i = 0; i < responses.length; i++) {
       const result = responses[i]
       const message = messages[i]
@@ -392,7 +398,7 @@ export class ConversationV1<T> implements Conversation<T> {
     message: MessageV1,
     decrypted: Uint8Array,
     topic: string
-  ): Promise<DecodedMessage<T>> {
+  ): Promise<DecodedMessage<ContentTypes>> {
     const { content, contentType, error, contentFallback } =
       await this.client.decodeContent(decrypted)
 
@@ -429,16 +435,18 @@ export class ConversationV1<T> implements Conversation<T> {
 /**
  * ConversationV2
  */
-export class ConversationV2<T> implements Conversation<T> {
+export class ConversationV2<ContentTypes>
+  implements Conversation<ContentTypes>
+{
   conversationVersion = 'v2' as const
-  client: Client<T>
+  client: Client<ContentTypes>
   topic: string
   peerAddress: string
   createdAt: Date
   context?: InvitationContext
 
   constructor(
-    client: Client<T>,
+    client: Client<ContentTypes>,
     topic: string,
     peerAddress: string,
     createdAt: Date,
@@ -458,7 +466,9 @@ export class ConversationV2<T> implements Conversation<T> {
   /**
    * Returns a list of all messages to/from the peerAddress
    */
-  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]> {
+  async messages(
+    opts?: ListMessagesOptions
+  ): Promise<DecodedMessage<ContentTypes>[]> {
     const messages = await this.client.listEnvelopes(
       this.topic,
       this.processEnvelope.bind(this),
@@ -470,7 +480,7 @@ export class ConversationV2<T> implements Conversation<T> {
 
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage<T>[]> {
+  ): AsyncGenerator<DecodedMessage<ContentTypes>[]> {
     return this.client.listEnvelopesPaginated(
       this.topic,
       this.decodeMessage.bind(this),
@@ -484,8 +494,8 @@ export class ConversationV2<T> implements Conversation<T> {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>, T>> {
-    return Stream.create<DecodedMessage<T>, T>(
+  ): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>> {
+    return Stream.create<DecodedMessage<ContentTypes>, ContentTypes>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -499,8 +509,8 @@ export class ConversationV2<T> implements Conversation<T> {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage<T>, T>> {
-    return Stream.create<DecodedMessage<T>, T>(
+  ): Promise<Stream<DecodedMessage<ContentTypes>, ContentTypes>> {
+    return Stream.create<DecodedMessage<ContentTypes>, ContentTypes>(
       this.client,
       [this.topic],
       this.decodeMessage.bind(this),
@@ -513,9 +523,9 @@ export class ConversationV2<T> implements Conversation<T> {
    * Send a message into the conversation
    */
   async send(
-    content: Exclude<T, undefined>,
+    content: Exclude<ContentTypes, undefined>,
     options?: SendOptions
-  ): Promise<DecodedMessage<T>> {
+  ): Promise<DecodedMessage<ContentTypes>> {
     const payload = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, options?.timestamp)
 
@@ -581,12 +591,12 @@ export class ConversationV2<T> implements Conversation<T> {
   private async decryptBatch(
     messages: MessageV2[],
     throwOnError = false
-  ): Promise<DecodedMessage<T>[]> {
+  ): Promise<DecodedMessage<ContentTypes>[]> {
     const responses = (
       await this.client.keystore.decryptV2(this.buildDecryptRequest(messages))
     ).responses
 
-    const out: DecodedMessage<T>[] = []
+    const out: DecodedMessage<ContentTypes>[] = []
     for (let i = 0; i < responses.length; i++) {
       const result = responses[i]
       const message = messages[i]
@@ -642,7 +652,7 @@ export class ConversationV2<T> implements Conversation<T> {
   private async buildDecodedMessage(
     msg: MessageV2,
     decrypted: Uint8Array
-  ): Promise<DecodedMessage<T>> {
+  ): Promise<DecodedMessage<ContentTypes>> {
     // Decode the decrypted bytes into SignedContent
     const signed = proto.SignedContent.decode(decrypted)
     if (
@@ -731,7 +741,9 @@ export class ConversationV2<T> implements Conversation<T> {
     return MessageV2.create(msg, header, env.message)
   }
 
-  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>> {
+  async decodeMessage(
+    env: messageApi.Envelope
+  ): Promise<DecodedMessage<ContentTypes>> {
     if (!env.contentTopic) {
       throw new Error('Missing content topic')
     }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -14,7 +14,7 @@ import Client, {
   SendOptions,
 } from '../Client'
 import { InvitationContext } from '../Invitation'
-import { DecodedMessage, MessageV1, MessageV2, decodeContent } from '../Message'
+import { DecodedMessage, MessageV1, MessageV2 } from '../Message'
 import {
   messageApi,
   message,
@@ -33,12 +33,10 @@ import { sha256 } from '../crypto/encryption'
 import { buildDecryptV1Request, getResultOrThrow } from '../utils/keystore'
 import { ContentTypeText } from '../codecs/Text'
 
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-
 /**
  * Conversation represents either a V1 or V2 conversation with a common set of methods.
  */
-export interface Conversation {
+export interface Conversation<T> {
   conversationVersion: 'v1' | 'v2'
   /**
    * The wallet address connected to the client
@@ -80,18 +78,18 @@ export interface Conversation {
    * })
    * ```
    */
-  messages(opts?: ListMessagesOptions): Promise<DecodedMessage[]>
+  messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]>
   /**
    * @deprecated
    */
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage[]>
+  ): AsyncGenerator<DecodedMessage<T>[]>
   /**
    * Takes a XMTP envelope as input and will decrypt and decode it
    * returning a `DecodedMessage` instance.
    */
-  decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage>
+  decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>>
   /**
    * Return a `Stream` of new messages in this conversation.
    *
@@ -104,7 +102,7 @@ export interface Conversation {
    * }
    * ```
    */
-  streamMessages(): Promise<Stream<DecodedMessage>>
+  streamMessages(): Promise<Stream<DecodedMessage<T>>>
   /**
    * Send a message into the conversation
    *
@@ -113,10 +111,7 @@ export interface Conversation {
    * await conversation.send('Hello world') // returns a `DecodedMessage` instance
    * ```
    */
-  send(
-    content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    options?: SendOptions
-  ): Promise<DecodedMessage>
+  send(content: T, options?: SendOptions): Promise<DecodedMessage<T>>
 
   /**
    * Return a `PreparedMessage` that has contains the message ID
@@ -140,20 +135,20 @@ export interface Conversation {
    * }
    * ```
    */
-  streamEphemeral(): Promise<Stream<DecodedMessage>>
+  streamEphemeral(): Promise<Stream<DecodedMessage<T>>>
 }
 
 /**
  * ConversationV1 allows you to view, stream, and send messages to/from a peer address
  */
-export class ConversationV1 implements Conversation {
+export class ConversationV1<T> implements Conversation<T> {
   conversationVersion = 'v1' as const
   peerAddress: string
   createdAt: Date
   context = undefined
-  private client: Client
+  private client: Client<T>
 
-  constructor(client: Client, address: string, createdAt: Date) {
+  constructor(client: Client<T>, address: string, createdAt: Date) {
     this.peerAddress = utils.getAddress(address)
     this.client = client
     this.createdAt = createdAt
@@ -177,7 +172,7 @@ export class ConversationV1 implements Conversation {
   /**
    * Returns a list of all messages to/from the peerAddress
    */
-  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage[]> {
+  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]> {
     const topic = buildDirectMessageTopic(this.peerAddress, this.client.address)
     const messages = await this.client.listEnvelopes(
       topic,
@@ -190,7 +185,7 @@ export class ConversationV1 implements Conversation {
 
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage[]> {
+  ): AsyncGenerator<DecodedMessage<T>[]> {
     return this.client.listEnvelopesPaginated(
       this.topic,
       // This won't be performant once we start supporting a remote keystore
@@ -201,7 +196,7 @@ export class ConversationV1 implements Conversation {
   }
 
   // decodeMessage takes an envelope and either returns a `DecodedMessage` or throws if an error occurs
-  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage> {
+  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>> {
     if (!env.contentTopic) {
       throw new Error('Missing content topic')
     }
@@ -265,8 +260,8 @@ export class ConversationV1 implements Conversation {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage>> {
-    return Stream.create<DecodedMessage>(
+  ): Promise<Stream<DecodedMessage<T>>> {
+    return Stream.create<DecodedMessage<T>>(
       this.client,
       [this.topic],
       async (env: messageApi.Envelope) => this.decodeMessage(env),
@@ -300,8 +295,8 @@ export class ConversationV1 implements Conversation {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage>> {
-    return Stream.create<DecodedMessage>(
+  ): Promise<Stream<DecodedMessage<T>>> {
+    return Stream.create<DecodedMessage<T>>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -313,10 +308,7 @@ export class ConversationV1 implements Conversation {
   /**
    * Send a message into the conversation.
    */
-  async send(
-    content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    options?: SendOptions
-  ): Promise<DecodedMessage> {
+  async send(content: T, options?: SendOptions): Promise<DecodedMessage<T>> {
     let topics: string[]
     let recipient = await this.client.getUserContact(this.peerAddress)
     if (!recipient) {
@@ -364,14 +356,14 @@ export class ConversationV1 implements Conversation {
     messages: MessageV1[],
     topic: string,
     throwOnError = false
-  ): Promise<DecodedMessage[]> {
+  ): Promise<DecodedMessage<T>[]> {
     const responses = (
       await this.client.keystore.decryptV1(
         buildDecryptV1Request(messages, this.client.publicKeyBundle)
       )
     ).responses
 
-    const out: DecodedMessage[] = []
+    const out: DecodedMessage<T>[] = []
     for (let i = 0; i < responses.length; i++) {
       const result = responses[i]
       const message = messages[i]
@@ -393,9 +385,9 @@ export class ConversationV1 implements Conversation {
     message: MessageV1,
     decrypted: Uint8Array,
     topic: string
-  ): Promise<DecodedMessage> {
+  ): Promise<DecodedMessage<T>> {
     const { content, contentType, error, contentFallback } =
-      await decodeContent(decrypted, this.client)
+      await this.client.decodeContent(decrypted)
 
     return DecodedMessage.fromV1Message(
       message,
@@ -430,16 +422,16 @@ export class ConversationV1 implements Conversation {
 /**
  * ConversationV2
  */
-export class ConversationV2 implements Conversation {
+export class ConversationV2<T> implements Conversation<T> {
   conversationVersion = 'v2' as const
-  client: Client
+  client: Client<T>
   topic: string
   peerAddress: string
   createdAt: Date
   context?: InvitationContext
 
   constructor(
-    client: Client,
+    client: Client<T>,
     topic: string,
     peerAddress: string,
     createdAt: Date,
@@ -459,7 +451,7 @@ export class ConversationV2 implements Conversation {
   /**
    * Returns a list of all messages to/from the peerAddress
    */
-  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage[]> {
+  async messages(opts?: ListMessagesOptions): Promise<DecodedMessage<T>[]> {
     const messages = await this.client.listEnvelopes(
       this.topic,
       this.processEnvelope.bind(this),
@@ -471,7 +463,7 @@ export class ConversationV2 implements Conversation {
 
   messagesPaginated(
     opts?: ListMessagesPaginatedOptions
-  ): AsyncGenerator<DecodedMessage[]> {
+  ): AsyncGenerator<DecodedMessage<T>[]> {
     return this.client.listEnvelopesPaginated(
       this.topic,
       this.decodeMessage.bind(this),
@@ -485,8 +477,8 @@ export class ConversationV2 implements Conversation {
 
   streamEphemeral(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage>> {
-    return Stream.create<DecodedMessage>(
+  ): Promise<Stream<DecodedMessage<T>>> {
+    return Stream.create<DecodedMessage<T>>(
       this.client,
       [this.ephemeralTopic],
       this.decodeMessage.bind(this),
@@ -500,8 +492,8 @@ export class ConversationV2 implements Conversation {
    */
   streamMessages(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<DecodedMessage>> {
-    return Stream.create<DecodedMessage>(
+  ): Promise<Stream<DecodedMessage<T>>> {
+    return Stream.create<DecodedMessage<T>>(
       this.client,
       [this.topic],
       this.decodeMessage.bind(this),
@@ -513,10 +505,7 @@ export class ConversationV2 implements Conversation {
   /**
    * Send a message into the conversation
    */
-  async send(
-    content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    options?: SendOptions
-  ): Promise<DecodedMessage> {
+  async send(content: T, options?: SendOptions): Promise<DecodedMessage<T>> {
     const payload = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, options?.timestamp)
 
@@ -582,12 +571,12 @@ export class ConversationV2 implements Conversation {
   private async decryptBatch(
     messages: MessageV2[],
     throwOnError = false
-  ): Promise<DecodedMessage[]> {
+  ): Promise<DecodedMessage<T>[]> {
     const responses = (
       await this.client.keystore.decryptV2(this.buildDecryptRequest(messages))
     ).responses
 
-    const out: DecodedMessage[] = []
+    const out: DecodedMessage<T>[] = []
     for (let i = 0; i < responses.length; i++) {
       const result = responses[i]
       const message = messages[i]
@@ -643,7 +632,7 @@ export class ConversationV2 implements Conversation {
   private async buildDecodedMessage(
     msg: MessageV2,
     decrypted: Uint8Array
-  ): Promise<DecodedMessage> {
+  ): Promise<DecodedMessage<T>> {
     // Decode the decrypted bytes into SignedContent
     const signed = proto.SignedContent.decode(decrypted)
     if (
@@ -673,7 +662,7 @@ export class ConversationV2 implements Conversation {
     ).walletSignatureAddress()
 
     const { content, contentType, error, contentFallback } =
-      await decodeContent(signed.payload, this.client)
+      await this.client.decodeContent(signed.payload)
 
     return DecodedMessage.fromV2Message(
       msg,
@@ -732,7 +721,7 @@ export class ConversationV2 implements Conversation {
     return MessageV2.create(msg, header, env.message)
   }
 
-  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage> {
+  async decodeMessage(env: messageApi.Envelope): Promise<DecodedMessage<T>> {
     if (!env.contentTopic) {
       throw new Error('Missing content topic')
     }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -28,7 +28,8 @@ const messageHasHeaders = (msg: MessageV1): boolean => {
 /**
  * Conversations allows you to view ongoing 1:1 messaging sessions with another wallet
  */
-export default class Conversations<T> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default class Conversations<T = any> {
   private client: Client<T>
   private v1JobRunner: JobRunner
   private v2JobRunner: JobRunner

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -210,7 +210,7 @@ export default class Conversations<T> {
    */
   async stream(
     onConnectionLost?: OnConnectionLostCallback
-  ): Promise<Stream<Conversation<T>>> {
+  ): Promise<Stream<Conversation<T>, T>> {
     const seenPeers: Set<string> = new Set()
     const introTopic = buildUserIntroTopic(this.client.address)
     const inviteTopic = buildUserInviteTopic(this.client.address)
@@ -249,7 +249,7 @@ export default class Conversations<T> {
 
     const topics = [introTopic, inviteTopic]
 
-    return Stream.create<Conversation<T>>(
+    return Stream.create<Conversation<T>, T>(
       this.client,
       topics,
       decodeConversation.bind(this),
@@ -369,7 +369,10 @@ export default class Conversations<T> {
       return undefined
     }
 
-    const str = await Stream.create<DecodedMessage<T> | Conversation<T> | null>(
+    const str = await Stream.create<
+      DecodedMessage<T> | Conversation<T> | null,
+      T
+    >(
       this.client,
       Array.from(topics.values()),
       decodeMessage,

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,3 +108,7 @@ export {
 } from './keystore/persistence'
 export { InvitationContext, SealedInvitation } from './Invitation'
 export { decodeContactBundle } from './ContactBundle'
+export type {
+  GetMessageContentTypeFromClient,
+  ExtractDecodedType,
+} from './types/client'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-export { Message, DecodedMessage, MessageV1, MessageV2 } from './Message'
+export {
+  Message,
+  DecodedMessage,
+  MessageV1,
+  MessageV2,
+  decodeContent,
+} from './Message'
 export {
   Ciphertext,
   PublicKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
-export {
-  Message,
-  DecodedMessage,
-  decodeContent,
-  MessageV1,
-  MessageV2,
-} from './Message'
+export { Message, DecodedMessage, MessageV1, MessageV2 } from './Message'
 export {
   Ciphertext,
   PublicKey,

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,8 @@
+import type Client from '../Client'
+import type { ContentCodec } from '../MessageContent'
+
+export type GetMessageContentTypeFromClient<C> = C extends Client<infer T>
+  ? T
+  : never
+
+export type ExtractDecodedType<C> = C extends ContentCodec<infer T> ? T : never

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -201,7 +201,9 @@ describe('encodeContent', () => {
 
 describe('canMessage', () => {
   it('can confirm a user is on the network statically', async () => {
-    const registeredClient = await newLocalHostClient()
+    const registeredClient = await newLocalHostClient({
+      codecs: [new TextCodec()],
+    })
     await waitForUserContact(registeredClient, registeredClient)
     const canMessageRegisteredClient = await Client.canMessage(
       registeredClient.address,

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -25,7 +25,7 @@ import LocalStoragePonyfill from '../src/keystore/persistence/LocalStoragePonyfi
 
 type TestCase = {
   name: string
-  newClient: (opts?: Partial<ClientOptions>) => Promise<Client>
+  newClient: (opts?: Partial<ClientOptions>) => Promise<Client<any>>
 }
 
 const mockEthRequest = jest.fn()

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -347,8 +347,8 @@ describe('ClientOptions', () => {
 
   describe('custom codecs', () => {
     it('gives type errors when you use the wrong types', async () => {
-      const client = await Client.create(newWallet())
-      const other = await Client.create(newWallet())
+      const client = await Client.create(newWallet(), { env: 'local' })
+      const other = await Client.create(newWallet(), { env: 'local' })
       const convo = await client.conversations.newConversation(other.address)
       expect(convo).toBeTruthy()
       try {

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -348,7 +348,7 @@ describe('ClientOptions', () => {
   describe('custom codecs', () => {
     it('gives type errors when you use the wrong types', async () => {
       const client = await Client.create(newWallet())
-      const other = await newLocalHostClient()
+      const other = await Client.create(newWallet())
       const convo = await client.conversations.newConversation(other.address)
       expect(convo).toBeTruthy()
       try {
@@ -371,7 +371,7 @@ describe('ClientOptions', () => {
       const client = await Client.create(newWallet(), {
         codecs: [new CompositeCodec()],
       })
-      const other = await newLocalHostClient()
+      const other = await Client.create(newWallet())
       const convo = await client.conversations.newConversation(other.address)
       expect(convo).toBeTruthy()
       // This will have a type error if the codecs field isn't being respected

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -248,6 +248,9 @@ describe('Message', function () {
         sentMessageBytes,
         aliceClient
       )
+      if (typeof aliceRestoredMessage.content === 'string') {
+        throw new Error('Expected content to be a PublicKeyBundle')
+      }
       expect(
         equalBytes(
           aliceRestoredMessage.content?.secp256k1Uncompressed.bytes,

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -248,7 +248,10 @@ describe('Message', function () {
         sentMessageBytes,
         aliceClient
       )
-      if (typeof aliceRestoredMessage.content === 'string') {
+      if (
+        typeof aliceRestoredMessage.content === 'string' ||
+        !aliceRestoredMessage.content
+      ) {
         throw new Error('Expected content to be a PublicKeyBundle')
       }
       expect(

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -80,7 +80,7 @@ describe('conversation', () => {
       expect(messageIds.size).toBe(10)
 
       // Test sorting
-      let lastMessage: DecodedMessage | undefined = undefined
+      let lastMessage: DecodedMessage<any> | undefined = undefined
       for await (const page of aliceConversation.messagesPaginated({
         direction: SortDirection.SORT_DIRECTION_DESCENDING,
       })) {
@@ -408,7 +408,7 @@ describe('conversation', () => {
       alice.keystore = aliceKeystore
       await aliceConvo.send('Hello from Alice')
       const result = await stream.next()
-      const msg = result.value as DecodedMessage
+      const msg = result.value
       expect(msg.senderAddress).toBe(alice.address)
       expect(msg.content).toBe('Hello from Alice')
       await stream.return()
@@ -437,11 +437,11 @@ describe('conversation', () => {
       })
 
       const aliceResult1 = await aliceStream.next()
-      const aliceMessage1 = aliceResult1.value as DecodedMessage
+      const aliceMessage1 = aliceResult1.value
       expect(aliceMessage1.content).toEqual(key)
 
       const bobResult1 = await bobStream.next()
-      const bobMessage1 = bobResult1.value as DecodedMessage
+      const bobMessage1 = bobResult1.value
       expect(bobMessage1).toBeTruthy()
       expect(bobMessage1.error?.message).toBe(
         'unknown content type xmtp.test/public-key:1.0'
@@ -457,7 +457,7 @@ describe('conversation', () => {
         contentType: ContentTypeTestKey,
       })
       const bobResult2 = await bobStream.next()
-      const bobMessage2 = bobResult2.value as DecodedMessage
+      const bobMessage2 = bobResult2.value
       expect(bobMessage2.contentType).toBeTruthy()
       expect(bobMessage2.contentType.sameAs(ContentTypeTestKey)).toBeTruthy()
       expect(key.equals(bobMessage2.content)).toBeTruthy()
@@ -603,7 +603,7 @@ describe('conversation', () => {
       )
       await sleep(100)
 
-      const firstMessageFromStream: DecodedMessage = (await stream.next()).value
+      const firstMessageFromStream = (await stream.next()).value
       expect(firstMessageFromStream.messageVersion).toBe('v2')
       expect(firstMessageFromStream.content).toBe('foo')
       expect(firstMessageFromStream.conversation.context?.conversationId).toBe(
@@ -675,11 +675,11 @@ describe('conversation', () => {
       })
 
       const aliceResult1 = await aliceStream.next()
-      const aliceMessage1 = aliceResult1.value as DecodedMessage
+      const aliceMessage1 = aliceResult1.value
       expect(aliceMessage1.content).toEqual(key)
 
       const bobResult1 = await bobStream.next()
-      const bobMessage1 = bobResult1.value as DecodedMessage
+      const bobMessage1 = bobResult1.value
       expect(bobMessage1).toBeTruthy()
       expect(bobMessage1.error?.message).toBe(
         'unknown content type xmtp.test/public-key:1.0'
@@ -695,7 +695,7 @@ describe('conversation', () => {
         contentType: ContentTypeTestKey,
       })
       const bobResult2 = await bobStream.next()
-      const bobMessage2 = bobResult2.value as DecodedMessage
+      const bobMessage2 = bobResult2.value
       expect(bobMessage2.contentType).toBeTruthy()
       expect(bobMessage2.contentType.sameAs(ContentTypeTestKey)).toBeTruthy()
       expect(key.equals(bobMessage2.content)).toBeTruthy()

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -10,8 +10,8 @@ import { ContentTypeTestKey, TestKeyCodec } from '../ContentTypeTestKey'
 import { content as proto } from '@xmtp/proto'
 
 describe('conversation', () => {
-  let alice: Client
-  let bob: Client
+  let alice: Client<string>
+  let bob: Client<string>
 
   describe('v1', () => {
     beforeEach(async () => {
@@ -425,6 +425,7 @@ describe('conversation', () => {
 
       // alice doesn't recognize the type
       await expect(
+        // @ts-expect-error
         aliceConvo.send(key, {
           contentType: ContentTypeTestKey,
         })
@@ -432,6 +433,7 @@ describe('conversation', () => {
 
       // bob doesn't recognize the type
       alice.registerCodec(new TestKeyCodec())
+      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -453,6 +455,7 @@ describe('conversation', () => {
 
       // both recognize the type
       bob.registerCodec(new TestKeyCodec())
+      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -467,6 +470,7 @@ describe('conversation', () => {
         ...ContentTypeTestKey,
         versionMajor: 2,
       })
+      // @ts-expect-error
       expect(aliceConvo.send(key, { contentType: type2 })).rejects.toThrow(
         'unknown content type xmtp.test/public-key:2.0'
       )
@@ -663,6 +667,7 @@ describe('conversation', () => {
 
       // alice doesn't recognize the type
       expect(
+        // @ts-expect-error
         aliceConvo.send(key, {
           contentType: ContentTypeTestKey,
         })
@@ -670,6 +675,7 @@ describe('conversation', () => {
 
       // bob doesn't recognize the type
       alice.registerCodec(new TestKeyCodec())
+      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -691,6 +697,7 @@ describe('conversation', () => {
 
       // both recognize the type
       bob.registerCodec(new TestKeyCodec())
+      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -705,6 +712,7 @@ describe('conversation', () => {
         ...ContentTypeTestKey,
         versionMajor: 2,
       })
+      // @ts-expect-error
       expect(aliceConvo.send(key, { contentType: type2 })).rejects.toThrow(
         'unknown content type xmtp.test/public-key:2.0'
       )

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -157,9 +157,7 @@ export class CodecRegistry {
 
 // client running against local node running on the host,
 // see github.com/xmtp/xmtp-node-go/scripts/xmtp-js.sh
-export const newLocalHostClient = (
-  opts?: Partial<ClientOptions>
-): Promise<Client> =>
+export const newLocalHostClient = (opts?: Partial<ClientOptions>) =>
   Client.create(newWallet(), {
     env: 'local',
     ...opts,
@@ -169,14 +167,14 @@ export const newLocalHostClient = (
 // with a non-ethers wallet
 export const newLocalHostClientWithCustomWallet = (
   opts?: Partial<ClientOptions>
-): Promise<Client> =>
+) =>
   Client.create(newCustomWallet(), {
     env: 'local',
     ...opts,
   })
 
 // client running against the dev cluster in AWS
-export const newDevClient = (opts?: Partial<ClientOptions>): Promise<Client> =>
+export const newDevClient = (opts?: Partial<ClientOptions>) =>
   Client.create(newWallet(), {
     env: 'dev',
     ...opts,


### PR DESCRIPTION
## Summary

A long-standing source of frustration with our JS SDK is the use of `any` types for message content. Sending and receiving messages has the `content` field typed as `any`.

Message content is of a finite set of types, defined by the codecs that get passed in to Client creation. If you have a codec that returns `number`, it's possible to get messages with content of type number. If you don't a number codec, it's not possible.

We just need to do some Typescript wrangling to infer those types from the codecs and pass them around to all the conversation methods.

This PR does that.

<img width="700" alt="CleanShot 2023-09-12 at 16 38 37@2x" src="https://github.com/xmtp/xmtp-js/assets/65710/3c007e72-d021-497e-bc52-753192b61798">

## Notes

I've structured this to be safe for existing implementers. All the existing types default to `any`. This will make the migration path smoother for developers, but also may lead devs to not take advantage of this feature.

```ts
// This will have strong typing
const goodClient = await Client.create(someWallet)
const goodConvo = await goodClient.conversations.newConversation(someAddress)
// Will cause a type error because the client is set to have a type of "string"
await goodConvo.send(1234)

// Coerce the type of Client to the default
let badClient: Client
badClient = await Client.create(someWallet)
const badConvo = await badClient.conversations.newConversation(someAddress)
// The type-checker will ignore this, because Client is set to the default of any
await badConvo.send(1234)

// This will also disable the strong typing
const otherBadConvo: Conversation = await goodClient.conversations.newConversation(someAddress)
// This will be allowed
await otherBadConvo.send(1234)
```