### PR TITLE
feat: add self encryption support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.29.0",
+        "@xmtp/ecies-bindings-wasm": "^0.1.7",
+        "@xmtp/proto": "^3.32.0",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -4819,10 +4820,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@xmtp/ecies-bindings-wasm": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@xmtp/ecies-bindings-wasm/-/ecies-bindings-wasm-0.1.7.tgz",
+      "integrity": "sha512-+bwI5koXneyRLVUh9Mpm9Md7A1w8GdEKqPPEVhaszfWyGr1eSeMOnkLZ0JCXMxCirYJcmiC/aua96LiuAQpACQ=="
+    },
     "node_modules/@xmtp/proto": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.29.0.tgz",
-      "integrity": "sha512-+ibo+u6NwdzfLN3QEDMiNrnXd7eT1/+F2j5WWz3b4mk91wgn8lJ66fxFPwLTQs6AbaBBUmhO2cdpgIL/g4kvZg==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.32.0.tgz",
+      "integrity": "sha512-rA05O3CtGEsVl5cLr9qCFg08lKeNiWsJiAOt33I1u9hQPgzm4JOywnc6GJrJomwED3cZ1TsKTf/1sj3yCzaDIA==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@xmtp/proto": "^3.29.0",
+    "@xmtp/ecies-bindings-wasm": "^0.1.7",
+    "@xmtp/proto": "^3.32.0",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
     "ethers": "^5.5.3",

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -29,6 +29,9 @@ import { hmacSha256Sign } from '../crypto/ecies'
 import crypto from '../crypto/crypto'
 import { bytesToHex } from '../crypto/utils'
 import Long from 'long'
+import { selfDecrypt, selfEncrypt } from '../keystore/encryption'
+// eslint-disable-next-line camelcase
+import { generate_private_preferences_topic } from '@xmtp/ecies-bindings-wasm'
 
 const { ErrorCode } = keystore
 
@@ -195,6 +198,68 @@ export default class InMemoryKeystore implements Keystore {
     return this.authenticator.createToken(
       timestampNs ? nsToDate(timestampNs) : undefined
     )
+  }
+
+  async selfEncrypt(
+    req: keystore.SelfEncryptRequest
+  ): Promise<keystore.SelfEncryptResponse> {
+    const responses = await mapAndConvertErrors(
+      req.requests,
+      async (req) => {
+        const { payload } = req
+
+        if (!payload) {
+          throw new KeystoreError(
+            ErrorCode.ERROR_CODE_INVALID_INPUT,
+            'Missing field payload'
+          )
+        }
+
+        return {
+          encrypted: await selfEncrypt(this.v1Keys.identityKey, payload),
+        }
+      },
+      ErrorCode.ERROR_CODE_INVALID_INPUT
+    )
+
+    return keystore.SelfEncryptResponse.fromPartial({
+      responses,
+    })
+  }
+
+  async selfDecrypt(
+    req: keystore.SelfDecryptRequest
+  ): Promise<keystore.DecryptResponse> {
+    const responses = await mapAndConvertErrors(
+      req.requests,
+      async (req) => {
+        const { payload } = req
+
+        if (!payload) {
+          throw new KeystoreError(
+            ErrorCode.ERROR_CODE_INVALID_INPUT,
+            'Missing field payload'
+          )
+        }
+
+        return {
+          decrypted: await selfDecrypt(this.v1Keys.identityKey, payload),
+        }
+      },
+      ErrorCode.ERROR_CODE_INVALID_INPUT
+    )
+
+    return keystore.DecryptResponse.fromPartial({
+      responses,
+    })
+  }
+
+  async getPrivatePreferencesTopicIdentifier(): Promise<keystore.GetPrivatePreferencesTopicIdentifierResponse> {
+    const privateKey = this.v1Keys.identityKey.secp256k1.bytes
+    const identifier = generate_private_preferences_topic(privateKey).toString()
+    return keystore.GetPrivatePreferencesTopicIdentifierResponse.fromPartial({
+      identifier,
+    })
   }
 
   async encryptV2(

--- a/src/keystore/encryption.ts
+++ b/src/keystore/encryption.ts
@@ -3,8 +3,15 @@ import {
   encrypt,
   PrivateKeyBundleV1,
   decrypt,
+  PrivateKey,
 } from '../crypto'
 import { ciphertext } from '@xmtp/proto'
+import {
+  // eslint-disable-next-line camelcase
+  ecies_decrypt_k256_sha3_256,
+  // eslint-disable-next-line camelcase
+  ecies_encrypt_k256_sha3_256,
+} from '@xmtp/ecies-bindings-wasm'
 
 export const decryptV1 = async (
   myKeys: PrivateKeyBundleV1,
@@ -48,3 +55,21 @@ export const encryptV2 = (
   secret: Uint8Array,
   headerBytes: Uint8Array
 ) => encrypt(payload, secret, headerBytes)
+
+export async function selfEncrypt(
+  identityKey: PrivateKey,
+  payload: Uint8Array
+) {
+  const publicKey = identityKey.publicKey.secp256k1Uncompressed.bytes
+  const privateKey = identityKey.secp256k1.bytes
+  return ecies_encrypt_k256_sha3_256(publicKey, privateKey, payload)
+}
+
+export async function selfDecrypt(
+  identityKey: PrivateKey,
+  payload: Uint8Array
+) {
+  const publicKey = identityKey.publicKey.secp256k1Uncompressed.bytes
+  const privateKey = identityKey.secp256k1.bytes
+  return ecies_decrypt_k256_sha3_256(publicKey, privateKey, payload)
+}

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -81,6 +81,22 @@ export interface Keystore {
    * Get the account address of the wallet used to create the Keystore
    */
   getAccountAddress(): Promise<string>
+  /**
+   * Encrypt a batch of messages to yourself
+   */
+  selfEncrypt(
+    req: keystore.SelfEncryptRequest
+  ): Promise<keystore.SelfEncryptResponse>
+  /**
+   * Decrypt a batch of messages to yourself
+   */
+  selfDecrypt(
+    req: keystore.SelfDecryptRequest
+  ): Promise<keystore.DecryptResponse>
+  /**
+   * Get the private preferences topic identifier
+   */
+  getPrivatePreferencesTopicIdentifier(): Promise<keystore.GetPrivatePreferencesTopicIdentifierResponse>
 }
 
 export type TopicData = WithoutUndefined<keystore.TopicMap_TopicData>

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -73,4 +73,16 @@ export const apiDefs: ApiDefs = {
     req: keystore.SetRefeshJobRequest,
     res: keystore.SetRefreshJobResponse,
   },
+  selfEncrypt: {
+    req: keystore.SelfEncryptRequest,
+    res: keystore.SelfEncryptResponse,
+  },
+  selfDecrypt: {
+    req: keystore.SelfDecryptRequest,
+    res: keystore.DecryptResponse,
+  },
+  getPrivatePreferencesTopicIdentifier: {
+    req: null,
+    res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
+  },
 } as const


### PR DESCRIPTION
in this PR:

* upgraded proto dependency
* added `@xmtp/ecies-bindings-wasm` dependency
* added RPC definitions and keystore methods for self encryption/decryption
* added RPC definition and keystore method for retrieving PP topic identifier

these changes are already in the `beta` branch and are being added to `main` in preparation for adding MetaMask Snaps support once the PPPP work lands in `main`. these new keystore methods will be unused until then.