### PR TITLE
Add self-encryption support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
+        "@xmtp/ecies-bindings-wasm": "^0.1.5",
         "@xmtp/proto": "^3.28.0-beta.1",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
@@ -4738,6 +4739,11 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@xmtp/ecies-bindings-wasm": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@xmtp/ecies-bindings-wasm/-/ecies-bindings-wasm-0.1.5.tgz",
+      "integrity": "sha512-SBxBxQCX0weIIHgrVxZ0QmAX7bqjhBsheXtmcgiciC/ZyAB7UC0KsNx2xqYrIDE0YQm6WXRg90qsX7a30SrLfQ=="
     },
     "node_modules/@xmtp/proto": {
       "version": "3.28.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
+    "@xmtp/ecies-bindings-wasm": "^0.1.5",
     "@xmtp/proto": "^3.28.0-beta.1",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",

--- a/src/crypto/SelfEncryption.ts
+++ b/src/crypto/SelfEncryption.ts
@@ -1,0 +1,32 @@
+import {
+  // eslint-disable-next-line camelcase
+  ecies_decrypt_k256_sha3_256,
+  // eslint-disable-next-line camelcase
+  ecies_encrypt_k256_sha3_256,
+} from '@xmtp/ecies-bindings-wasm'
+import { PrivateKey } from '.'
+
+// Uses ECIES to encrypt messages where the sender and recipient are the same
+export default class SelfEncryption {
+  privateKey: PrivateKey
+
+  constructor(identityKey: PrivateKey) {
+    this.privateKey = identityKey
+  }
+
+  encrypt(data: Uint8Array): Uint8Array {
+    return ecies_encrypt_k256_sha3_256(
+      this.privateKey.publicKey.secp256k1Uncompressed.bytes,
+      this.privateKey.secp256k1.bytes,
+      data
+    )
+  }
+
+  decrypt(message: Uint8Array): Uint8Array {
+    return ecies_decrypt_k256_sha3_256(
+      this.privateKey.publicKey.secp256k1Uncompressed.bytes,
+      this.privateKey.secp256k1.bytes,
+      message
+    )
+  }
+}

--- a/test/crypto/P4Encryption.test.ts
+++ b/test/crypto/P4Encryption.test.ts
@@ -1,0 +1,36 @@
+import { PrivateKeyBundleV1 } from '../../src/crypto/PrivateKeyBundle'
+import SelfEncryption from '../../src/crypto/SelfEncryption'
+import { newWallet } from '../helpers'
+import { equalBytes } from '../../src/crypto/utils'
+
+describe('SelfEncryption', () => {
+  let bundle: PrivateKeyBundleV1
+
+  beforeEach(async () => {
+    bundle = await PrivateKeyBundleV1.generate(newWallet())
+  })
+
+  it('round trips data', async () => {
+    const message = new TextEncoder().encode('hello world')
+    const encryptor = new SelfEncryption(bundle.identityKey)
+
+    const ciphertext = encryptor.encrypt(message)
+    expect(ciphertext).toBeDefined()
+
+    const decrypted = encryptor.decrypt(ciphertext)
+    expect(equalBytes(decrypted, message)).toBeTruthy()
+  })
+
+  it('throws on decryption failure', async () => {
+    const message = new TextEncoder().encode('hello world')
+    const encryptor = new SelfEncryption(bundle.identityKey)
+
+    const ciphertext = encryptor.encrypt(message)
+    expect(ciphertext).toBeDefined()
+
+    const differentEncryptor = new SelfEncryption(
+      (await PrivateKeyBundleV1.generate(newWallet())).identityKey
+    )
+    expect(() => differentEncryptor.decrypt(ciphertext)).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Creates a class wrapping our new WASM-backed self encryption
- The results from `encrypt` are safe to publish directly to the network