### PR TITLE
Support `base` WalletClient type

### DIFF
--- a/src/utils/viem.ts
+++ b/src/utils/viem.ts
@@ -15,7 +15,10 @@ export function getSigner(wallet: Signer | WalletClient | null): Signer | null {
 }
 
 function isWalletClient(wallet: Signer | WalletClient): wallet is WalletClient {
-  return 'type' in wallet && wallet.type === 'walletClient'
+  return (
+    'type' in wallet &&
+    (wallet.type === 'walletClient' || wallet.type === 'base')
+  )
 }
 
 export function convertWalletClientToSigner(


### PR DESCRIPTION
# Summary

When using the latest version of `wagmi`, the `useWalletClient` hook returns a `WalletClient` instance with a type of `base`, which is still compatible but throws an error. This PR allows a type of `base` when determining the signer type.