### PR TITLE
Add consent list streaming

### DIFF
--- a/test/Contacts.test.ts
+++ b/test/Contacts.test.ts
@@ -1,3 +1,4 @@
+import { privatePreferences } from '@xmtp/proto'
 import Client from '../src/Client'
 import { Contacts } from '../src/Contacts'
 import { newWallet } from './helpers'
@@ -134,5 +135,21 @@ describe('Contacts', () => {
     expect(aliceClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(aliceClient.contacts.isAllowed(carol.address)).toBe(true)
     expect(aliceClient.contacts.isDenied(carol.address)).toBe(false)
+  })
+
+  it('should stream consent updates', async () => {
+    const aliceStream = await aliceClient.contacts.streamConsentList()
+    await aliceClient.conversations.newConversation(bob.address)
+
+    let numActions = 0
+    const actions: privatePreferences.PrivatePreferencesAction[] = []
+    for await (const action of aliceStream) {
+      numActions++
+      expect(action.block).toBeUndefined()
+      expect(action.allow?.walletAddresses).toEqual([bob.address])
+      break
+    }
+    expect(numActions).toBe(1)
+    await aliceStream.return()
   })
 })


### PR DESCRIPTION
in this PR:

- added `streamConsentList` method to allow for streaming of new consent entries
- reorganized some code for easier reuse

as the consent messages stream in, the internal consent list is updated.