### PR TITLE
`block` => `deny`, update consent on message send if unknown

### DIFF
--- a/src/Contacts.ts
+++ b/src/Contacts.ts
@@ -6,7 +6,7 @@ import {
   fromNanoString,
 } from './utils'
 
-export type ConsentState = 'allowed' | 'blocked' | 'unknown'
+export type ConsentState = 'allowed' | 'denied' | 'unknown'
 
 export type ConsentListEntryType = 'address'
 
@@ -54,9 +54,9 @@ export class ConsentList {
     return entry
   }
 
-  block(address: string) {
-    const entry = ConsentListEntry.fromAddress(address, 'blocked')
-    this.entries.set(entry.key, 'blocked')
+  deny(address: string) {
+    const entry = ConsentListEntry.fromAddress(address, 'denied')
+    this.entries.set(entry.key, 'denied')
     return entry
   }
 
@@ -120,7 +120,7 @@ export class ConsentList {
         this.allow(address)
       })
       action.block?.walletAddresses.forEach((address) => {
-        this.block(address)
+        this.deny(address)
       })
     })
 
@@ -144,7 +144,7 @@ export class ConsentList {
                 }
               : undefined,
           block:
-            entry.permissionType === 'blocked'
+            entry.permissionType === 'denied'
               ? {
                   walletAddresses: [entry.value],
                 }
@@ -229,8 +229,8 @@ export class Contacts {
       if (entry.permissionType === 'allowed') {
         this.consentList.allow(entry.value)
       }
-      if (entry.permissionType === 'blocked') {
-        this.consentList.block(entry.value)
+      if (entry.permissionType === 'denied') {
+        this.consentList.deny(entry.value)
       }
     })
   }
@@ -239,8 +239,8 @@ export class Contacts {
     return this.consentList.state(address) === 'allowed'
   }
 
-  isBlocked(address: string) {
-    return this.consentList.state(address) === 'blocked'
+  isDenied(address: string) {
+    return this.consentList.state(address) === 'denied'
   }
 
   consentState(address: string) {
@@ -255,10 +255,10 @@ export class Contacts {
     )
   }
 
-  async block(addresses: string[]) {
+  async deny(addresses: string[]) {
     await this.consentList.publish(
       addresses.map((address) =>
-        ConsentListEntry.fromAddress(address, 'blocked')
+        ConsentListEntry.fromAddress(address, 'denied')
       )
     )
   }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -410,6 +410,13 @@ export class ConversationV1<ContentTypes>
       }))
     )
 
+    // if the conversation consent state is unknown, we assume the user has
+    // consented to the conversation by sending a message into it
+    if (this.consentState === 'unknown') {
+      // add conversation to the allow list
+      await this.allow()
+    }
+
     return DecodedMessage.fromV1Message(
       msg,
       content,
@@ -614,6 +621,13 @@ export class ConversationV2<ContentTypes>
       },
     ])
     const contentType = options?.contentType || ContentTypeText
