### PR TITLE
feat: return DecodedMessage when sending PreparedMessage

### DIFF
--- a/src/PreparedMessage.ts
+++ b/src/PreparedMessage.ts
@@ -1,12 +1,16 @@
 import { Envelope } from '@xmtp/proto/ts/dist/types/message_api/v1/message_api.pb'
 import { bytesToHex } from './crypto/utils'
 import { sha256 } from './crypto/encryption'
+import { DecodedMessage } from './Message'
 
 export class PreparedMessage {
   messageEnvelope: Envelope
-  onSend: () => Promise<void>
+  onSend: () => Promise<DecodedMessage>
 
-  constructor(messageEnvelope: Envelope, onSend: () => Promise<void>) {
+  constructor(
+    messageEnvelope: Envelope,
+    onSend: () => Promise<DecodedMessage>
+  ) {
     this.messageEnvelope = messageEnvelope
     this.onSend = onSend
   }
@@ -20,6 +24,6 @@ export class PreparedMessage {
   }
 
   async send() {
-    await this.onSend()
+    return this.onSend()
   }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -235,22 +235,24 @@ export class ConversationV1<ContentTypes>
       recipient = recipient.toLegacyBundle()
     }
 
+    const topic = options?.ephemeral ? this.ephemeralTopic : this.topic
+
     if (!this.client.contacts.has(this.peerAddress)) {
       topics = [
         buildUserIntroTopic(this.peerAddress),
         buildUserIntroTopic(this.client.address),
-        this.topic,
+        topic,
       ]
       this.client.contacts.add(this.peerAddress)
     } else {
-      topics = [this.topic]
+      topics = [topic]
     }
     const payload = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, recipient, options?.timestamp)
     const msgBytes = msg.toBytes()
 
     const env: messageApi.Envelope = {
-      contentTopic: this.topic,
+      contentTopic: topic,
       message: msgBytes,
       timestampNs: toNanoString(msg.sent),
     }
@@ -269,7 +271,7 @@ export class ConversationV1<ContentTypes>
         content,
         options?.contentType || ContentTypeText,
         payload,
-        topics[0],
+        topic,
         this
       )
     })
@@ -351,7 +353,7 @@ export class ConversationV1<ContentTypes>
       ]
       this.client.contacts.add(this.peerAddress)
     } else {
-      topics = [this.topic]
+      topics = [topic]
     }
     const contentType = options?.contentType || ContentTypeText
     const payload = await this.client.encodeContent(content, options)
@@ -370,7 +372,7 @@ export class ConversationV1<ContentTypes>
       content,
       contentType,
       payload,
-      topics[0], // Just use the first topic for the returned value
+      topic,
       this
     )
   }
@@ -539,12 +541,7 @@ export class ConversationV2<ContentTypes>
     const payload = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, options?.timestamp)
 
-    let topic: string
-    if (options?.ephemeral) {
-      topic = this.ephemeralTopic
-    } else {
-      topic = this.topic
-    }
+    const topic = options?.ephemeral ? this.ephemeralTopic : this.topic
 
     await this.client.publishEnvelopes([
       {
@@ -559,7 +556,7 @@ export class ConversationV2<ContentTypes>
       msg,
       content,
       contentType,
-      this.topic,
+      topic,
       payload,
       this,
       this.client.address
@@ -726,7 +723,7 @@ export class ConversationV2<ContentTypes>
     return new PreparedMessage(env, async () => {
       await this.client.publishEnvelopes([
         {
-          contentTopic: this.topic,
+          contentTopic: topic,
           message: msgBytes,
           timestamp: msg.sent,
         },

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -138,11 +138,13 @@ describe('conversation', () => {
       const preparedMessage = await aliceConversation.prepareMessage('1')
       const messageID = await preparedMessage.messageID()
 
-      await preparedMessage.send()
+      const sentMessage = await preparedMessage.send()
 
       const messages = await aliceConversation.messages()
       const message = messages[0]
       expect(message.id).toBe(messageID)
+      expect(sentMessage.id).toBe(messageID)
+      expect(sentMessage.messageVersion).toBe('v1')
     })
 
     it('can send a prepared message v2', async () => {
@@ -157,12 +159,14 @@ describe('conversation', () => {
       const preparedMessage = await aliceConversation.prepareMessage('sup')
       const messageID = await preparedMessage.messageID()
 
-      await preparedMessage.send()
+      const sentMessage = await preparedMessage.send()
 
       const messages = await aliceConversation.messages()
       const message = messages[0]
       expect(message.id).toBe(messageID)
       expect(message.content).toBe('sup')
+      expect(sentMessage.id).toBe(messageID)
+      expect(sentMessage.messageVersion).toBe('v2')
     })
 
     it('can send and stream ephemeral topic v1', async () => {


### PR DESCRIPTION
after sending a prepared message, there's no easy way to access the `DecodedMessage` of the sent message. this PR returns a `DecodedMessage` from the `send` method of a `PreparedMessage`.