### PR TITLE
Use JobRunner to load consent list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@xmtp/ecies-bindings-wasm": "^0.1.7",
-        "@xmtp/proto": "^3.32.0",
+        "@xmtp/proto": "^3.34.0",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -4826,9 +4826,9 @@
       "integrity": "sha512-+bwI5koXneyRLVUh9Mpm9Md7A1w8GdEKqPPEVhaszfWyGr1eSeMOnkLZ0JCXMxCirYJcmiC/aua96LiuAQpACQ=="
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.32.0.tgz",
-      "integrity": "sha512-rA05O3CtGEsVl5cLr9qCFg08lKeNiWsJiAOt33I1u9hQPgzm4JOywnc6GJrJomwED3cZ1TsKTf/1sj3yCzaDIA==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.34.0.tgz",
+      "integrity": "sha512-UJ0doz01peGEi5+fJ6th6JsUXFLMHaVk9L9avrv7L7FhfmAzM/V5iqHao8YpIKyMrJ7BelsGrbDcTfe28SsxFg==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@xmtp/ecies-bindings-wasm": "^0.1.7",
-    "@xmtp/proto": "^3.32.0",
+    "@xmtp/proto": "^3.34.0",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
     "ethers": "^5.5.3",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -273,7 +273,6 @@ export default class Client<ContentTypes = any> {
     backupClient: BackupClient,
     keystore: Keystore
   ) {
-    this.contacts = new Contacts(this)
     this.knownPublicKeyBundles = new Map<
       string,
       PublicKeyBundle | SignedPublicKeyBundle
@@ -287,6 +286,7 @@ export default class Client<ContentTypes = any> {
     this._maxContentSize = MaxContentSize
     this.apiClient = apiClient
     this._backupClient = backupClient
+    this.contacts = new Contacts(this)
   }
 
   /**

--- a/src/Contacts.ts
+++ b/src/Contacts.ts
@@ -283,7 +283,7 @@ export class Contacts {
     if (!entries.length) {
       return
     }
-    this.consentList.entries.clear()
+    this.consentList.reset()
     entries.forEach((entry) => {
       if (entry.permissionType === 'allowed') {
         this.consentList.allow(entry.value)

--- a/src/Contacts.ts
+++ b/src/Contacts.ts
@@ -7,6 +7,7 @@ import {
 } from './utils'
 import Stream from './Stream'
 import { OnConnectionLostCallback } from './ApiClient'
+import JobRunner from './conversations/JobRunner'
 
 export type ConsentState = 'allowed' | 'denied' | 'unknown'
 
@@ -103,18 +104,21 @@ export class ConsentList {
     actions: privatePreferences.PrivatePreferencesAction[],
     lastTimestampNs?: string
   ) {
+    const entries: ConsentListEntry[] = []
     actions.forEach((action) => {
       action.allow?.walletAddresses.forEach((address) => {
-        this.allow(address)
+        entries.push(this.allow(address))
       })
       action.block?.walletAddresses.forEach((address) => {
-        this.deny(address)
+        entries.push(this.deny(address))
       })
     })
 
     if (lastTimestampNs) {
       this.lastEntryTimestamp = fromNanoString(lastTimestampNs)
     }
+
+    return entries
   }
 
   async stream(onConnectionLost?: OnConnectionLostCallback) {
@@ -140,12 +144,12 @@ export class ConsentList {
     )
   }
 
+  reset() {
+    // clear existing entries
+    this.entries.clear()
+  }
+
   async load(startTime?: Date) {
-    // no startTime, all entries will be fetched
-    if (!startTime) {
-      // clear existing entries
-      this.entries.clear()
-    }
     const identifier = await this.getIdentifier()
     const contentTopic = buildUserPrivatePreferencesTopic(identifier)
 
@@ -167,7 +171,7 @@ export class ConsentList {
     const actions = await this.decodeMessages(messages)
 
     // update consent list
-    this.processActions(actions, lastTimestampNs)
+    return this.processActions(actions, lastTimestampNs)
   }
 
   async publish(entries: ConsentListEntry[]) {
@@ -239,19 +243,29 @@ export class Contacts {
    */
   client: Client
   private consentList: ConsentList
+  private jobRunner: JobRunner
 
   constructor(client: Client) {
     this.addresses = new Set<string>()
     this.consentList = new ConsentList(client)
     this.client = client
+    this.jobRunner = new JobRunner('pppp', client.keystore)
   }
 
   async loadConsentList(startTime?: Date) {
-    await this.consentList.load(startTime)
+    return this.jobRunner.run(async (lastRun) => {
+      // allow for override of startTime
+      return this.consentList.load(startTime ?? lastRun)
+    })
   }
 
   async refreshConsentList() {
-    await this.loadConsentList()
+    // clear existing consent list
+    this.consentList.reset()
+    // reset last run time to the epoch
+    await this.jobRunner.resetLastRunTime()
+    // reload the consent list
+    return this.loadConsentList()
   }
 
   async streamConsentList(onConnectionLost?: OnConnectionLostCallback) {
@@ -261,7 +275,7 @@ export class Contacts {
   /**
    * The timestamp of the last entry in the consent list
    */
-  get lastSyncedAt() {
+  get lastConsentListEntryTimestamp() {
     return this.consentList.lastEntryTimestamp
   }
 

--- a/src/conversations/Conversations.ts
+++ b/src/conversations/Conversations.ts
@@ -19,8 +19,6 @@ import { SortDirection } from '../ApiClient'
 import Long from 'long'
 import JobRunner from './JobRunner'
 
-const CLOCK_SKEW_OFFSET_MS = 10000
-
 const messageHasHeaders = (msg: MessageV1): boolean => {
   return Boolean(msg.recipientAddress && msg.senderAddress)
 }
@@ -74,9 +72,7 @@ export default class Conversations<ContentTypes = any> {
   private async listV1Conversations(): Promise<Conversation<ContentTypes>[]> {
     return this.v1JobRunner.run(async (latestSeen) => {
       const seenPeers = await this.getIntroductionPeers({
-        startTime: latestSeen
-          ? new Date(+latestSeen - CLOCK_SKEW_OFFSET_MS)
-          : undefined,
+        startTime: latestSeen,
         direction: SortDirection.SORT_DIRECTION_ASCENDING,
       })
 
@@ -144,9 +140,7 @@ export default class Conversations<ContentTypes = any> {
     startTime?: Date
   ): Promise<ConversationV2<ContentTypes>[]> {
     const envelopes = await this.client.listInvitations({
-      startTime: startTime
-        ? new Date(+startTime - CLOCK_SKEW_OFFSET_MS)
-        : undefined,
+      startTime,
       direction: SortDirection.SORT_DIRECTION_ASCENDING,
     })
 

--- a/test/conversations/JobRunner.test.ts
+++ b/test/conversations/JobRunner.test.ts
@@ -81,4 +81,23 @@ describe('JobRunner', () => {
       })
     ).rejects.toThrow('foo')
   })
+
+  it('resets the last run time', async () => {
+    const ppppRunner = new JobRunner('pppp', keystore)
+    await ppppRunner.run(async () => {})
+
+    const { lastRunNs: ppppLastRunNs } = await keystore.getRefreshJob({
+      jobType: keystoreProto.JobType.JOB_TYPE_REFRESH_PPPP,
+    })
+
+    expect(ppppLastRunNs.gt(0)).toBeTruthy()
+
+    await ppppRunner.resetLastRunTime()
+
+    const { lastRunNs: ppppLastRunNs2 } = await keystore.getRefreshJob({
+      jobType: keystoreProto.JobType.JOB_TYPE_REFRESH_PPPP,
+    })
+
+    expect(ppppLastRunNs2.eq(0)).toBeTruthy()
+  })
 })


### PR DESCRIPTION
in this PR:

* upgraded `@xmtp/proto` to support new `JobRunner` type
* added `pppp` type to `JobRunner`
* added `resetLastRunTime` method to `JobRunner` (see note below)
* included time offset logic in `JobRunner` with option to disable it
* removed time offset logic from `conversations.list()` as it's now included with the `JobRunner`
* added `reset` method to `ConsentList` for clearing the current list
* removed logic to auto reset the consent list when loading it when `startTime` was `undefined`
* added `JobRunner` for loading the consent list
* added return value (entries) when loading the consent list
* renamed `lastSyncedAt` => `lastConsentListEntryTimestamp`

#### resetLastRunTime

the `Persistence` interface doesn't support `removeItem` as it's not supported in every persistence layer and would require additional work to support in others. also, the `setItem` method doesn't accept nil values. in order to support a "reset" of the last run time, this new method simply sets it to the epoch date.