### PR TITLE
Fix webpack builds using browser/bundler export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@xmtp/proto": "^3.34.0",
-        "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
+        "@xmtp/user-preferences-bindings-wasm": "^0.3.5",
         "async-mutex": "^0.4.0",
         "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
@@ -5552,9 +5552,9 @@
       }
     },
     "node_modules/@xmtp/user-preferences-bindings-wasm": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@xmtp/user-preferences-bindings-wasm/-/user-preferences-bindings-wasm-0.3.4.tgz",
-      "integrity": "sha512-4d0j8QDZT8Z9DXIjxRJh7M1DjLNWcPV6807eeMN79gwF9SWbR1CXGSnBNqSrOgVu9nQSWqtg6qfyrrlQ3yHybA=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@xmtp/user-preferences-bindings-wasm/-/user-preferences-bindings-wasm-0.3.5.tgz",
+      "integrity": "sha512-6zfUbjEs7yRwPkYUo9JjxcI3AGg8HIGvb+2DiLgZU+dDj3BTKoL+N3+oXA649zH2PF5k+EJ8kCz2n9uuJwT7mA=="
     },
     "node_modules/abab": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "@noble/secp256k1": "^1.5.2",
     "@xmtp/proto": "^3.34.0",
-    "@xmtp/user-preferences-bindings-wasm": "^0.3.4",
+    "@xmtp/user-preferences-bindings-wasm": "^0.3.5",
     "async-mutex": "^0.4.0",
     "elliptic": "^6.5.4",
     "ethers": "^5.5.3",


### PR DESCRIPTION
this PR upgrades the `@xmtp/user-preferences-bindings-wasm` dependency to fix `webpack` builds using the `/browser/bundler` export.