### PR TITLE
Update snapRPC types and fix snapRequest

### DIFF
--- a/src/keystore/SnapKeystore.ts
+++ b/src/keystore/SnapKeystore.ts
@@ -24,9 +24,11 @@ export function SnapKeystore(
   ) as SnapKeystoreApiEntries) {
     generatedMethods[method] = async (req?: SnapKeystoreApiRequestValues) => {
       if (!rpc.req) {
-        return snapRPC(method, rpc, undefined, snapMeta, snapId)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return snapRPC(method, rpc, undefined, snapMeta, snapId) as any
       }
-      return snapRPC(method, rpc, req, snapMeta, snapId)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return snapRPC(method, rpc, req, snapMeta, snapId) as any
     }
   }
 

--- a/src/keystore/snapHelpers.ts
+++ b/src/keystore/snapHelpers.ts
@@ -53,8 +53,9 @@ export async function snapRPC<T extends SnapKeystoreApiMethods>(
     throw new Error('Unexpected array response')
   }
 
-  const decoder = rpc.res.decode as SnapKeystoreApiResponseDecoders[T]
-  return decoder(b64Decode(responseString))
+  return rpc.res.decode(b64Decode(responseString)) as ReturnType<
+    SnapKeystoreApiResponseDecoders[T]
+  >
 }
 
 export async function snapRequest(
@@ -78,11 +79,11 @@ export async function snapRequest(
     },
   })
 
-  if (!response || !response.res) {
+  if (!response || typeof response !== 'object') {
     throw new Error('No response value')
   }
 
-  return response.res
+  return (response as SnapResponse).res
 }
 
 export type Snap = {


### PR DESCRIPTION
in this PR:

- fixed `snapRPC` return type
- asserted return type of `snapRPC` in `SnapKeystore` to fix type error
- fixed response check in `snapRequest`

asserting the return type of `snapRPC` in `SnapKeystore` is not ideal, but this way we get accurate return types when calling `snapRPC` locally. the return type of `SnapKeystore` is unaffected by this change as it's also asserted.