### PR TITLE
Fix `js-sha3` import

### DIFF
--- a/src/authn/LocalAuthenticator.ts
+++ b/src/authn/LocalAuthenticator.ts
@@ -1,9 +1,11 @@
-import { keccak256 } from 'js-sha3'
+import sha3 from 'js-sha3'
 import { authn, signature, publicKey } from '@xmtp/proto'
 import AuthData from './AuthData'
 import { PrivateKey } from '../crypto'
 import { hexToBytes } from '../crypto/utils'
 import Token from './Token'
+
+const { keccak256 } = sha3
 
 export default class LocalAuthenticator {
   private identityKey: PrivateKey

--- a/test/authn/Authn.test.ts
+++ b/test/authn/Authn.test.ts
@@ -1,4 +1,4 @@
-import { keccak256 } from 'js-sha3'
+import sha3 from 'js-sha3'
 import Long from 'long'
 import { PrivateKey, PrivateKeyBundleV1, Signature } from '../../src/crypto'
 import Authenticator from '../../src/authn/LocalAuthenticator'
@@ -7,6 +7,8 @@ import { hexToBytes } from '../../src/crypto/utils'
 import { newWallet, sleep } from '../helpers'
 import { Wallet } from 'ethers'
 import AuthCache from '../../src/authn/AuthCache'
+
+const { keccak256 } = sha3
 
 describe('authn', () => {
   let authenticator: Authenticator


### PR DESCRIPTION
since `js-sha3` is a CommonJS module, we must import its default export. this should fix #518.