### PR TITLE
Add `senderHmac` and `shouldPush` to `MessageV2`

### DIFF
--- a/bench/decode.ts
+++ b/bench/decode.ts
@@ -22,9 +22,10 @@ const decodeV1 = () => {
       const bob = await newPrivateKeyBundle()
 
       const message = randomBytes(size)
+      const { payload } = await alice.encodeContent(message)
       const encodedMessage = await MessageV1.encode(
         alice.keystore,
-        await alice.encodeContent(message),
+        payload,
         alice.publicKeyBundle,
         bob.getPublicKeyBundle(),
         new Date()
@@ -75,8 +76,8 @@ const decodeV2 = () => {
         new Date(),
         undefined
       )
-      const payload = await alice.encodeContent(message)
-      const encodedMessage = await convo.createMessage(payload)
+      const { payload, shouldPush } = await alice.encodeContent(message)
+      const encodedMessage = await convo.createMessage(payload, shouldPush)
       const messageBytes = encodedMessage.toBytes()
 
       const envelope = {

--- a/bench/encode.ts
+++ b/bench/encode.ts
@@ -22,7 +22,7 @@ const encodeV1 = () => {
 
       // The returned function is the actual benchmark. Everything above is setup
       return async () => {
-        const encodedMessage = await alice.encodeContent(message)
+        const { payload: encodedMessage } = await alice.encodeContent(message)
         await MessageV1.encode(
           alice.keystore,
           encodedMessage,
@@ -57,11 +57,11 @@ const encodeV2 = () => {
         undefined
       )
       const message = randomBytes(size)
-      const payload = await alice.encodeContent(message)
+      const { payload, shouldPush } = await alice.encodeContent(message)
 
       // The returned function is the actual benchmark. Everything above is setup
       return async () => {
-        await convo.createMessage(payload)
+        await convo.createMessage(payload, shouldPush)
       }
     })
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.37.0-beta.1",
+        "@xmtp/proto": "^3.37.0-beta.2",
         "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.37.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.37.0-beta.1.tgz",
-      "integrity": "sha512-060+4wSnrN1yvUxEDdWyJt0v8f2gr0lt6Bt5wK8/9w6hH0OWyzO09PHccbHe2wkBqg36gANMPw9rQh2hmtlAkg==",
+      "version": "3.37.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.37.0-beta.2.tgz",
+      "integrity": "sha512-D8vqMe9MCpbKx6ECw01VxLaiMRK4jtoeYuCTCwunsc/Z44SgxEKi+bO7q6T7EsIcaBBdz06rLvyjSdj/s1CCQA==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.37.0-beta.2",
+        "@xmtp/proto": "^3.39.0-beta.2",
         "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.37.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.37.0-beta.2.tgz",
-      "integrity": "sha512-D8vqMe9MCpbKx6ECw01VxLaiMRK4jtoeYuCTCwunsc/Z44SgxEKi+bO7q6T7EsIcaBBdz06rLvyjSdj/s1CCQA==",
+      "version": "3.39.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.39.0-beta.2.tgz",
+      "integrity": "sha512-pHqbZUrd62qcWZj6MryOKfdeo/lirJrxt1Pv0c1hdpCEyz2J19j+TkGLkoiq7f5wrU3z9Yci+HooAj9BfHZ8og==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.34.0",
+        "@xmtp/proto": "^3.37.0-beta.1",
         "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.34.0.tgz",
-      "integrity": "sha512-UJ0doz01peGEi5+fJ6th6JsUXFLMHaVk9L9avrv7L7FhfmAzM/V5iqHao8YpIKyMrJ7BelsGrbDcTfe28SsxFg==",
+      "version": "3.37.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.37.0-beta.1.tgz",
+      "integrity": "sha512-060+4wSnrN1yvUxEDdWyJt0v8f2gr0lt6Bt5wK8/9w6hH0OWyzO09PHccbHe2wkBqg36gANMPw9rQh2hmtlAkg==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
-        "@xmtp/proto": "^3.39.0-beta.2",
+        "@xmtp/proto": "^3.39.0-beta.3",
         "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
@@ -5511,9 +5511,9 @@
       }
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.39.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.39.0-beta.2.tgz",
-      "integrity": "sha512-pHqbZUrd62qcWZj6MryOKfdeo/lirJrxt1Pv0c1hdpCEyz2J19j+TkGLkoiq7f5wrU3z9Yci+HooAj9BfHZ8og==",
+      "version": "3.39.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.39.0-beta.3.tgz",
+      "integrity": "sha512-vsAthHovb8c/18/VloSrG7GGcW1OCYRK0M9kRK5Sq+09fX5cWNt3Urt4Bw0TTtmPQqM/2ghK9slgC1qQF80jkA==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@xmtp/proto": "^3.39.0-beta.2",
+    "@xmtp/proto": "^3.39.0-beta.3",
     "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@xmtp/proto": "^3.37.0-beta.1",
+    "@xmtp/proto": "^3.37.0-beta.2",
     "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@xmtp/proto": "^3.37.0-beta.2",
+    "@xmtp/proto": "^3.39.0-beta.2",
     "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
-    "@xmtp/proto": "^3.34.0",
+    "@xmtp/proto": "^3.37.0-beta.1",
     "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -635,7 +635,10 @@ export default class Client<ContentTypes = any> {
   async encodeContent(
     content: ContentTypes,
     options?: SendOptions
-  ): Promise<Uint8Array> {
+  ): Promise<{
+    payload: Uint8Array
+    shouldPush: boolean
+  }> {
     const contentType = options?.contentType || ContentTypeText
     const codec = this.codecFor(contentType)
     if (!codec) {
@@ -651,7 +654,10 @@ export default class Client<ContentTypes = any> {
       encoded.compression = options.compression
     }
     await compress(encoded)
-    return proto.EncodedContent.encode(encoded).finish()
+    return {
+      payload: proto.EncodedContent.encode(encoded).finish(),
+      shouldPush: codec.shouldPush(content),
+    }
   }
 
   async decodeContent(contentBytes: Uint8Array): Promise<{

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -190,26 +190,30 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
 
 export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
-  private header: proto.MessageHeaderV2 // eslint-disable-line camelcase
+  private header: proto.MessageHeaderV2
+  senderHmac: Uint8Array
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
-    header: proto.MessageHeaderV2
+    header: proto.MessageHeaderV2,
+    senderHmac: Uint8Array
   ) {
     super(id, bytes, obj)
     this.header = header
+    this.senderHmac = senderHmac
   }
 
   static async create(
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    bytes: Uint8Array
+    bytes: Uint8Array,
+    senderHmac: Uint8Array
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
 
-    return new MessageV2(id, bytes, obj, header)
+    return new MessageV2(id, bytes, obj, header, senderHmac)
   }
 
   get sent(): Date {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -192,28 +192,32 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
   private header: proto.MessageHeaderV2
   senderHmac: Uint8Array
+  shouldPush: boolean
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    senderHmac: Uint8Array
+    senderHmac: Uint8Array,
+    shouldPush: boolean
   ) {
     super(id, bytes, obj)
     this.header = header
     this.senderHmac = senderHmac
+    this.shouldPush = shouldPush
   }
 
   static async create(
     obj: proto.Message,
     header: proto.MessageHeaderV2,
     bytes: Uint8Array,
-    senderHmac: Uint8Array
+    senderHmac: Uint8Array,
+    shouldPush: boolean
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
 
-    return new MessageV2(id, bytes, obj, header, senderHmac)
+    return new MessageV2(id, bytes, obj, header, senderHmac, shouldPush)
   }
 
   get sent(): Date {

--- a/src/MessageContent.ts
+++ b/src/MessageContent.ts
@@ -58,6 +58,7 @@ export interface ContentCodec<T> {
   encode(content: T, registry: CodecRegistry): EncodedContent
   decode(content: EncodedContent, registry: CodecRegistry): T
   fallback(content: T): string | undefined
+  shouldPush: (content: T) => boolean
 }
 
 // xmtp.org/fallback

--- a/src/codecs/Composite.ts
+++ b/src/codecs/Composite.ts
@@ -112,4 +112,8 @@ export class CompositeCodec implements ContentCodec<Composite> {
   fallback(content: Composite): string | undefined {
     return undefined
   }
+
+  shouldPush() {
+    return false
+  }
 }

--- a/src/codecs/Text.ts
+++ b/src/codecs/Text.ts
@@ -39,4 +39,8 @@ export class TextCodec implements ContentCodec<string> {
   fallback(content: string): string | undefined {
     return undefined
   }
+
+  shouldPush() {
+    return true
+  }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -284,7 +284,7 @@ export class ConversationV1<ContentTypes>
     } else {
       topics = [topic]
     }
-    const payload = await this.client.encodeContent(content, options)
+    const { payload } = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, recipient, options?.timestamp)
     const msgBytes = msg.toBytes()
 
@@ -393,7 +393,7 @@ export class ConversationV1<ContentTypes>
       topics = [topic]
     }
     const contentType = options?.contentType || ContentTypeText
-    const payload = await this.client.encodeContent(content, options)
+    const { payload } = await this.client.encodeContent(content, options)
     const msg = await this.createMessage(payload, recipient, options?.timestamp)
 
     await this.client.publishEnvelopes(
@@ -602,8 +602,15 @@ export class ConversationV2<ContentTypes>
     content: Exclude<ContentTypes, undefined>,
     options?: SendOptions
   ): Promise<DecodedMessage<ContentTypes>> {
-    const payload = await this.client.encodeContent(content, options)
-    const msg = await this.createMessage(payload, options?.timestamp)
+    const { payload, shouldPush } = await this.client.encodeContent(
+      content,
+      options
+    )
+    const msg = await this.createMessage(
+      payload,
+      shouldPush,
+      options?.timestamp
+    )
 
     const topic = options?.ephemeral ? this.ephemeralTopic : this.topic
 
@@ -637,6 +644,7 @@ export class ConversationV2<ContentTypes>
   async createMessage(
     // Payload is expected to have already gone through `client.encodeContent`
     payload: Uint8Array,
+    shouldPush: boolean,
     timestamp?: Date
   ): Promise<MessageV2> {
     const header: message.MessageHeaderV2 = {
@@ -660,13 +668,14 @@ export class ConversationV2<ContentTypes>
       signedBytes,
       headerBytes
     )
+
     const protoMsg = {
       v1: undefined,
-      v2: { headerBytes, ciphertext, senderHmac },
+      v2: { headerBytes, ciphertext, senderHmac, shouldPush },
     }
     const bytes = message.Message.encode(protoMsg).finish()
 
-    return MessageV2.create(protoMsg, header, bytes, senderHmac)
+    return MessageV2.create(protoMsg, header, bytes, senderHmac, shouldPush)
   }
 
   private async decryptBatch(
@@ -779,8 +788,15 @@ export class ConversationV2<ContentTypes>
     content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
     options?: SendOptions
   ): Promise<PreparedMessage> {
-    const payload = await this.client.encodeContent(content, options)
-    const msg = await this.createMessage(payload, options?.timestamp)
+    const { payload, shouldPush } = await this.client.encodeContent(
+      content,
+      options
+    )
+    const msg = await this.createMessage(
+      payload,
+      shouldPush,
+      options?.timestamp
+    )
     const msgBytes = msg.toBytes()
 
     const topic = options?.ephemeral ? this.ephemeralTopic : this.topic
@@ -827,7 +843,13 @@ export class ConversationV2<ContentTypes>
       throw new Error('topic mismatch')
     }
 
-    return MessageV2.create(msg, header, env.message, msg.v2.senderHmac)
+    return MessageV2.create(
+      msg,
+      header,
+      env.message,
+      msg.v2.senderHmac,
+      msg.v2.shouldPush
+    )
   }
 
   async decodeMessage(

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -116,3 +116,26 @@ export async function generateHmac(
   const key = await hkdfHmacKey(secret, salt)
   return generateHmacWithKey(key, message)
 }
+
+export async function validateHmac(
+  key: CryptoKey,
+  signature: Uint8Array,
+  message: Uint8Array
+): Promise<boolean> {
+  return await crypto.subtle.verify('HMAC', key, signature, message)
+}
+
+export async function exportHmacKey(key: CryptoKey): Promise<Uint8Array> {
+  const exported = await crypto.subtle.exportKey('raw', key)
+  return new Uint8Array(exported)
+}
+
+export async function importHmacKey(key: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    key,
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true,
+    ['sign', 'verify']
+  )
+}

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -84,7 +84,7 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
   )
 }
 
-async function hkdfHmacKey(
+export async function hkdfHmacKey(
   secret: Uint8Array,
   salt: Uint8Array
 ): Promise<CryptoKey> {

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -100,7 +100,7 @@ export async function hkdfHmacKey(
   )
 }
 
-async function generateHmac(
+async function generateHmacWithKey(
   key: CryptoKey,
   message: Uint8Array
 ): Promise<Uint8Array> {
@@ -108,11 +108,11 @@ async function generateHmac(
   return new Uint8Array(signed)
 }
 
-export async function generateHmacSignature(
+export async function generateHmac(
   secret: Uint8Array,
   salt: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
   const key = await hkdfHmacKey(secret, salt)
-  return generateHmac(key, message)
+  return generateHmacWithKey(key, message)
 }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -100,24 +100,17 @@ export async function hkdfHmacKey(
   )
 }
 
-async function generateHmacWithKey(
-  key: CryptoKey,
-  message: Uint8Array
-): Promise<Uint8Array> {
-  const signed = await crypto.subtle.sign('HMAC', key, message)
-  return new Uint8Array(signed)
-}
-
-export async function generateHmac(
+export async function generateHmacSignature(
   secret: Uint8Array,
   salt: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
   const key = await hkdfHmacKey(secret, salt)
-  return generateHmacWithKey(key, message)
+  const signed = await crypto.subtle.sign('HMAC', key, message)
+  return new Uint8Array(signed)
 }
 
-export async function validateHmac(
+export async function verifyHmacSignature(
   key: CryptoKey,
   signature: Uint8Array,
   message: Uint8Array

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -3,6 +3,7 @@ import Ciphertext, { AESGCMNonceSize, KDFSaltSize } from './Ciphertext'
 import crypto from './crypto'
 
 const hkdfNoInfo = new ArrayBuffer(0)
+const hkdfNoSalt = new ArrayBuffer(0)
 
 // This is a variation of https://github.com/paulmillr/noble-secp256k1/blob/main/index.ts#L1378-L1388
 // that uses `digest('SHA-256', bytes)` instead of `digest('SHA-256', bytes.buffer)`
@@ -86,13 +87,13 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
 
 export async function hkdfHmacKey(
   secret: Uint8Array,
-  salt: Uint8Array
+  info: Uint8Array
 ): Promise<CryptoKey> {
   const key = await crypto.subtle.importKey('raw', secret, 'HKDF', false, [
     'deriveKey',
   ])
   return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
+    { name: 'HKDF', hash: 'SHA-256', salt: hkdfNoSalt, info },
     key,
     { name: 'HMAC', hash: 'SHA-256', length: 256 },
     true,
@@ -102,10 +103,10 @@ export async function hkdfHmacKey(
 
 export async function generateHmacSignature(
   secret: Uint8Array,
-  salt: Uint8Array,
+  info: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
-  const key = await hkdfHmacKey(secret, salt)
+  const key = await hkdfHmacKey(secret, info)
   const signed = await crypto.subtle.sign('HMAC', key, message)
   return new Uint8Array(signed)
 }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -95,7 +95,7 @@ export async function hkdfHmacKey(
     { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
     key,
     { name: 'HMAC', hash: 'SHA-256', length: 256 },
-    false,
+    true,
     ['sign', 'verify']
   )
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -9,7 +9,15 @@ import {
 import { UnsignedPublicKey, SignedPublicKey, PublicKey } from './PublicKey'
 import Signature, { WalletSigner } from './Signature'
 import * as utils from './utils'
-import { encrypt, decrypt } from './encryption'
+import {
+  decrypt,
+  encrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
+} from './encryption'
 import Ciphertext from './Ciphertext'
 import SignedEciesCiphertext from './SignedEciesCiphertext'
 
@@ -17,6 +25,11 @@ export {
   utils,
   encrypt,
   decrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
   Ciphertext,
   UnsignedPublicKey,
   SignedPublicKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,11 @@ export {
   Signature,
   encrypt,
   decrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
 } from './crypto'
 export { default as Stream } from './Stream'
 export { Signer } from './types/Signer'

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import { KeystoreInterface } from '..'
-import { generateHmacSignature, hkdfHmacKey } from '../crypto/encryption'
+import { generateHmac, hkdfHmacKey } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -302,7 +302,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
         const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
-        const hmac = await generateHmacSignature(
+        const hmac = await generateHmac(
           keyMaterial,
           new TextEncoder().encode(salt),
           headerBytes

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -305,10 +305,10 @@ export default class InMemoryKeystore implements KeystoreInterface {
         const thirtyDayPeriodsSinceEpoch = Math.floor(
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
-        const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
+        const info = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
         const hmac = await generateHmacSignature(
           keyMaterial,
-          new TextEncoder().encode(salt),
+          new TextEncoder().encode(info),
           headerBytes
         )
 

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,11 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import { KeystoreInterface } from '..'
-import { exportHmacKey, generateHmac, hkdfHmacKey } from '../crypto/encryption'
+import {
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+} from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -302,7 +306,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
         const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
-        const hmac = await generateHmac(
+        const hmac = await generateHmacSignature(
           keyMaterial,
           new TextEncoder().encode(salt),
           headerBytes

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import { KeystoreInterface } from '..'
-import { generateHmac, hkdfHmacKey } from '../crypto/encryption'
+import { exportHmacKey, generateHmac, hkdfHmacKey } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -598,35 +598,35 @@ export default class InMemoryKeystore implements KeystoreInterface {
 
     const hmacKeys: keystore.GetConversationHmacKeysResponse['hmacKeys'] = {}
 
-    this.v2Store.topics.forEach(async (topicData) => {
-      if (topicData.invitation?.topic) {
-        const keyMaterial = getKeyMaterial(topicData.invitation)
-        const values = await Promise.all(
-          [
-            thirtyDayPeriodsSinceEpoch - 1,
-            thirtyDayPeriodsSinceEpoch,
-            thirtyDayPeriodsSinceEpoch + 1,
-          ].map(async (value) => {
-            const salt = `${value}-${this.accountAddress}`
-            const hmacKey = await hkdfHmacKey(
-              keyMaterial,
-              new TextEncoder().encode(salt)
-            )
-            return {
-              thirtyDayPeriodsSinceEpoch: value,
-              // convert CryptoKey to Uint8Array to match the proto
-              hmacKey: new Uint8Array(
-                await crypto.subtle.exportKey('raw', hmacKey)
-              ),
-            }
-          })
-        )
+    await Promise.all(
+      this.v2Store.topics.map(async (topicData) => {
+        if (topicData.invitation?.topic) {
+          const keyMaterial = getKeyMaterial(topicData.invitation)
+          const values = await Promise.all(
+            [
+              thirtyDayPeriodsSinceEpoch - 1,
+              thirtyDayPeriodsSinceEpoch,
+              thirtyDayPeriodsSinceEpoch + 1,
+            ].map(async (value) => {
+              const salt = `${value}-${this.accountAddress}`
+              const hmacKey = await hkdfHmacKey(
+                keyMaterial,
+                new TextEncoder().encode(salt)
+              )
+              return {
+                thirtyDayPeriodsSinceEpoch: value,
+                // convert CryptoKey to Uint8Array to match the proto
+                hmacKey: await exportHmacKey(hmacKey),
+              }
+            })
+          )
 
-        hmacKeys[topicData.invitation.topic] = {
-          values,
+          hmacKeys[topicData.invitation.topic] = {
+            values,
+          }
         }
-      }
-    })
+      })
+    )
 
     return { hmacKeys }
   }

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import { KeystoreInterface } from '..'
-import { generateHmacSignature } from '../crypto/encryption'
+import { generateHmacSignature, hkdfHmacKey } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -298,14 +298,19 @@ export default class InMemoryKeystore implements KeystoreInterface {
 
         const keyMaterial = getKeyMaterial(topicData.invitation)
         const ciphertext = await encryptV2(payload, keyMaterial, headerBytes)
+        const thirtyDayPeriodsSinceEpoch = Math.floor(
+          Date.now() / 1000 / 60 / 60 / 24 / 30
+        )
+        const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
+        const hmac = await generateHmacSignature(
+          keyMaterial,
+          new TextEncoder().encode(salt),
+          headerBytes
+        )
 
         return {
           encrypted: ciphertext,
-          senderHmac: await generateHmacSignature(
-            keyMaterial,
-            new TextEncoder().encode(contentTopic),
-            headerBytes
-          ),
+          senderHmac: hmac,
         }
       },
       ErrorCode.ERROR_CODE_INVALID_INPUT
@@ -584,5 +589,45 @@ export default class InMemoryKeystore implements KeystoreInterface {
   // on the InMemoryKeystore to support legacy use-cases.
   lookupTopic(topic: string) {
     return this.v2Store.lookup(topic)
+  }
+
+  async getV2ConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse> {
+    const thirtyDayPeriodsSinceEpoch = Math.floor(
+      Date.now() / 1000 / 60 / 60 / 24 / 30
+    )
+
+    const hmacKeys: keystore.GetConversationHmacKeysResponse['hmacKeys'] = {}
+
+    this.v2Store.topics.forEach(async (topicData) => {
+      if (topicData.invitation?.topic) {
+        const keyMaterial = getKeyMaterial(topicData.invitation)
+        const values = await Promise.all(
+          [
+            thirtyDayPeriodsSinceEpoch - 1,
+            thirtyDayPeriodsSinceEpoch,
+            thirtyDayPeriodsSinceEpoch + 1,
+          ].map(async (value) => {
+            const salt = `${value}-${this.accountAddress}`
+            const hmacKey = await hkdfHmacKey(
+              keyMaterial,
+              new TextEncoder().encode(salt)
+            )
+            return {
+              thirtyDayPeriodsSinceEpoch: value,
+              // convert CryptoKey to Uint8Array to match the proto
+              hmacKey: new Uint8Array(
+                await crypto.subtle.exportKey('raw', hmacKey)
+              ),
+            }
+          })
+        )
+
+        hmacKeys[topicData.invitation.topic] = {
+          values,
+        }
+      }
+    })
+
+    return { hmacKeys }
   }
 }

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,6 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import { KeystoreInterface } from '..'
+import { generateHmacSignature } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -295,10 +296,14 @@ export default class InMemoryKeystore implements KeystoreInterface {
           )
         }
 
+        const keyMaterial = getKeyMaterial(topicData.invitation)
+        const ciphertext = await encryptV2(payload, keyMaterial, headerBytes)
+
         return {
-          encrypted: await encryptV2(
-            payload,
-            getKeyMaterial(topicData.invitation),
+          encrypted: ciphertext,
+          senderHmac: await generateHmacSignature(
+            keyMaterial,
+            new TextEncoder().encode(contentTopic),
             headerBytes
           ),
         }

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -612,10 +612,10 @@ export default class InMemoryKeystore implements KeystoreInterface {
               thirtyDayPeriodsSinceEpoch,
               thirtyDayPeriodsSinceEpoch + 1,
             ].map(async (value) => {
-              const salt = `${value}-${this.accountAddress}`
+              const info = `${value}-${this.accountAddress}`
               const hmacKey = await hkdfHmacKey(
                 keyMaterial,
-                new TextEncoder().encode(salt)
+                new TextEncoder().encode(info)
               )
               return {
                 thirtyDayPeriodsSinceEpoch: value,

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -98,6 +98,11 @@ export interface Keystore {
    * Get the private preferences topic identifier
    */
   getPrivatePreferencesTopicIdentifier(): Promise<keystore.GetPrivatePreferencesTopicIdentifierResponse>
+  /**
+   * Returns the conversation HMAC keys for the current, previous, and next
+   * 30 day periods since the epoch
+   */
+  getV2ConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse>
 }
 
 export type TopicData = WithoutUndefined<keystore.TopicMap_TopicData>

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -199,8 +199,12 @@ export const apiDefs = {
     req: null,
     res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
   },
+  /**
+   * Returns the conversation HMAC keys for the current, previous, and next
+   * 30 day periods since the epoch
+   */
   getV2ConversationHmacKeys: {
-    req: null,
+    req: keystore.GetConversationHmacKeysRequest,
     res: keystore.GetConversationHmacKeysResponse,
   },
 }

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -199,6 +199,10 @@ export const apiDefs = {
     req: null,
     res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
   },
+  getV2ConversationHmacKeys: {
+    req: null,
+    res: keystore.GetConversationHmacKeysResponse,
+  },
 }
 
 export type KeystoreApiDefs = typeof apiDefs

--- a/src/utils/keystore.ts
+++ b/src/utils/keystore.ts
@@ -4,6 +4,12 @@ import { KeystoreError } from '../keystore/errors'
 import { MessageV1 } from '../Message'
 import { WithoutUndefined } from './typedefs'
 
+type EncryptionResponseResult<
+  T extends
+    | keystore.DecryptResponse_Response
+    | keystore.EncryptResponse_Response,
+> = WithoutUndefined<T>['result']
+
 // Validates the Keystore response. Throws on errors or missing fields.
 // Returns a type with all possibly undefined fields required to be defined
 export const getResultOrThrow = <
@@ -12,10 +18,11 @@ export const getResultOrThrow = <
     | keystore.EncryptResponse_Response,
 >(
   response: T
-): WithoutUndefined<NonNullable<T['result']>> => {
+) => {
   if (response.error) {
     throw new KeystoreError(response.error.code, response.error.message)
   }
+
   if (!response.result) {
     throw new KeystoreError(
       keystore.ErrorCode.ERROR_CODE_UNSPECIFIED,
@@ -31,9 +38,7 @@ export const getResultOrThrow = <
     throw new Error('Missing decrypted result')
   }
 
-  return response.result as unknown as WithoutUndefined<
-    NonNullable<T['result']>
-  >
+  return response.result as EncryptionResponseResult<T>
 }
 
 export const buildDecryptV1Request = (

--- a/test/Client.test.ts
+++ b/test/Client.test.ts
@@ -6,7 +6,7 @@ import {
   waitForUserContact,
   newLocalHostClientWithCustomWallet,
 } from './helpers'
-import { buildUserContactTopic } from '../src/utils'
+import { EnvelopeWithMessage, buildUserContactTopic } from '../src/utils'
 import Client, { ClientOptions } from '../src/Client'
 import {
   ApiUrls,
@@ -20,15 +20,17 @@ import {
 } from '../src'
 import NetworkKeyManager from '../src/keystore/providers/NetworkKeyManager'
 import TopicPersistence from '../src/keystore/persistence/TopicPersistence'
-import { PrivateKeyBundleV1 } from '../src/crypto'
+import { PrivateKey, PrivateKeyBundleV1 } from '../src/crypto'
 import { Wallet } from 'ethers'
 import { NetworkKeystoreProvider } from '../src/keystore/providers'
 import { PublishResponse } from '@xmtp/proto/ts/dist/types/message_api/v1/message_api.pb'
 import LocalStoragePonyfill from '../src/keystore/persistence/LocalStoragePonyfill'
+import { message } from '@xmtp/proto'
 import { createWalletClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 import { generatePrivateKey } from 'viem/accounts'
+import { ContentTypeTestKey, TestKeyCodec } from './ContentTypeTestKey'
 
 type TestCase = {
   name: string
@@ -196,10 +198,24 @@ describe('encodeContent', () => {
       173, 229,
     ])
 
-    const payload = await c.encodeContent(uncompressed, {
+    const { payload } = await c.encodeContent(uncompressed, {
       compression: Compression.COMPRESSION_DEFLATE,
     })
     assert.deepEqual(Uint8Array.from(payload), compressed)
+  })
+
+  it('returns shouldPush based on content codec', async () => {
+    const alice = await newLocalHostClient()
+    alice.registerCodec(new TestKeyCodec())
+
+    const { shouldPush: result1 } = await alice.encodeContent('gm')
+    expect(result1).toBe(true)
+
+    const key = PrivateKey.generate().publicKey
+    const { shouldPush: result2 } = await alice.encodeContent(key, {
+      contentType: ContentTypeTestKey,
+    })
+    expect(result2).toBe(false)
   })
 })
 
@@ -293,6 +309,43 @@ describe('canMessageMultipleBatches', () => {
         Array.from({ length: 5 }, () => false)
       )
     )
+  })
+})
+
+describe('listEnvelopes', () => {
+  it('has envelopes with senderHmac and shouldPush', async () => {
+    const alice = await newLocalHostClient()
+    const bob = await newLocalHostClient()
+    alice.registerCodec(new TestKeyCodec())
+    const convo = await alice.conversations.newConversation(bob.address)
+    await convo.send('hi')
+    const key = PrivateKey.generate().publicKey
+    await convo.send(key, {
+      contentType: ContentTypeTestKey,
+    })
+
+    const envelopes = await alice.listEnvelopes(
+      convo.topic,
+      (env: EnvelopeWithMessage) => Promise.resolve(env)
+    )
+
+    const msg1 = message.Message.decode(envelopes[0].message)
+    if (!msg1.v2) {
+      throw new Error('unknown message version')
+    }
+    const header1 = message.MessageHeaderV2.decode(msg1.v2.headerBytes)
+    expect(header1.topic).toEqual(convo.topic)
+    expect(msg1.v2.senderHmac).toBeDefined()
+    expect(msg1.v2.shouldPush).toBe(true)
+
+    const msg2 = message.Message.decode(envelopes[1].message)
+    if (!msg2.v2) {
+      throw new Error('unknown message version')
+    }
+    const header2 = message.MessageHeaderV2.decode(msg2.v2.headerBytes)
+    expect(header2.topic).toEqual(convo.topic)
+    expect(msg2.v2.senderHmac).toBeDefined()
+    expect(msg2.v2.shouldPush).toBe(false)
   })
 })
 

--- a/test/ContentTypeTestKey.ts
+++ b/test/ContentTypeTestKey.ts
@@ -29,4 +29,8 @@ export class TestKeyCodec implements ContentCodec<PublicKey> {
   fallback(content: PublicKey): string | undefined {
     return 'publickey bundle'
   }
+
+  shouldPush() {
+    return false
+  }
 }

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -154,7 +154,7 @@ describe('Message', function () {
         env: 'local',
         privateKeyOverride: alice.encode(),
       })
-      const payload = await aliceClient.encodeContent(text)
+      const { payload } = await aliceClient.encodeContent(text)
       const timestamp = new Date()
       const sender = alice.getPublicKeyBundle()
       const recipient = bob.getPublicKeyBundle()

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -1,0 +1,62 @@
+import {
+  importHmacKey,
+  exportHmacKey,
+  hkdfHmacKey,
+  validateHmac,
+  generateHmac,
+} from '../../src/crypto/encryption'
+import crypto from '../../src/crypto/crypto'
+
+describe('HMAC encryption', () => {
+  it('generates and validates HMAC', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const valid = await validateHmac(key, hmac, message)
+    expect(valid).toBe(true)
+  })
+
+  it('generates and validates HMAC with imported key', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const exportedKey = await exportHmacKey(key)
+    const importedKey = await importHmacKey(exportedKey)
+    const valid = await validateHmac(importedKey, hmac, message)
+    expect(valid).toBe(true)
+  })
+
+  it('fails to validate HMAC with wrong message', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const valid = await validateHmac(
+      key,
+      hmac,
+      crypto.getRandomValues(new Uint8Array(32))
+    )
+    expect(valid).toBe(false)
+  })
+
+  it('fails to validate HMAC with wrong key', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const valid = await validateHmac(
+      await hkdfHmacKey(
+        crypto.getRandomValues(new Uint8Array(32)),
+        crypto.getRandomValues(new Uint8Array(32))
+      ),
+      hmac,
+      message
+    )
+    expect(valid).toBe(false)
+  })
+})

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -10,32 +10,42 @@ import crypto from '../../src/crypto/crypto'
 describe('HMAC encryption', () => {
   it('generates and validates HMAC', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const valid = await verifyHmacSignature(key, hmac, message)
     expect(valid).toBe(true)
   })
 
   it('generates and validates HMAC with imported key', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const exportedKey = await exportHmacKey(key)
     const importedKey = await importHmacKey(exportedKey)
     const valid = await verifyHmacSignature(importedKey, hmac, message)
     expect(valid).toBe(true)
   })
 
+  it('generates different HMAC keys with different infos', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const info1 = crypto.getRandomValues(new Uint8Array(32))
+    const info2 = crypto.getRandomValues(new Uint8Array(32))
+    const key1 = await hkdfHmacKey(secret, info1)
+    const key2 = await hkdfHmacKey(secret, info2)
+
+    expect(await exportHmacKey(key1)).not.toEqual(await exportHmacKey(key2))
+  })
+
   it('fails to validate HMAC with wrong message', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const valid = await verifyHmacSignature(
       key,
       hmac,
@@ -46,9 +56,9 @@ describe('HMAC encryption', () => {
 
   it('fails to validate HMAC with wrong key', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, info, message)
     const valid = await verifyHmacSignature(
       await hkdfHmacKey(
         crypto.getRandomValues(new Uint8Array(32)),

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -2,8 +2,8 @@ import {
   importHmacKey,
   exportHmacKey,
   hkdfHmacKey,
-  validateHmac,
-  generateHmac,
+  verifyHmacSignature,
+  generateHmacSignature,
 } from '../../src/crypto/encryption'
 import crypto from '../../src/crypto/crypto'
 
@@ -12,9 +12,9 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
-    const valid = await validateHmac(key, hmac, message)
+    const valid = await verifyHmacSignature(key, hmac, message)
     expect(valid).toBe(true)
   })
 
@@ -22,11 +22,11 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
     const exportedKey = await exportHmacKey(key)
     const importedKey = await importHmacKey(exportedKey)
-    const valid = await validateHmac(importedKey, hmac, message)
+    const valid = await verifyHmacSignature(importedKey, hmac, message)
     expect(valid).toBe(true)
   })
 
@@ -34,9 +34,9 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
-    const valid = await validateHmac(
+    const valid = await verifyHmacSignature(
       key,
       hmac,
       crypto.getRandomValues(new Uint8Array(32))
@@ -48,8 +48,8 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
-    const valid = await validateHmac(
+    const hmac = await generateHmacSignature(secret, salt, message)
+    const valid = await verifyHmacSignature(
       await hkdfHmacKey(
         crypto.getRandomValues(new Uint8Array(32)),
         crypto.getRandomValues(new Uint8Array(32))

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -21,10 +21,10 @@ import { CreateInviteResponse } from '@xmtp/proto/ts/dist/types/keystore_api/v1/
 import { ethers } from 'ethers'
 import { getKeyMaterial } from '../../src/keystore/utils'
 import {
-  generateHmac,
+  generateHmacSignature,
   hkdfHmacKey,
   importHmacKey,
-  validateHmac,
+  verifyHmacSignature,
 } from '../../src/crypto/encryption'
 
 describe('InMemoryKeystore', () => {
@@ -447,7 +447,11 @@ describe('InMemoryKeystore', () => {
 
       expect(encrypted.result?.senderHmac).toBeTruthy()
       expect(
-        await validateHmac(hmacKey, encrypted.result!.senderHmac, headerBytes)
+        await verifyHmacSignature(
+          hmacKey,
+          encrypted.result!.senderHmac,
+          headerBytes
+        )
       ).toBeTruthy()
     })
   })
@@ -932,7 +936,7 @@ describe('InMemoryKeystore', () => {
           const topicData = aliceKeystore.lookupTopic(topic)
           const keyMaterial = getKeyMaterial(topicData!.invitation)
           const salt = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
-          const hmac = await generateHmac(
+          const hmac = await generateHmacSignature(
             keyMaterial,
             new TextEncoder().encode(salt),
             headerBytes
@@ -950,7 +954,7 @@ describe('InMemoryKeystore', () => {
             hmacData.values.map(
               async ({ hmacKey, thirtyDayPeriodsSinceEpoch }, idx) => {
                 expect(thirtyDayPeriodsSinceEpoch).toBe(periods[idx])
-                const valid = await validateHmac(
+                const valid = await verifyHmacSignature(
                   await importHmacKey(hmacKey),
                   topicHmacs[topic],
                   headerBytes

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -935,10 +935,10 @@ describe('InMemoryKeystore', () => {
 
           const topicData = aliceKeystore.lookupTopic(topic)
           const keyMaterial = getKeyMaterial(topicData!.invitation)
-          const salt = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
+          const info = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
           const hmac = await generateHmacSignature(
             keyMaterial,
-            new TextEncoder().encode(salt),
+            new TextEncoder().encode(info),
             headerBytes
           )
 

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -19,6 +19,13 @@ import Token from '../../src/authn/Token'
 import Long from 'long'
 import { CreateInviteResponse } from '@xmtp/proto/ts/dist/types/keystore_api/v1/keystore.pb'
 import { ethers } from 'ethers'
+import { getKeyMaterial } from '../../src/keystore/utils'
+import {
+  generateHmac,
+  hkdfHmacKey,
+  importHmacKey,
+  validateHmac,
+} from '../../src/crypto/encryption'
 
 describe('InMemoryKeystore', () => {
   let aliceKeys: PrivateKeyBundleV1
@@ -394,6 +401,54 @@ describe('InMemoryKeystore', () => {
       }
 
       expect(equalBytes(payload, decrypted.result!.decrypted)).toBeTruthy()
+    })
+
+    it('generates a valid sender HMAC', async () => {
+      const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+        bobKeys.getPublicKeyBundle()
+      )
+      const createdNs = dateToNs(new Date())
+      const response = await aliceKeystore.createInvite({
+        recipient,
+        createdNs,
+        context: undefined,
+      })
+
+      const payload = new TextEncoder().encode('Hello, world!')
+      const headerBytes = new Uint8Array(10)
+
+      const {
+        responses: [encrypted],
+      } = await aliceKeystore.encryptV2({
+        requests: [
+          {
+            contentTopic: response.conversation!.topic,
+            payload,
+            headerBytes,
+          },
+        ],
+      })
+
+      if (encrypted.error) {
+        throw encrypted.error
+      }
+
+      const thirtyDayPeriodsSinceEpoch = Math.floor(
+        Date.now() / 1000 / 60 / 60 / 24 / 30
+      )
+      const topicData = aliceKeystore.lookupTopic(response.conversation!.topic)
+      const keyMaterial = getKeyMaterial(topicData!.invitation)
+      const hmacKey = await hkdfHmacKey(
+        keyMaterial,
+        new TextEncoder().encode(
+          `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
+        )
+      )
+
+      expect(encrypted.result?.senderHmac).toBeTruthy()
+      expect(
+        await validateHmac(hmacKey, encrypted.result!.senderHmac, headerBytes)
+      ).toBeTruthy()
     })
   })
 
@@ -804,6 +859,108 @@ describe('InMemoryKeystore', () => {
           )
         ).lastRunNs.equals(lastRunNs)
       ).toBeTruthy()
+    })
+  })
+
+  describe('getV2ConversationHmacKeys', () => {
+    it('returns conversation HMAC keys', async () => {
+      const baseTime = new Date()
+      const timestamps = Array.from(
+        { length: 5 },
+        (_, i) => new Date(baseTime.getTime() + i)
+      )
+
+      const invites = await Promise.all(
+        [...timestamps].map(async (createdAt) => {
+          let keys = await PrivateKeyBundleV1.generate(newWallet())
+
+          const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+            keys.getPublicKeyBundle()
+          )
+
+          return aliceKeystore.createInvite({
+            recipient,
+            createdNs: dateToNs(createdAt),
+            context: undefined,
+          })
+        })
+      )
+
+      const thirtyDayPeriodsSinceEpoch = Math.floor(
+        Date.now() / 1000 / 60 / 60 / 24 / 30
+      )
+
+      const periods = [
+        thirtyDayPeriodsSinceEpoch - 1,
+        thirtyDayPeriodsSinceEpoch,
+        thirtyDayPeriodsSinceEpoch + 1,
+      ]
+
+      const { hmacKeys } = await aliceKeystore.getV2ConversationHmacKeys()
+
+      const topics = Object.keys(hmacKeys)
+      invites.forEach((invite) => {
+        expect(topics.includes(invite.conversation!.topic)).toBeTruthy()
+      })
+
+      const topicHmacs: {
+        [topic: string]: Uint8Array
+      } = {}
+      const headerBytes = new Uint8Array(10)
+
+      await Promise.all(
+        invites.map(async (invite) => {
+          const topic = invite.conversation!.topic
+          const payload = new TextEncoder().encode('Hello, world!')
+
+          const {
+            responses: [encrypted],
+          } = await aliceKeystore.encryptV2({
+            requests: [
+              {
+                contentTopic: topic,
+                payload,
+                headerBytes,
+              },
+            ],
+          })
+
+          if (encrypted.error) {
+            throw encrypted.error
+          }
+
+          const topicData = aliceKeystore.lookupTopic(topic)
+          const keyMaterial = getKeyMaterial(topicData!.invitation)
+          const salt = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
+          const hmac = await generateHmac(
+            keyMaterial,
+            new TextEncoder().encode(salt),
+            headerBytes
+          )
+
+          topicHmacs[topic] = hmac
+        })
+      )
+
+      await Promise.all(
+        Object.keys(hmacKeys).map(async (topic) => {
+          const hmacData = hmacKeys[topic]
+
+          await Promise.all(
+            hmacData.values.map(
+              async ({ hmacKey, thirtyDayPeriodsSinceEpoch }, idx) => {
+                expect(thirtyDayPeriodsSinceEpoch).toBe(periods[idx])
+                const valid = await validateHmac(
+                  await importHmacKey(hmacKey),
+                  topicHmacs[topic],
+                  headerBytes
+                )
+                expect(valid).toBe(idx === 1 ? true : false)
+              }
+            )
+          )
+        })
+      )
     })
   })
 })


### PR DESCRIPTION
context: https://community.xmtp.org/t/xip-35-message-sender-identifier-in-topic/509/2

in this PR:

* added `shouldPush` to `ContentCodec` type
* added `shouldPush` method to `TextCodec` and `CompositeCodec`
* added `senderHmac` and `shouldPush` to `MessageV2`
* added encryption methods for generating, importing, and exporting HMAC keys
* added encryption methods for generating and verifying HMAC signatures
* added `getV2ConversationHmacKeys` to `InMemoryKeystore` to retrieve conversation topics and their associated HMAC keys

TODO:

- [x] confirm encryption correctness
- [x] add unit tests