### PR TITLE
Update Keystore types

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -28,7 +28,6 @@ import { KeystoreAuthenticator } from './authn'
 import { Flatten } from './utils/typedefs'
 import BackupClient, { BackupType } from './message-backup/BackupClient'
 import { createBackupClient } from './message-backup/BackupClientFactory'
-import { Keystore } from './keystore'
 import {
   KeyGeneratorKeystoreProvider,
   KeystoreProvider,
@@ -47,6 +46,7 @@ import { packageName, version } from './snapInfo.json'
 import { ExtractDecodedType } from './types/client'
 import type { WalletClient } from 'viem'
 import { Contacts } from './Contacts'
+import { KeystoreInterfaces } from './keystore/rpcDefinitions'
 const { Compression } = proto
 
 // eslint-disable @typescript-eslint/explicit-module-boundary-types
@@ -147,7 +147,7 @@ export type KeyStoreOptions = {
    * The client will attempt to use each one in sequence until one successfully
    * returns a Keystore instance
    */
-  keystoreProviders: KeystoreProvider[]
+  keystoreProviders: KeystoreProvider<KeystoreInterfaces>[]
   /**
    * Enable the Keystore to persist conversations in the provided storage interface
    */
@@ -252,7 +252,7 @@ export function defaultOptions(opts?: Partial<ClientOptions>): ClientOptions {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default class Client<ContentTypes = any> {
   address: string
-  keystore: Keystore
+  keystore: KeystoreInterfaces
   apiClient: ApiClient
   contacts: Contacts
   publicKeyBundle: PublicKeyBundle
@@ -271,7 +271,7 @@ export default class Client<ContentTypes = any> {
     publicKeyBundle: PublicKeyBundle,
     apiClient: ApiClient,
     backupClient: BackupClient,
-    keystore: Keystore
+    keystore: KeystoreInterfaces
   ) {
     this.knownPublicKeyBundles = new Map<
       string,
@@ -857,7 +857,7 @@ async function bootstrapKeystore(
   opts: ClientOptions,
   apiClient: ApiClient,
   wallet: Signer | null
-): Promise<Keystore> {
+) {
   for (const provider of opts.keystoreProviders) {
     try {
       return await provider.newKeystore(opts, apiClient, wallet ?? undefined)

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -12,8 +12,8 @@ import { bytesToHex } from './crypto/utils'
 import { sha256 } from './crypto/encryption'
 import { ContentTypeId } from './MessageContent'
 import { dateToNs, nsToDate } from './utils'
-import { Keystore } from './keystore'
 import { buildDecryptV1Request, getResultOrThrow } from './utils/keystore'
+import { KeystoreInterfaces } from './keystore/rpcDefinitions'
 
 const headerBytesAndCiphertext = (
   msg: proto.Message
@@ -105,7 +105,7 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
   }
 
   async decrypt(
-    keystore: Keystore,
+    keystore: KeystoreInterfaces,
     myPublicKeyBundle: PublicKeyBundle
   ): Promise<Uint8Array> {
     const responses = (
@@ -151,7 +151,7 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
   }
 
   static async encode(
-    keystore: Keystore,
+    keystore: KeystoreInterfaces,
     payload: Uint8Array,
     sender: PublicKeyBundle,
     recipient: PublicKeyBundle,

--- a/src/authn/KeystoreAuthenticator.ts
+++ b/src/authn/KeystoreAuthenticator.ts
@@ -1,7 +1,10 @@
 import { authn } from '@xmtp/proto'
-import { Keystore } from '../keystore'
 import { dateToNs } from '../utils'
 import Token from './Token'
+import {
+  KeystoreInterface,
+  KeystoreInterfaces,
+} from '../keystore/rpcDefinitions'
 
 const wrapToken = (token: authn.Token): Token => {
   if (token instanceof Token) {
@@ -10,10 +13,12 @@ const wrapToken = (token: authn.Token): Token => {
   return new Token(token)
 }
 
-export default class KeystoreAuthenticator {
-  private keystore: Keystore
+export default class KeystoreAuthenticator<
+  T extends KeystoreInterfaces = KeystoreInterface,
+> {
+  private keystore: T
 
-  constructor(keystore: Keystore) {
+  constructor(keystore: T) {
     this.keystore = keystore
   }
 

--- a/src/conversations/JobRunner.ts
+++ b/src/conversations/JobRunner.ts
@@ -1,8 +1,8 @@
 import { keystore } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
-import { Keystore } from '../keystore'
 import Long from 'long'
 import { dateToNs, nsToDate } from '../utils'
+import { KeystoreInterfaces } from '../keystore/rpcDefinitions'
 
 const CLOCK_SKEW_OFFSET_MS = 10000
 
@@ -13,10 +13,10 @@ type UpdateJob<T> = (lastRun: Date | undefined) => Promise<T>
 export default class JobRunner {
   readonly jobType: JobType
   readonly mutex: Mutex
-  readonly keystore: Keystore
+  readonly keystore: KeystoreInterfaces
   disableOffset: boolean = false
 
-  constructor(jobType: JobType, keystore: Keystore) {
+  constructor(jobType: JobType, keystore: KeystoreInterfaces) {
     this.jobType = jobType
     this.mutex = new Mutex()
     this.keystore = keystore

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,12 +86,30 @@ export {
   buildUserInviteTopic,
   buildUserPrivateStoreTopic,
 } from './utils'
+export { Keystore, InMemoryKeystore, TopicData } from './keystore'
 export {
-  Keystore,
-  InMemoryKeystore,
-  TopicData,
-  keystoreApiDefs,
-} from './keystore'
+  apiDefs as keystoreApiDefs,
+  snapApiDefs as snapKeystoreApiDefs,
+  KeystoreApiDefs,
+  KeystoreApiEntries,
+  KeystoreApiMethods,
+  KeystoreApiRequestEncoders,
+  KeystoreApiRequestValues,
+  KeystoreApiResponseDecoders,
+  KeystoreInterface,
+  KeystoreInterfaceRequestValues,
+  KeystoreInterfaces,
+  KeystoreRPC,
+  KeystoreRPCCodec,
+  SnapKeystoreApiDefs,
+  SnapKeystoreApiEntries,
+  SnapKeystoreApiMethods,
+  SnapKeystoreApiRequestEncoders,
+  SnapKeystoreApiRequestValues,
+  SnapKeystoreApiResponseDecoders,
+  SnapKeystoreInterface,
+  SnapKeystoreInterfaceRequestValues,
+} from './keystore/rpcDefinitions'
 export {
   KeystoreProvider,
   KeyGeneratorKeystoreProvider,

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -5,7 +5,7 @@ import {
 } from './../crypto/PrivateKeyBundle'
 import { InvitationV1, SealedInvitation } from './../Invitation'
 import { PrivateKey, PublicKeyBundle } from '../crypto'
-import { Keystore, TopicData } from './interfaces'
+import { TopicData } from './interfaces'
 import { decryptV1, encryptV1, encryptV2, decryptV2 } from './encryption'
 import { KeystoreError } from './errors'
 import {
@@ -34,6 +34,7 @@ import {
   userPreferencesEncrypt,
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
+import { KeystoreInterface } from '..'
 
 const { ErrorCode } = keystore
 
@@ -57,7 +58,7 @@ async function deriveKey(
   )
 }
 
-export default class InMemoryKeystore implements Keystore {
+export default class InMemoryKeystore implements KeystoreInterface {
   private v1Keys: PrivateKeyBundleV1
   private v2Keys: PrivateKeyBundleV2 // Do I need this?
   private v1Store: V1Store

--- a/src/keystore/index.ts
+++ b/src/keystore/index.ts
@@ -1,6 +1,5 @@
 export { default as InMemoryKeystore } from './InMemoryKeystore'
 export { SnapKeystore } from './SnapKeystore'
-export { apiDefs as keystoreApiDefs } from './rpcDefinitions'
 export { V1Store, V2Store } from './conversationStores'
 export * from './encryption'
 export * from './errors'

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -4,6 +4,7 @@ import { WithoutUndefined } from '../utils/typedefs'
 /**
  * A Keystore is responsible for holding the user's XMTP private keys and using them to encrypt/decrypt/sign messages.
  * Keystores are instantiated using a `KeystoreProvider`
+ * @deprecated Use `KeystoreInterface` instead
  */
 export interface Keystore {
   /**

--- a/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
+++ b/src/keystore/providers/KeyGeneratorKeystoreProvider.ts
@@ -6,8 +6,8 @@ import { KeystoreProviderUnavailableError } from './errors'
 import { buildPersistenceFromOptions } from './helpers'
 import NetworkKeyManager from './NetworkKeyManager'
 import type { Signer } from '../../types/Signer'
-import type { Keystore } from '../interfaces'
 import type { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
+import { KeystoreInterface } from '../rpcDefinitions'
 
 /**
  * KeyGeneratorKeystoreProvider will create a new XMTP `PrivateKeyBundle` and persist it to the network
@@ -19,7 +19,7 @@ export default class KeyGeneratorKeystoreProvider implements KeystoreProvider {
     opts: KeystoreProviderOptions,
     apiClient: ApiClient,
     wallet?: Signer
-  ): Promise<Keystore> {
+  ): Promise<KeystoreInterface> {
     if (!wallet) {
       throw new KeystoreProviderUnavailableError(
         'Wallet required to generate new keys'

--- a/src/keystore/providers/NetworkKeystoreProvider.ts
+++ b/src/keystore/providers/NetworkKeystoreProvider.ts
@@ -4,9 +4,9 @@ import { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
 import NetworkKeyLoader from './NetworkKeyManager'
 import { KeystoreProviderUnavailableError } from './errors'
 import TopicPersistence from '../persistence/TopicPersistence'
-import { Keystore } from '../interfaces'
 import InMemoryKeystore from '../InMemoryKeystore'
 import { buildPersistenceFromOptions } from './helpers'
+import { KeystoreInterface } from '../rpcDefinitions'
 
 /**
  * NetworkKeystoreProvider will look on the XMTP network for an `EncryptedPrivateKeyBundle`
@@ -18,7 +18,7 @@ export default class NetworkKeystoreProvider implements KeystoreProvider {
     opts: KeystoreProviderOptions,
     apiClient: ApiClient,
     wallet?: Signer
-  ): Promise<Keystore> {
+  ): Promise<KeystoreInterface> {
     if (!wallet) {
       throw new KeystoreProviderUnavailableError('No wallet provided')
     }

--- a/src/keystore/providers/SnapProvider.ts
+++ b/src/keystore/providers/SnapProvider.ts
@@ -1,5 +1,4 @@
 import { KeystoreProviderUnavailableError } from './errors'
-import { Keystore } from '../interfaces'
 import { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
 import { SnapKeystore } from '../SnapKeystore'
 import {
@@ -17,6 +16,7 @@ import { PrivateKeyBundleV1, decodePrivateKeyBundle } from '../../crypto'
 import KeyGeneratorKeystoreProvider from './KeyGeneratorKeystoreProvider'
 import type { XmtpEnv } from '../../Client'
 import { semverGreaterThan } from '../../utils/semver'
+import { SnapKeystoreInterface } from '../rpcDefinitions'
 const { GetKeystoreStatusResponse_KeystoreStatus: KeystoreStatus } = keystore
 
 export const SNAP_LOCAL_ORIGIN = 'local:http://localhost:8080'
@@ -27,7 +27,9 @@ export const SNAP_LOCAL_ORIGIN = 'local:http://localhost:8080'
  * 2. Check if the user has already setup the Snap with the appropriate keys
  * 3. If not, will get keys from the network or create new keys and store them in the Snap
  */
-export default class SnapKeystoreProvider implements KeystoreProvider {
+export default class SnapKeystoreProvider
+  implements KeystoreProvider<SnapKeystoreInterface>
+{
   snapId: string
   snapVersion?: string
 
@@ -40,7 +42,7 @@ export default class SnapKeystoreProvider implements KeystoreProvider {
     opts: KeystoreProviderOptions,
     apiClient: ApiClient,
     wallet?: Signer
-  ): Promise<Keystore> {
+  ) {
     if (!wallet) {
       throw new KeystoreProviderUnavailableError('No wallet provided')
     }

--- a/src/keystore/providers/StaticKeystoreProvider.ts
+++ b/src/keystore/providers/StaticKeystoreProvider.ts
@@ -1,5 +1,4 @@
 import { KeystoreProviderUnavailableError } from './errors'
-import { Keystore } from '../interfaces'
 import type { KeystoreProvider, KeystoreProviderOptions } from './interfaces'
 import InMemoryKeystore from '../InMemoryKeystore'
 import {
@@ -7,6 +6,7 @@ import {
   PrivateKeyBundleV2,
 } from '../../crypto/PrivateKeyBundle'
 import { buildPersistenceFromOptions } from './helpers'
+import { KeystoreInterface } from '../rpcDefinitions'
 
 /**
  * StaticKeystoreProvider will look for a `privateKeyOverride` in the provided options,
@@ -16,7 +16,7 @@ import { buildPersistenceFromOptions } from './helpers'
  * the client to continue iterating through the `KeystoreProviders` list.
  */
 export default class StaticKeystoreProvider implements KeystoreProvider {
-  async newKeystore(opts: KeystoreProviderOptions): Promise<Keystore> {
+  async newKeystore(opts: KeystoreProviderOptions): Promise<KeystoreInterface> {
     const { privateKeyOverride } = opts
     if (!privateKeyOverride) {
       throw new KeystoreProviderUnavailableError(

--- a/src/keystore/providers/interfaces.ts
+++ b/src/keystore/providers/interfaces.ts
@@ -1,8 +1,8 @@
 import type { XmtpEnv, PreEventCallbackOptions } from '../../Client'
 import type { Signer } from '../../types/Signer'
-import type { Keystore } from '../interfaces'
 import type { ApiClient } from '../../ApiClient'
 import { Persistence } from '../persistence'
+import { KeystoreInterface, KeystoreInterfaces } from '../rpcDefinitions'
 
 export type KeystoreProviderOptions = {
   env: XmtpEnv
@@ -16,10 +16,12 @@ export type KeystoreProviderOptions = {
  * A Keystore Provider is responsible for either creating a Keystore instance or throwing a KeystoreUnavailableError
  * It is typically used once on application startup to bootstrap the Keystore and load/decrypt the user's private keys
  */
-export interface KeystoreProvider {
+export interface KeystoreProvider<
+  T extends KeystoreInterfaces = KeystoreInterface,
+> {
   newKeystore(
     opts: KeystoreProviderOptions,
     apiClient: ApiClient,
     wallet?: Signer
-  ): Promise<Keystore>
+  ): Promise<T>
 }

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -1,88 +1,245 @@
-import { keystore, authn, publicKey, signature } from '@xmtp/proto'
+import { keystore, authn, publicKey, privateKey, signature } from '@xmtp/proto'
 import { Reader, Writer } from 'protobufjs/minimal'
+import { Flatten } from '../utils/typedefs'
 
-type Codec<T> = {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type KeystoreRPCCodec<T = any> = {
   decode(input: Reader | Uint8Array, length?: number): T
   encode(message: T, writer?: Writer): Writer
 }
 
-export type RPC<Req, Res> = {
-  req: Codec<Req> | null
-  res: Codec<Res>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type KeystoreRPC<Request = any, Response = any> = {
+  req: KeystoreRPCCodec<Request> | null
+  res: KeystoreRPCCodec<Response>
 }
+
+type Entries<T> = {
+  [K in keyof T]: [K, T[K]]
+}[keyof T][]
+
+type Values<T> = {
+  [K in keyof T]: T[K]
+}[keyof T]
 
 type ApiDefs = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [k: string]: RPC<any, any>
+  [key: string]: KeystoreRPC
 }
 
-export const apiDefs: ApiDefs = {
+type ApiInterface = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: (...args: any[]) => any
+}
+
+type OtherKeyStoreMethods = {
+  /**
+   * Get the account address of the wallet used to create the Keystore
+   */
+  getAccountAddress(): Promise<string>
+}
+
+type ExtractInterface<T extends ApiDefs> = Flatten<
+  {
+    [K in keyof T]: T[K] extends KeystoreRPC<infer Req, infer Res>
+      ? T[K]['req'] extends null
+        ? () => Promise<Res>
+        : (req: Req) => Promise<Res>
+      : never
+  } & OtherKeyStoreMethods
+>
+
+type ExtractInterfaceRequestEncoders<T extends ApiDefs> = {
+  [K in keyof T]: T[K]['req'] extends KeystoreRPCCodec
+    ? T[K]['req']['encode']
+    : never
+}
+
+type ExtractInterfaceResponseDecoders<T extends ApiDefs> = {
+  [K in keyof T]: T[K]['res'] extends KeystoreRPCCodec
+    ? T[K]['res']['decode']
+    : never
+}
+
+type ExtractInterfaceRequestValues<T extends ApiInterface> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof T]: T[K] extends (...args: any[]) => any
+    ? Parameters<T[K]>[0]
+    : never
+}
+
+export const apiDefs = {
+  /**
+   * Decrypt a batch of V1 messages
+   */
   decryptV1: {
     req: keystore.DecryptV1Request,
     res: keystore.DecryptResponse,
   },
-  encryptV1: {
-    req: keystore.EncryptV1Request,
-    res: keystore.EncryptResponse,
-  },
-  encryptV2: {
-    req: keystore.EncryptV2Request,
-    res: keystore.EncryptResponse,
-  },
+  /**
+   * Decrypt a batch of V2 messages
+   */
   decryptV2: {
     req: keystore.DecryptV2Request,
     res: keystore.DecryptResponse,
   },
+  /**
+   * Encrypt a batch of V1 messages
+   */
+  encryptV1: {
+    req: keystore.EncryptV1Request,
+    res: keystore.EncryptResponse,
+  },
+  /**
+   * Encrypt a batch of V2 messages
+   */
+  encryptV2: {
+    req: keystore.EncryptV2Request,
+    res: keystore.EncryptResponse,
+  },
+  /**
+   * Take a batch of invite messages and store the `TopicKeys` for later use in
+   * decrypting messages
+   */
   saveInvites: {
     req: keystore.SaveInvitesRequest,
     res: keystore.SaveInvitesResponse,
   },
+  /**
+   * Create a sealed/encrypted invite and store the Topic keys in the Keystore
+   * for later use. The returned invite payload must be sent to the network for
+   * the other party to be able to communicate.
+   */
   createInvite: {
     req: keystore.CreateInviteRequest,
     res: keystore.CreateInviteResponse,
   },
+  /**
+   * Create an XMTP auth token to be used as a header on XMTP API requests
+   */
   createAuthToken: {
     req: keystore.CreateAuthTokenRequest,
     res: authn.Token,
   },
+  /**
+   * Sign the provided digest with either the `IdentityKey` or a specified
+   * `PreKey`
+   */
   signDigest: {
     req: keystore.SignDigestRequest,
     res: signature.Signature,
   },
+  /**
+   * Get the `PublicKeyBundle` associated with the Keystore's private keys
+   */
   getPublicKeyBundle: {
     req: null,
     res: publicKey.PublicKeyBundle,
   },
+  /**
+   * Export the private keys. May throw an error if the keystore implementation
+   * does not allow this operation
+   */
+  getPrivateKeyBundle: {
+    req: null,
+    res: privateKey.PrivateKeyBundleV1,
+  },
+  /**
+   * Save V1 Conversations
+   */
   saveV1Conversations: {
     req: keystore.SaveV1ConversationsRequest,
     res: keystore.SaveV1ConversationsResponse,
   },
+  /**
+   * Get a list of V1 conversations
+   */
   getV1Conversations: {
     req: null,
     res: keystore.GetConversationsResponse,
   },
+  /**
+   * Get a list of V2 conversations
+   */
   getV2Conversations: {
     req: null,
     res: keystore.GetConversationsResponse,
   },
+  /**
+   * Get a refresh job from the persistence
+   */
   getRefreshJob: {
     req: keystore.GetRefreshJobRequest,
     res: keystore.GetRefreshJobResponse,
   },
+  /**
+   * Sets the time of a refresh job
+   */
   setRefreshJob: {
     req: keystore.SetRefeshJobRequest,
     res: keystore.SetRefreshJobResponse,
   },
+  /**
+   * Encrypt a batch of messages to yourself
+   */
   selfEncrypt: {
     req: keystore.SelfEncryptRequest,
     res: keystore.SelfEncryptResponse,
   },
+  /**
+   * Decrypt a batch of messages to yourself
+   */
   selfDecrypt: {
     req: keystore.SelfDecryptRequest,
     res: keystore.DecryptResponse,
   },
+  /**
+   * Get the private preferences topic identifier
+   */
   getPrivatePreferencesTopicIdentifier: {
     req: null,
     res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
   },
-} as const
+}
+
+export type KeystoreApiDefs = typeof apiDefs
+export type KeystoreApiMethods = keyof KeystoreApiDefs
+export type KeystoreInterface = ExtractInterface<KeystoreApiDefs>
+export type KeystoreApiEntries = Entries<KeystoreApiDefs>
+export type KeystoreApiRequestEncoders =
+  ExtractInterfaceRequestEncoders<KeystoreApiDefs>
+export type KeystoreApiResponseDecoders =
+  ExtractInterfaceResponseDecoders<KeystoreApiDefs>
+export type KeystoreInterfaceRequestValues =
+  ExtractInterfaceRequestValues<KeystoreInterface>
+export type KeystoreApiRequestValues = Values<KeystoreInterfaceRequestValues>
+
+export const snapApiDefs = {
+  ...apiDefs,
+  getKeystoreStatus: {
+    req: keystore.GetKeystoreStatusRequest,
+    res: keystore.GetKeystoreStatusResponse,
+  },
+  initKeystore: {
+    req: keystore.InitKeystoreRequest,
+    res: keystore.InitKeystoreResponse,
+  },
+}
+
+export type SnapKeystoreApiDefs = typeof snapApiDefs
+export type SnapKeystoreApiMethods = keyof SnapKeystoreApiDefs
+export type SnapKeystoreInterface = ExtractInterface<SnapKeystoreApiDefs>
+export type SnapKeystoreApiEntries = Entries<SnapKeystoreApiDefs>
+export type SnapKeystoreApiRequestEncoders =
+  ExtractInterfaceRequestEncoders<SnapKeystoreApiDefs>
+export type SnapKeystoreApiResponseDecoders =
+  ExtractInterfaceResponseDecoders<SnapKeystoreApiDefs>
+export type SnapKeystoreInterfaceRequestValues =
+  ExtractInterfaceRequestValues<SnapKeystoreInterface>
+export type SnapKeystoreApiRequestValues =
+  Values<SnapKeystoreInterfaceRequestValues>
+
+/**
+ * A Keystore is responsible for holding the user's XMTP private keys and using them to encrypt/decrypt/sign messages.
+ * Keystores are instantiated using a `KeystoreProvider`
+ */
+export type KeystoreInterfaces = KeystoreInterface | SnapKeystoreInterface

--- a/src/types/metamask.ts
+++ b/src/types/metamask.ts
@@ -1,7 +1,4 @@
-/* eslint-disable*/
-
 import { MetaMaskInpageProvider } from '@metamask/providers'
-import type { providers } from 'ethers'
 
 type EthereumType = MetaMaskInpageProvider & {
   setProvider?: (provider: MetaMaskInpageProvider) => void

--- a/test/conversations/JobRunner.test.ts
+++ b/test/conversations/JobRunner.test.ts
@@ -1,7 +1,7 @@
 import {
   InMemoryKeystore,
   InMemoryPersistence,
-  Keystore,
+  KeystoreInterface,
   PrivateKeyBundleV1,
   nsToDate,
 } from '../../src'
@@ -10,7 +10,7 @@ import JobRunner from '../../src/conversations/JobRunner'
 import { newWallet, sleep } from '../helpers'
 
 describe('JobRunner', () => {
-  let keystore: Keystore
+  let keystore: KeystoreInterface
 
   beforeEach(async () => {
     const bundle = await PrivateKeyBundleV1.generate(newWallet())

--- a/test/keystore/encryption.test.ts
+++ b/test/keystore/encryption.test.ts
@@ -1,4 +1,3 @@
-import { Keystore } from '../../src/keystore'
 import { Ciphertext } from '../../src/crypto'
 import { PrivateKeyBundleV1 } from './../../src/crypto/PrivateKeyBundle'
 import { decryptV1, encryptV1 } from '../../src/keystore/encryption'
@@ -7,12 +6,12 @@ import { Wallet } from 'ethers'
 import { equalBytes } from '../../src/crypto/utils'
 import { newWallet } from '../helpers'
 import { InMemoryKeystore } from '../../src/keystore'
-import { InMemoryPersistence } from '../../src'
+import { InMemoryPersistence, KeystoreInterface } from '../../src'
 
 describe('encryption primitives', () => {
   let aliceKeys: PrivateKeyBundleV1
   let aliceWallet: Wallet
-  let aliceKeystore: Keystore
+  let aliceKeystore: KeystoreInterface
   let bobKeys: PrivateKeyBundleV1
   let bobWallet: Wallet
 


### PR DESCRIPTION
in this PR:

- created new types for keystore interfaces based on their RPC
- deprecated existing `Keystore` interface

these new types allow for a single source of truth for keystore functionality and their associated types. updating a keystore's RPC definitions will automatically update its types.

i decided to export all the derivative types as well so that integrators have them. they are invaluable for creating type-safe custom keystores and their handlers.