### PR TITLE
Add `startTime` option, remove auto-fetch and auto-allow consent calls

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -197,8 +197,8 @@ export type PreEventCallbackOptions = {
   preEnableIdentityCallback?: PreEventCallback
 }
 
-export type ConsentListOptions = {
-  enableConsentList: boolean
+export type ConsentOptions = {
+  enableConsent: boolean
 }
 
 /**
@@ -211,7 +211,7 @@ export type ClientOptions = Flatten<
     ContentOptions &
     LegacyOptions &
     PreEventCallbackOptions &
-    ConsentListOptions
+    ConsentOptions
 >
 
 /**
@@ -234,7 +234,7 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
     disablePersistenceEncryption: false,
     keystoreProviders: defaultKeystoreProviders(),
     apiClientFactory: createHttpApiClientFromOptions,
-    enableConsentList: false,
+    enableConsent: false,
   }
 
   if (opts?.codecs) {
@@ -272,14 +272,14 @@ export default class Client<ContentTypes = any> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _codecs: Map<string, ContentCodec<any>>
   private _maxContentSize: number
-  readonly _enableConsentList: boolean
+  readonly consentEnabled: boolean
 
   constructor(
     publicKeyBundle: PublicKeyBundle,
     apiClient: ApiClient,
     backupClient: BackupClient,
     keystore: Keystore,
-    enableConsentList: boolean = false
+    enableConsent: boolean = false
   ) {
     this.contacts = new Contacts(this)
     this.knownPublicKeyBundles = new Map<
@@ -295,7 +295,7 @@ export default class Client<ContentTypes = any> {
     this._maxContentSize = MaxContentSize
     this.apiClient = apiClient
     this._backupClient = backupClient
-    this._enableConsentList = enableConsentList
+    this.consentEnabled = enableConsent
   }
 
   /**
@@ -340,13 +340,7 @@ export default class Client<ContentTypes = any> {
     const backupClient = await Client.setupBackupClient(address, options.env)
     const client = new Client<
       ExtractDecodedType<[...ContentCodecs, TextCodec][number]> | undefined
-    >(
-      publicKeyBundle,
-      apiClient,
-      backupClient,
-      keystore,
-      opts?.enableConsentList
-    )
+    >(publicKeyBundle, apiClient, backupClient, keystore, opts?.enableConsent)
     await client.init(options)
     return client
   }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -197,10 +197,6 @@ export type PreEventCallbackOptions = {
   preEnableIdentityCallback?: PreEventCallback
 }
 
-export type ConsentOptions = {
-  enableConsent: boolean
-}
-
 /**
  * Aggregate type for client options. Optional properties are used when the default value is calculated on invocation, and are computed
  * as needed by each function. All other defaults are specified in defaultOptions.
@@ -210,8 +206,7 @@ export type ClientOptions = Flatten<
     KeyStoreOptions &
     ContentOptions &
     LegacyOptions &
-    PreEventCallbackOptions &
-    ConsentOptions
+    PreEventCallbackOptions
 >
 
 /**
@@ -234,7 +229,6 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
     disablePersistenceEncryption: false,
     keystoreProviders: defaultKeystoreProviders(),
     apiClientFactory: createHttpApiClientFromOptions,
-    enableConsent: false,
   }
 
   if (opts?.codecs) {
@@ -272,14 +266,12 @@ export default class Client<ContentTypes = any> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _codecs: Map<string, ContentCodec<any>>
   private _maxContentSize: number
-  readonly consentEnabled: boolean
 
   constructor(
     publicKeyBundle: PublicKeyBundle,
     apiClient: ApiClient,
     backupClient: BackupClient,
-    keystore: Keystore,
-    enableConsent: boolean = false
+    keystore: Keystore
   ) {
     this.contacts = new Contacts(this)
     this.knownPublicKeyBundles = new Map<
@@ -295,7 +287,6 @@ export default class Client<ContentTypes = any> {
     this._maxContentSize = MaxContentSize
     this.apiClient = apiClient
     this._backupClient = backupClient
-    this.consentEnabled = enableConsent
   }
 
   /**
@@ -340,7 +331,7 @@ export default class Client<ContentTypes = any> {
     const backupClient = await Client.setupBackupClient(address, options.env)
     const client = new Client<
       ExtractDecodedType<[...ContentCodecs, TextCodec][number]> | undefined
-    >(publicKeyBundle, apiClient, backupClient, keystore, opts?.enableConsent)
+    >(publicKeyBundle, apiClient, backupClient, keystore)
     await client.init(options)
     return client
   }

--- a/src/Contacts.ts
+++ b/src/Contacts.ts
@@ -175,9 +175,7 @@ export class Contacts {
   }
 
   async refreshConsentList(startTime?: Date) {
-    if (this.client.consentEnabled) {
-      this.consentList = await ConsentList.load(this.client, startTime)
-    }
+    this.consentList = await ConsentList.load(this.client, startTime)
   }
 
   isAllowed(address: string) {
@@ -193,20 +191,16 @@ export class Contacts {
   }
 
   async allow(addresses: string[]) {
-    if (this.client.consentEnabled) {
-      await ConsentList.publish(
-        addresses.map((address) => this.consentList.allow(address)),
-        this.client
-      )
-    }
+    await ConsentList.publish(
+      addresses.map((address) => this.consentList.allow(address)),
+      this.client
+    )
   }
 
   async block(addresses: string[]) {
-    if (this.client.consentEnabled) {
-      await ConsentList.publish(
-        addresses.map((address) => this.consentList.block(address)),
-        this.client
-      )
-    }
+    await ConsentList.publish(
+      addresses.map((address) => this.consentList.block(address)),
+      this.client
+    )
   }
 }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -49,9 +49,6 @@ export default class Conversations<ContentTypes = any> {
       this.listV2Conversations(),
     ])
 
-    // fetch allow list if enabled
-    this.client.contacts.refreshConsentList()
-
     const conversations = v1Convos.concat(v2Convos)
 
     conversations.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
@@ -571,9 +568,7 @@ export default class Conversations<ContentTypes = any> {
     ])
 
     // add peer address to allow list
-    if (this.client.consentEnabled) {
-      this.client.contacts.allow([peerAddress])
-    }
+    this.client.contacts.allow([peerAddress])
 
     return this.conversationReferenceToV2(conversation)
   }

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -571,7 +571,7 @@ export default class Conversations<ContentTypes = any> {
     ])
 
     // add peer address to allow list
-    if (this.client._enableConsentList) {
+    if (this.client.consentEnabled) {
       this.client.contacts.allow([peerAddress])
     }
 

--- a/src/crypto/ecies.ts
+++ b/src/crypto/ecies.ts
@@ -110,7 +110,6 @@ async function hmacSha256Verify(key: Buffer, msg: Buffer, sig: Buffer) {
 /**
  * Generate a new valid private key. Will use the window.crypto or window.msCrypto as source
  * depending on your browser.
- *
  * @returns {Buffer} A 32-byte private key.
  * @function
  */

--- a/src/message-backup/BackupClientFactory.ts
+++ b/src/message-backup/BackupClientFactory.ts
@@ -10,12 +10,11 @@ import TopicStoreBackupClient from './TopicStoreBackupClient'
  * Creates a backup client of the correct provider type (e.g. xmtp backup, no backup, etc).
  * Uses an existing user preference from the backend if it exists, else prompts for a new
  * one using the `providerSelector`
- *
  * @param walletAddress The public address of the user's wallet
  * @param selectBackupProvider A callback for determining the provider to use, in the event there is no
  * existing user preference. The app can define the policy to use here (e.g. prompt the user,
  * or default to a certain provider type).
- * @returns A backup client of the correct type
+ * @returns {Promise<BackupClient>} A backup client of the correct type
  */
 export async function createBackupClient(
   walletAddress: string,

--- a/test/Contacts.test.ts
+++ b/test/Contacts.test.ts
@@ -14,15 +14,12 @@ describe('Contacts', () => {
   beforeEach(async () => {
     aliceClient = await Client.create(alice, {
       env: 'local',
-      enableConsent: true,
     })
     bobClient = await Client.create(bob, {
       env: 'local',
-      enableConsent: true,
     })
     carolClient = await Client.create(carol, {
       env: 'local',
-      enableConsent: true,
     })
   })
 
@@ -102,7 +99,6 @@ describe('Contacts', () => {
 
     aliceClient = await Client.create(alice, {
       env: 'local',
-      enableConsent: true,
     })
 
     expect(aliceClient.contacts.consentState(bob.address)).toBe('unknown')

--- a/test/Contacts.test.ts
+++ b/test/Contacts.test.ts
@@ -14,15 +14,15 @@ describe('Contacts', () => {
   beforeEach(async () => {
     aliceClient = await Client.create(alice, {
       env: 'local',
-      enableConsentList: true,
+      enableConsent: true,
     })
     bobClient = await Client.create(bob, {
       env: 'local',
-      enableConsentList: true,
+      enableConsent: true,
     })
     carolClient = await Client.create(carol, {
       env: 'local',
-      enableConsentList: true,
+      enableConsent: true,
     })
   })
 
@@ -102,7 +102,7 @@ describe('Contacts', () => {
 
     aliceClient = await Client.create(alice, {
       env: 'local',
-      enableConsentList: true,
+      enableConsent: true,
     })
 
     expect(aliceClient.contacts.consentState(bob.address)).toBe('unknown')


### PR DESCRIPTION
in this PR:

- added `startTime` option when loading / refreshing a consent list to allow for smaller updates when consent is cached locally
- removed client option to enable consent
- removed consent list auto-fetch when fetching conversations