+
+    // if the conversation consent state is unknown, we assume the user has
+    // consented to the conversation by sending a message into it
+    if (this.consentState === 'unknown') {
+      // add conversation to the allow list
+      await this.allow()
+    }
 
     return DecodedMessage.fromV2Message(
       msg,

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -72,18 +72,18 @@ export interface Conversation<ContentTypes = any> {
    */
   allow(): Promise<void>
   /**
-   * Add conversation peer address to block list
+   * Add conversation peer address to deny list
    */
-  block(): Promise<void>
+  deny(): Promise<void>
 
   /**
    * Returns true if conversation peer address is on the allow list
    */
   isAllowed: boolean
   /**
-   * Returns true if conversation peer address is on the block list
+   * Returns true if conversation peer address is on the deny list
    */
-  isBlocked: boolean
+  isDenied: boolean
   /**
    * Returns the consent state of the conversation peer address
    */
@@ -191,16 +191,16 @@ export class ConversationV1<ContentTypes>
     await this.client.contacts.allow([this.peerAddress])
   }
 
-  async block() {
-    await this.client.contacts.block([this.peerAddress])
+  async deny() {
+    await this.client.contacts.deny([this.peerAddress])
   }
 
   get isAllowed() {
     return this.client.contacts.isAllowed(this.peerAddress)
   }
 
-  get isBlocked() {
-    return this.client.contacts.isBlocked(this.peerAddress)
+  get isDenied() {
+    return this.client.contacts.isDenied(this.peerAddress)
   }
 
   get consentState() {
@@ -522,16 +522,16 @@ export class ConversationV2<ContentTypes>
     await this.client.contacts.allow([this.peerAddress])
   }
 
-  async block() {
-    await this.client.contacts.block([this.peerAddress])
+  async deny() {
+    await this.client.contacts.deny([this.peerAddress])
   }
 
   get isAllowed() {
     return this.client.contacts.isAllowed(this.peerAddress)
   }
 
-  get isBlocked() {
-    return this.client.contacts.isBlocked(this.peerAddress)
+  get isDenied() {
+    return this.client.contacts.isDenied(this.peerAddress)
   }
 
   get consentState() {

--- a/test/Contacts.test.ts
+++ b/test/Contacts.test.ts
@@ -29,16 +29,16 @@ describe('Contacts', () => {
     expect(Array.from(aliceClient.contacts.addresses.keys()).length).toBe(0)
   })
 
-  it('should allow and block addresses', async () => {
+  it('should allow and deny addresses', async () => {
     await aliceClient.contacts.allow([bob.address])
     expect(aliceClient.contacts.consentState(bob.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(bob.address)).toBe(true)
-    expect(aliceClient.contacts.isBlocked(bob.address)).toBe(false)
+    expect(aliceClient.contacts.isDenied(bob.address)).toBe(false)
 
-    await aliceClient.contacts.block([bob.address])
-    expect(aliceClient.contacts.consentState(bob.address)).toBe('blocked')
+    await aliceClient.contacts.deny([bob.address])
+    expect(aliceClient.contacts.consentState(bob.address)).toBe('denied')
     expect(aliceClient.contacts.isAllowed(bob.address)).toBe(false)
-    expect(aliceClient.contacts.isBlocked(bob.address)).toBe(true)
+    expect(aliceClient.contacts.isDenied(bob.address)).toBe(true)
   })
 
   it('should allow an address when a conversation is started', async () => {
@@ -48,54 +48,54 @@ describe('Contacts', () => {
 
     expect(aliceClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(true)
-    expect(aliceClient.contacts.isBlocked(carol.address)).toBe(false)
+    expect(aliceClient.contacts.isDenied(carol.address)).toBe(false)
 
     expect(conversation.isAllowed).toBe(true)
-    expect(conversation.isBlocked).toBe(false)
+    expect(conversation.isDenied).toBe(false)
     expect(conversation.consentState).toBe('allowed')
   })
 
-  it('should allow or block an address from a conversation', async () => {
+  it('should allow or deny an address from a conversation', async () => {
     const conversation = await aliceClient.conversations.newConversation(
       carol.address
     )
 
-    await conversation.block()
+    await conversation.deny()
 
-    expect(aliceClient.contacts.consentState(carol.address)).toBe('blocked')
+    expect(aliceClient.contacts.consentState(carol.address)).toBe('denied')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(false)
-    expect(aliceClient.contacts.isBlocked(carol.address)).toBe(true)
+    expect(aliceClient.contacts.isDenied(carol.address)).toBe(true)
 
     expect(conversation.isAllowed).toBe(false)
-    expect(conversation.isBlocked).toBe(true)
-    expect(conversation.consentState).toBe('blocked')
+    expect(conversation.isDenied).toBe(true)
+    expect(conversation.consentState).toBe('denied')
 
     await conversation.allow()
 
     expect(aliceClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(true)
-    expect(aliceClient.contacts.isBlocked(carol.address)).toBe(false)
+    expect(aliceClient.contacts.isDenied(carol.address)).toBe(false)
 
     expect(conversation.isAllowed).toBe(true)
-    expect(conversation.isBlocked).toBe(false)
+    expect(conversation.isDenied).toBe(false)
     expect(conversation.consentState).toBe('allowed')
   })
 
   it('should retrieve consent state', async () => {
-    await aliceClient.contacts.block([bob.address])
+    await aliceClient.contacts.deny([bob.address])
     await aliceClient.contacts.allow([carol.address])
     await aliceClient.contacts.allow([bob.address])
-    await aliceClient.contacts.block([carol.address])
-    await aliceClient.contacts.block([bob.address])
+    await aliceClient.contacts.deny([carol.address])
+    await aliceClient.contacts.deny([bob.address])
     await aliceClient.contacts.allow([carol.address])
 
-    expect(aliceClient.contacts.consentState(bob.address)).toBe('blocked')
+    expect(aliceClient.contacts.consentState(bob.address)).toBe('denied')
     expect(aliceClient.contacts.isAllowed(bob.address)).toBe(false)
-    expect(aliceClient.contacts.isBlocked(bob.address)).toBe(true)
+    expect(aliceClient.contacts.isDenied(bob.address)).toBe(true)
 
     expect(aliceClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(true)
-    expect(aliceClient.contacts.isBlocked(carol.address)).toBe(false)
+    expect(aliceClient.contacts.isDenied(carol.address)).toBe(false)
 
     aliceClient = await Client.create(alice, {
       env: 'local',
@@ -106,12 +106,12 @@ describe('Contacts', () => {
 
     await aliceClient.contacts.refreshConsentList()
 
-    expect(aliceClient.contacts.consentState(bob.address)).toBe('blocked')
+    expect(aliceClient.contacts.consentState(bob.address)).toBe('denied')
     expect(aliceClient.contacts.isAllowed(bob.address)).toBe(false)
-    expect(aliceClient.contacts.isBlocked(bob.address)).toBe(true)
+    expect(aliceClient.contacts.isDenied(bob.address)).toBe(true)
 
     expect(aliceClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(true)
-    expect(aliceClient.contacts.isBlocked(carol.address)).toBe(false)
+    expect(aliceClient.contacts.isDenied(carol.address)).toBe(false)
   })
 })

--- a/test/Contacts.test.ts
+++ b/test/Contacts.test.ts
@@ -55,6 +55,27 @@ describe('Contacts', () => {
     expect(conversation.consentState).toBe('allowed')
   })
 
+  it('should allow an address when a conversation has an unknown consent state and a message is sent into it', async () => {
+    await aliceClient.conversations.newConversation(carol.address)
+
+    expect(carolClient.contacts.consentState(alice.address)).toBe('unknown')
+    expect(carolClient.contacts.isAllowed(carol.address)).toBe(false)
+    expect(carolClient.contacts.isDenied(carol.address)).toBe(false)
+
+    const carolConversation = await carolClient.conversations.newConversation(
+      alice.address
+    )
+    expect(carolConversation.consentState).toBe('unknown')
+    expect(carolConversation.isAllowed).toBe(false)
+    expect(carolConversation.isDenied).toBe(false)
+
+    await carolConversation.send('gm')
+
+    expect(carolConversation.consentState).toBe('allowed')
+    expect(carolConversation.isAllowed).toBe(true)
+    expect(carolConversation.isDenied).toBe(false)
+  })
+
   it('should allow or deny an address from a conversation', async () => {
     const conversation = await aliceClient.conversations.newConversation(
       carol.address


### PR DESCRIPTION
in this PR:

* changed all instances of `block`/`blocked` to `deny`/`denied`
* added consent change to `allowed` when sending a message into a conversation with an `unknown` consent state
* added better tracking for the timestamp of the last consent entry to allow for more accurate progressive updating of the consent list
* added ability to set the consent list directly to allow for loading of cached entries