### PR TITLE
Support running specific tests via npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "updateSnapVersion": "npm view @xmtp/snap --json | jq '{\"version\": .version, \"package\": .name}' > ./src/snapInfo.json",
     "test:setup": "./dev/up",
     "test:teardown": "./dev/down",
-    "test": "npm run test:node",
+    "test": "npm run test:node --",
     "test:node": "jest --no-cache --env='node' --testTimeout=30000",
     "test:jsdom": "jest --no-cache --env='./jest.jsdom.env.cjs' --testTimeout=30000",
     "test:cov": "jest --coverage --no-cache --runInBand",


### PR DESCRIPTION
Update the package.json/scripts/test entry to include a `--` suffix so that we can run specific tests via `npm run test`. For example, `npm run test -- -t 'viem'`.

Without this suffix, using `npm run test -- -t '...'` doesn't work as expected, but `npm run test:node -- -t '...'` does.