### PR TITLE
Add `senderHmac`, `shouldPush` for entitlements

### DIFF
--- a/bench/decode.ts
+++ b/bench/decode.ts
@@ -22,9 +22,10 @@ const decodeV1 = () => {
       const bob = await newPrivateKeyBundle()
 
       const message = randomBytes(size)
+      const { payload } = await alice.encodeContent(message)
       const encodedMessage = await MessageV1.encode(
         alice.keystore,
-        await alice.encodeContent(message),
+        payload,
         alice.publicKeyBundle,
         bob.getPublicKeyBundle(),
         new Date()
@@ -75,8 +76,8 @@ const decodeV2 = () => {
         new Date(),
         undefined
       )
-      const payload = await alice.encodeContent(message)
-      const encodedMessage = await convo.createMessage(payload)
+      const { payload, shouldPush } = await alice.encodeContent(message)
+      const encodedMessage = await convo.createMessage(payload, shouldPush)
       const messageBytes = encodedMessage.toBytes()
 
       const envelope = {

--- a/bench/encode.ts
+++ b/bench/encode.ts
@@ -22,7 +22,7 @@ const encodeV1 = () => {
 
       // The returned function is the actual benchmark. Everything above is setup
       return async () => {
-        const encodedMessage = await alice.encodeContent(message)
+        const { payload: encodedMessage } = await alice.encodeContent(message)
         await MessageV1.encode(
           alice.keystore,
           encodedMessage,
@@ -57,11 +57,11 @@ const encodeV2 = () => {
         undefined
       )
       const message = randomBytes(size)
-      const payload = await alice.encodeContent(message)
+      const { payload, shouldPush } = await alice.encodeContent(message)
 
       // The returned function is the actual benchmark. Everything above is setup
       return async () => {
-        await convo.createMessage(payload)
+        await convo.createMessage(payload, shouldPush)
       }
     })
   )

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -634,7 +634,10 @@ export default class Client<ContentTypes = any> {
   async encodeContent(
     content: ContentTypes,
     options?: SendOptions
-  ): Promise<Uint8Array> {
+  ): Promise<{
+    payload: Uint8Array
+    shouldPush: boolean
+  }> {
     const contentType = options?.contentType || ContentTypeText
     const codec = this.codecFor(contentType)
     if (!codec) {
@@ -654,7 +657,10 @@ export default class Client<ContentTypes = any> {
       encoded.compression = options.compression
     }
     await compress(encoded)
-    return proto.EncodedContent.encode(encoded).finish()
+    return {
+      payload: proto.EncodedContent.encode(encoded).finish(),
+      shouldPush: codec.shouldPush(content),
+    }
   }
 
   async decodeContent(contentBytes: Uint8Array): Promise<{

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -188,26 +188,30 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
 
 export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
-  private header: proto.MessageHeaderV2 // eslint-disable-line camelcase
+  private header: proto.MessageHeaderV2
+  senderHmac: Uint8Array
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
-    header: proto.MessageHeaderV2
+    header: proto.MessageHeaderV2,
+    senderHmac: Uint8Array
   ) {
     super(id, bytes, obj)
     this.header = header
+    this.senderHmac = senderHmac
   }
 
   static async create(
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    bytes: Uint8Array
+    bytes: Uint8Array,
+    senderHmac: Uint8Array
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
 
-    return new MessageV2(id, bytes, obj, header)
+    return new MessageV2(id, bytes, obj, header, senderHmac)
   }
 
   get sent(): Date {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -190,28 +190,32 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
   private header: proto.MessageHeaderV2
   senderHmac: Uint8Array
+  shouldPush: boolean
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    senderHmac: Uint8Array
+    senderHmac: Uint8Array,
+    shouldPush: boolean
   ) {
     super(id, bytes, obj)
     this.header = header
     this.senderHmac = senderHmac
+    this.shouldPush = shouldPush
   }
 
   static async create(
     obj: proto.Message,
     header: proto.MessageHeaderV2,
     bytes: Uint8Array,
-    senderHmac: Uint8Array
+    senderHmac: Uint8Array,
+    shouldPush: boolean
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
 
-    return new MessageV2(id, bytes, obj, header, senderHmac)
+    return new MessageV2(id, bytes, obj, header, senderHmac, shouldPush)
   }
 
   get sent(): Date {

--- a/src/Message.ts
+++ b/src/Message.ts
@@ -189,16 +189,16 @@ export class MessageV1 extends MessageBase implements proto.MessageV1 {
 export class MessageV2 extends MessageBase implements proto.MessageV2 {
   senderAddress: string | undefined
   private header: proto.MessageHeaderV2
-  senderHmac: Uint8Array
-  shouldPush: boolean
+  senderHmac?: Uint8Array
+  shouldPush?: boolean
 
   constructor(
     id: string,
     bytes: Uint8Array,
     obj: proto.Message,
     header: proto.MessageHeaderV2,
-    senderHmac: Uint8Array,
-    shouldPush: boolean
+    senderHmac?: Uint8Array,
+    shouldPush?: boolean
   ) {
     super(id, bytes, obj)
     this.header = header
@@ -210,8 +210,8 @@ export class MessageV2 extends MessageBase implements proto.MessageV2 {
     obj: proto.Message,
     header: proto.MessageHeaderV2,
     bytes: Uint8Array,
-    senderHmac: Uint8Array,
-    shouldPush: boolean
+    senderHmac?: Uint8Array,
+    shouldPush?: boolean
   ): Promise<MessageV2> {
     const id = bytesToHex(await sha256(bytes))
 

--- a/src/MessageContent.ts
+++ b/src/MessageContent.ts
@@ -58,6 +58,7 @@ export interface ContentCodec<T> {
   encode(content: T, registry: CodecRegistry): EncodedContent
   decode(content: EncodedContent, registry: CodecRegistry): T
   fallback(content: T): string | undefined
+  shouldPush: (content: T) => boolean
 }
 
 // xmtp.org/fallback

--- a/src/codecs/Composite.ts
+++ b/src/codecs/Composite.ts
@@ -111,4 +111,8 @@ export class CompositeCodec implements ContentCodec<Composite> {
   fallback(content: Composite): string | undefined {
     return undefined
   }
+
+  shouldPush() {
+    return false
+  }
 }

--- a/src/codecs/Text.ts
+++ b/src/codecs/Text.ts
@@ -40,4 +40,8 @@ export class TextCodec implements ContentCodec<string> {
   fallback(content: string): string | undefined {
     return undefined
   }
+
+  shouldPush() {
+    return true
+  }
 }

--- a/src/conversations/Conversation.ts
+++ b/src/conversations/Conversation.ts
@@ -15,7 +15,7 @@ import type {
 import type Client from '../Client'
 import type { InvitationContext } from '../Invitation'
 import { DecodedMessage, MessageV1, MessageV2 } from '../Message'
-import type { messageApi, keystore, ciphertext } from '@xmtp/proto'
+import type { messageApi, keystore } from '@xmtp/proto'
 import { message, content as proto } from '@xmtp/proto'
 import {
   SignedPublicKey,
@@ -658,14 +658,17 @@ export class ConversationV2<ContentTypes>
     }
     const signedBytes = proto.SignedContent.encode(signed).finish()
 
-    const ciphertext = await this.encryptMessage(signedBytes, headerBytes)
+    const { encrypted: ciphertext, senderHmac } = await this.encryptMessage(
+      signedBytes,
+      headerBytes
+    )
     const protoMsg = {
       v1: undefined,
-      v2: { headerBytes, ciphertext },
+      v2: { headerBytes, ciphertext, senderHmac },
     }
     const bytes = message.Message.encode(protoMsg).finish()
 
-    return MessageV2.create(protoMsg, header, bytes)
+    return MessageV2.create(protoMsg, header, bytes, senderHmac)
   }
 
   private async decryptBatch(
@@ -709,10 +712,7 @@ export class ConversationV2<ContentTypes>
     }
   }
 
-  private async encryptMessage(
-    payload: Uint8Array,
-    headerBytes: Uint8Array
-  ): Promise<ciphertext.Ciphertext> {
+  private async encryptMessage(payload: Uint8Array, headerBytes: Uint8Array) {
     const { responses } = await this.client.keystore.encryptV2({
       requests: [
         {
@@ -725,8 +725,8 @@ export class ConversationV2<ContentTypes>
     if (responses.length !== 1) {
       throw new Error('Invalid response length')
     }
-    const { encrypted } = getResultOrThrow(responses[0])
-    return encrypted
+    const { encrypted, senderHmac } = getResultOrThrow(responses[0])
+    return { encrypted, senderHmac }
   }
 
   private async buildDecodedMessage(
@@ -829,7 +829,7 @@ export class ConversationV2<ContentTypes>
       throw new Error('topic mismatch')
     }
 
-    return MessageV2.create(msg, header, env.message)
+    return MessageV2.create(msg, header, env.message, msg.v2.senderHmac)
   }
 
   async decodeMessage(

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -3,6 +3,7 @@ import Ciphertext, { AESGCMNonceSize, KDFSaltSize } from './Ciphertext'
 import crypto from './crypto'
 
 const hkdfNoInfo = new Uint8Array().buffer
+const hkdfNoSalt = new Uint8Array().buffer
 
 // This is a variation of https://github.com/paulmillr/noble-secp256k1/blob/main/index.ts#L1378-L1388
 // that uses `digest('SHA-256', bytes)` instead of `digest('SHA-256', bytes.buffer)`
@@ -86,13 +87,13 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
 
 export async function hkdfHmacKey(
   secret: Uint8Array,
-  salt: Uint8Array
+  info: Uint8Array
 ): Promise<CryptoKey> {
   const key = await crypto.subtle.importKey('raw', secret, 'HKDF', false, [
     'deriveKey',
   ])
   return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
+    { name: 'HKDF', hash: 'SHA-256', salt: hkdfNoSalt, info },
     key,
     { name: 'HMAC', hash: 'SHA-256', length: 256 },
     true,
@@ -102,10 +103,10 @@ export async function hkdfHmacKey(
 
 export async function generateHmacSignature(
   secret: Uint8Array,
-  salt: Uint8Array,
+  info: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
-  const key = await hkdfHmacKey(secret, salt)
+  const key = await hkdfHmacKey(secret, info)
   const signed = await crypto.subtle.sign('HMAC', key, message)
   return new Uint8Array(signed)
 }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -116,3 +116,26 @@ export async function generateHmac(
   const key = await hkdfHmacKey(secret, salt)
   return generateHmacWithKey(key, message)
 }
+
+export async function validateHmac(
+  key: CryptoKey,
+  signature: Uint8Array,
+  message: Uint8Array
+): Promise<boolean> {
+  return await crypto.subtle.verify('HMAC', key, signature, message)
+}
+
+export async function exportHmacKey(key: CryptoKey): Promise<Uint8Array> {
+  const exported = await crypto.subtle.exportKey('raw', key)
+  return new Uint8Array(exported)
+}
+
+export async function importHmacKey(key: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    key,
+    { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    true,
+    ['sign', 'verify']
+  )
+}

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -84,7 +84,7 @@ async function hkdf(secret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
   )
 }
 
-async function hkdfHmacKey(
+export async function hkdfHmacKey(
   secret: Uint8Array,
   salt: Uint8Array
 ): Promise<CryptoKey> {

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -100,7 +100,7 @@ export async function hkdfHmacKey(
   )
 }
 
-async function generateHmac(
+async function generateHmacWithKey(
   key: CryptoKey,
   message: Uint8Array
 ): Promise<Uint8Array> {
@@ -108,11 +108,11 @@ async function generateHmac(
   return new Uint8Array(signed)
 }
 
-export async function generateHmacSignature(
+export async function generateHmac(
   secret: Uint8Array,
   salt: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
   const key = await hkdfHmacKey(secret, salt)
-  return generateHmac(key, message)
+  return generateHmacWithKey(key, message)
 }

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -100,24 +100,17 @@ export async function hkdfHmacKey(
   )
 }
 
-async function generateHmacWithKey(
-  key: CryptoKey,
-  message: Uint8Array
-): Promise<Uint8Array> {
-  const signed = await crypto.subtle.sign('HMAC', key, message)
-  return new Uint8Array(signed)
-}
-
-export async function generateHmac(
+export async function generateHmacSignature(
   secret: Uint8Array,
   salt: Uint8Array,
   message: Uint8Array
 ): Promise<Uint8Array> {
   const key = await hkdfHmacKey(secret, salt)
-  return generateHmacWithKey(key, message)
+  const signed = await crypto.subtle.sign('HMAC', key, message)
+  return new Uint8Array(signed)
 }
 
-export async function validateHmac(
+export async function verifyHmacSignature(
   key: CryptoKey,
   signature: Uint8Array,
   message: Uint8Array

--- a/src/crypto/encryption.ts
+++ b/src/crypto/encryption.ts
@@ -95,7 +95,7 @@ export async function hkdfHmacKey(
     { name: 'HKDF', hash: 'SHA-256', salt, info: hkdfNoInfo },
     key,
     { name: 'HMAC', hash: 'SHA-256', length: 256 },
-    false,
+    true,
     ['sign', 'verify']
   )
 }

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -9,7 +9,15 @@ import {
 import { UnsignedPublicKey, SignedPublicKey, PublicKey } from './PublicKey'
 import Signature, { WalletSigner } from './Signature'
 import * as utils from './utils'
-import { encrypt, decrypt } from './encryption'
+import {
+  decrypt,
+  encrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
+} from './encryption'
 import Ciphertext from './Ciphertext'
 import SignedEciesCiphertext from './SignedEciesCiphertext'
 
@@ -18,6 +26,11 @@ export {
   utils,
   encrypt,
   decrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
   Ciphertext,
   UnsignedPublicKey,
   SignedPublicKey,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ export {
   Signature,
   encrypt,
   decrypt,
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+  importHmacKey,
+  verifyHmacSignature,
 } from './crypto'
 export { default as Stream } from './Stream'
 export type { Signer } from './types/Signer'

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import type { KeystoreInterface } from '..'
-import { generateHmacSignature, hkdfHmacKey } from '../crypto/encryption'
+import { generateHmac, hkdfHmacKey } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -302,7 +302,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
         const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
-        const hmac = await generateHmacSignature(
+        const hmac = await generateHmac(
           keyMaterial,
           new TextEncoder().encode(salt),
           headerBytes

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -305,10 +305,10 @@ export default class InMemoryKeystore implements KeystoreInterface {
         const thirtyDayPeriodsSinceEpoch = Math.floor(
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
-        const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
+        const info = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
         const hmac = await generateHmacSignature(
           keyMaterial,
-          new TextEncoder().encode(salt),
+          new TextEncoder().encode(info),
           headerBytes
         )
 

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,6 +35,7 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import type { KeystoreInterface } from '..'
+import { generateHmacSignature } from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -295,10 +296,14 @@ export default class InMemoryKeystore implements KeystoreInterface {
           )
         }
 
+        const keyMaterial = getKeyMaterial(topicData.invitation)
+        const ciphertext = await encryptV2(payload, keyMaterial, headerBytes)
+
         return {
-          encrypted: await encryptV2(
-            payload,
-            getKeyMaterial(topicData.invitation),
+          encrypted: ciphertext,
+          senderHmac: await generateHmacSignature(
+            keyMaterial,
+            new TextEncoder().encode(contentTopic),
             headerBytes
           ),
         }

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -612,10 +612,10 @@ export default class InMemoryKeystore implements KeystoreInterface {
               thirtyDayPeriodsSinceEpoch,
               thirtyDayPeriodsSinceEpoch + 1,
             ].map(async (value) => {
-              const salt = `${value}-${this.accountAddress}`
+              const info = `${value}-${this.accountAddress}`
               const hmacKey = await hkdfHmacKey(
                 keyMaterial,
-                new TextEncoder().encode(salt)
+                new TextEncoder().encode(info)
               )
               return {
                 thirtyDayPeriodsSinceEpoch: value,

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -34,12 +34,12 @@ import {
   userPreferencesEncrypt,
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
-import type { KeystoreInterface } from '..'
 import {
   exportHmacKey,
   generateHmacSignature,
   hkdfHmacKey,
 } from '../crypto/encryption'
+import type { KeystoreInterface } from './rpcDefinitions'
 
 const { ErrorCode } = keystore
 
@@ -595,15 +595,28 @@ export default class InMemoryKeystore implements KeystoreInterface {
     return this.v2Store.lookup(topic)
   }
 
-  async getV2ConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse> {
+  async getV2ConversationHmacKeys(
+    req?: keystore.GetConversationHmacKeysRequest
+  ): Promise<keystore.GetConversationHmacKeysResponse> {
     const thirtyDayPeriodsSinceEpoch = Math.floor(
       Date.now() / 1000 / 60 / 60 / 24 / 30
     )
 
     const hmacKeys: keystore.GetConversationHmacKeysResponse['hmacKeys'] = {}
 
+    let topics = this.v2Store.topics
+
+    // if specific topics are requested, only include those topics
+    if (req?.topics) {
+      topics = topics.filter(
+        (topicData) =>
+          topicData.invitation !== undefined &&
+          req.topics.includes(topicData.invitation.topic)
+      )
+    }
+
     await Promise.all(
-      this.v2Store.topics.map(async (topicData) => {
+      topics.map(async (topicData) => {
         if (topicData.invitation?.topic) {
           const keyMaterial = getKeyMaterial(topicData.invitation)
           const values = await Promise.all(

--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -35,7 +35,11 @@ import {
   generateUserPreferencesTopic,
 } from '../crypto/selfEncryption'
 import type { KeystoreInterface } from '..'
-import { exportHmacKey, generateHmac, hkdfHmacKey } from '../crypto/encryption'
+import {
+  exportHmacKey,
+  generateHmacSignature,
+  hkdfHmacKey,
+} from '../crypto/encryption'
 
 const { ErrorCode } = keystore
 
@@ -302,7 +306,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
         const salt = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
-        const hmac = await generateHmac(
+        const hmac = await generateHmacSignature(
           keyMaterial,
           new TextEncoder().encode(salt),
           headerBytes

--- a/src/keystore/interfaces.ts
+++ b/src/keystore/interfaces.ts
@@ -104,6 +104,11 @@ export interface Keystore {
    * Get the private preferences topic identifier
    */
   getPrivatePreferencesTopicIdentifier(): Promise<keystore.GetPrivatePreferencesTopicIdentifierResponse>
+  /**
+   * Returns the conversation HMAC keys for the current, previous, and next
+   * 30 day periods since the epoch
+   */
+  getV2ConversationHmacKeys(): Promise<keystore.GetConversationHmacKeysResponse>
 }
 
 export type TopicData = WithoutUndefined<keystore.TopicMap_TopicData>

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -199,8 +199,12 @@ export const apiDefs = {
     req: null,
     res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
   },
+  /**
+   * Returns the conversation HMAC keys for the current, previous, and next
+   * 30 day periods since the epoch
+   */
   getV2ConversationHmacKeys: {
-    req: null,
+    req: keystore.GetConversationHmacKeysRequest,
     res: keystore.GetConversationHmacKeysResponse,
   },
 }

--- a/src/keystore/rpcDefinitions.ts
+++ b/src/keystore/rpcDefinitions.ts
@@ -199,6 +199,10 @@ export const apiDefs = {
     req: null,
     res: keystore.GetPrivatePreferencesTopicIdentifierResponse,
   },
+  getV2ConversationHmacKeys: {
+    req: null,
+    res: keystore.GetConversationHmacKeysResponse,
+  },
 }
 
 export type KeystoreApiDefs = typeof apiDefs

--- a/src/utils/keystore.ts
+++ b/src/utils/keystore.ts
@@ -4,6 +4,12 @@ import { KeystoreError } from '../keystore/errors'
 import type { MessageV1 } from '../Message'
 import type { WithoutUndefined } from './typedefs'
 
+type EncryptionResponseResult<
+  T extends
+    | keystore.DecryptResponse_Response
+    | keystore.EncryptResponse_Response,
+> = WithoutUndefined<T>['result']
+
 // Validates the Keystore response. Throws on errors or missing fields.
 // Returns a type with all possibly undefined fields required to be defined
 export const getResultOrThrow = <
@@ -12,10 +18,11 @@ export const getResultOrThrow = <
     | keystore.EncryptResponse_Response,
 >(
   response: T
-): WithoutUndefined<NonNullable<T['result']>> => {
+) => {
   if (response.error) {
     throw new KeystoreError(response.error.code, response.error.message)
   }
+
   if (!response.result) {
     throw new KeystoreError(
       keystore.ErrorCode.ERROR_CODE_UNSPECIFIED,
@@ -31,9 +38,7 @@ export const getResultOrThrow = <
     throw new Error('Missing decrypted result')
   }
 
-  return response.result as unknown as WithoutUndefined<
-    NonNullable<T['result']>
-  >
+  return response.result as EncryptionResponseResult<T>
 }
 
 export const buildDecryptV1Request = (

--- a/test/ContentTypeTestKey.ts
+++ b/test/ContentTypeTestKey.ts
@@ -30,4 +30,8 @@ export class TestKeyCodec implements ContentCodec<PublicKey> {
   fallback(content: PublicKey): string | undefined {
     return 'publickey bundle'
   }
+
+  shouldPush() {
+    return false
+  }
 }

--- a/test/Message.test.ts
+++ b/test/Message.test.ts
@@ -153,7 +153,7 @@ describe('Message', function () {
         env: 'local',
         privateKeyOverride: alice.encode(),
       })
-      const payload = await aliceClient.encodeContent(text)
+      const { payload } = await aliceClient.encodeContent(text)
       const timestamp = new Date()
       const sender = alice.getPublicKeyBundle()
       const recipient = bob.getPublicKeyBundle()

--- a/test/conversations/Conversation.test.ts
+++ b/test/conversations/Conversation.test.ts
@@ -1,4 +1,4 @@
-import { DecodedMessage, MessageV1 } from './../../src/Message'
+import { DecodedMessage, MessageV1, MessageV2 } from './../../src/Message'
 import { buildDirectMessageTopic } from './../../src/utils'
 import { Client, Compression, ContentTypeId, ContentTypeText } from '../../src'
 import { SortDirection } from '../../src/ApiClient'
@@ -543,6 +543,17 @@ describe('conversation', () => {
 
       await bs.return()
       await as.return()
+
+      const messages = await alice.listEnvelopes<MessageV2>(
+        ac.topic,
+        ac.processEnvelope.bind(ac)
+      )
+
+      expect(messages).toHaveLength(2)
+      expect(messages[0].shouldPush).toBe(true)
+      expect(messages[0].senderHmac).toBeDefined()
+      expect(messages[1].shouldPush).toBe(true)
+      expect(messages[1].senderHmac).toBeDefined()
     })
 
     // it('rejects spoofed contact bundles', async () => {
@@ -733,6 +744,9 @@ describe('conversation', () => {
           metadata: {},
         }
       )
+      if (!(aliceConvo instanceof ConversationV2)) {
+        assert.fail()
+      }
       await sleep(100)
       const bobConvo = await bob.conversations.newConversation(alice.address, {
         conversationId: 'xmtp.org/key',
@@ -744,7 +758,6 @@ describe('conversation', () => {
 
       // alice doesn't recognize the type
       expect(
-        // @ts-expect-error
         aliceConvo.send(key, {
           contentType: ContentTypeTestKey,
         })
@@ -752,7 +765,6 @@ describe('conversation', () => {
 
       // bob doesn't recognize the type
       alice.registerCodec(new TestKeyCodec())
-      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -774,7 +786,6 @@ describe('conversation', () => {
 
       // both recognize the type
       bob.registerCodec(new TestKeyCodec())
-      // @ts-expect-error
       await aliceConvo.send(key, {
         contentType: ContentTypeTestKey,
       })
@@ -789,13 +800,23 @@ describe('conversation', () => {
         ...ContentTypeTestKey,
         versionMajor: 2,
       })
-      // @ts-expect-error
       expect(aliceConvo.send(key, { contentType: type2 })).rejects.toThrow(
         'unknown content type xmtp.test/public-key:2.0'
       )
 
       await bobStream.return()
       await aliceStream.return()
+
+      const messages = await alice.listEnvelopes<MessageV2>(
+        aliceConvo.topic,
+        aliceConvo.processEnvelope.bind(aliceConvo)
+      )
+
+      expect(messages).toHaveLength(2)
+      expect(messages[0].shouldPush).toBe(false)
+      expect(messages[0].senderHmac).toBeDefined()
+      expect(messages[1].shouldPush).toBe(false)
+      expect(messages[1].senderHmac).toBeDefined()
     })
   })
 })

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -1,0 +1,62 @@
+import {
+  importHmacKey,
+  exportHmacKey,
+  hkdfHmacKey,
+  validateHmac,
+  generateHmac,
+} from '../../src/crypto/encryption'
+import crypto from '../../src/crypto/crypto'
+
+describe('HMAC encryption', () => {
+  it('generates and validates HMAC', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const valid = await validateHmac(key, hmac, message)
+    expect(valid).toBe(true)
+  })
+
+  it('generates and validates HMAC with imported key', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const exportedKey = await exportHmacKey(key)
+    const importedKey = await importHmacKey(exportedKey)
+    const valid = await validateHmac(importedKey, hmac, message)
+    expect(valid).toBe(true)
+  })
+
+  it('fails to validate HMAC with wrong message', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const key = await hkdfHmacKey(secret, salt)
+    const valid = await validateHmac(
+      key,
+      hmac,
+      crypto.getRandomValues(new Uint8Array(32))
+    )
+    expect(valid).toBe(false)
+  })
+
+  it('fails to validate HMAC with wrong key', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const message = crypto.getRandomValues(new Uint8Array(32))
+    const hmac = await generateHmac(secret, salt, message)
+    const valid = await validateHmac(
+      await hkdfHmacKey(
+        crypto.getRandomValues(new Uint8Array(32)),
+        crypto.getRandomValues(new Uint8Array(32))
+      ),
+      hmac,
+      message
+    )
+    expect(valid).toBe(false)
+  })
+})

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -10,32 +10,42 @@ import crypto from '../../src/crypto/crypto'
 describe('HMAC encryption', () => {
   it('generates and validates HMAC', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const valid = await verifyHmacSignature(key, hmac, message)
     expect(valid).toBe(true)
   })
 
   it('generates and validates HMAC with imported key', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const exportedKey = await exportHmacKey(key)
     const importedKey = await importHmacKey(exportedKey)
     const valid = await verifyHmacSignature(importedKey, hmac, message)
     expect(valid).toBe(true)
   })
 
+  it('generates different HMAC keys with different infos', async () => {
+    const secret = crypto.getRandomValues(new Uint8Array(32))
+    const info1 = crypto.getRandomValues(new Uint8Array(32))
+    const info2 = crypto.getRandomValues(new Uint8Array(32))
+    const key1 = await hkdfHmacKey(secret, info1)
+    const key2 = await hkdfHmacKey(secret, info2)
+
+    expect(await exportHmacKey(key1)).not.toEqual(await exportHmacKey(key2))
+  })
+
   it('fails to validate HMAC with wrong message', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
-    const key = await hkdfHmacKey(secret, salt)
+    const hmac = await generateHmacSignature(secret, info, message)
+    const key = await hkdfHmacKey(secret, info)
     const valid = await verifyHmacSignature(
       key,
       hmac,
@@ -46,9 +56,9 @@ describe('HMAC encryption', () => {
 
   it('fails to validate HMAC with wrong key', async () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
-    const salt = crypto.getRandomValues(new Uint8Array(32))
+    const info = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmacSignature(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, info, message)
     const valid = await verifyHmacSignature(
       await hkdfHmacKey(
         crypto.getRandomValues(new Uint8Array(32)),

--- a/test/crypto/encryption.test.ts
+++ b/test/crypto/encryption.test.ts
@@ -2,8 +2,8 @@ import {
   importHmacKey,
   exportHmacKey,
   hkdfHmacKey,
-  validateHmac,
-  generateHmac,
+  verifyHmacSignature,
+  generateHmacSignature,
 } from '../../src/crypto/encryption'
 import crypto from '../../src/crypto/crypto'
 
@@ -12,9 +12,9 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
-    const valid = await validateHmac(key, hmac, message)
+    const valid = await verifyHmacSignature(key, hmac, message)
     expect(valid).toBe(true)
   })
 
@@ -22,11 +22,11 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
     const exportedKey = await exportHmacKey(key)
     const importedKey = await importHmacKey(exportedKey)
-    const valid = await validateHmac(importedKey, hmac, message)
+    const valid = await verifyHmacSignature(importedKey, hmac, message)
     expect(valid).toBe(true)
   })
 
@@ -34,9 +34,9 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
+    const hmac = await generateHmacSignature(secret, salt, message)
     const key = await hkdfHmacKey(secret, salt)
-    const valid = await validateHmac(
+    const valid = await verifyHmacSignature(
       key,
       hmac,
       crypto.getRandomValues(new Uint8Array(32))
@@ -48,8 +48,8 @@ describe('HMAC encryption', () => {
     const secret = crypto.getRandomValues(new Uint8Array(32))
     const salt = crypto.getRandomValues(new Uint8Array(32))
     const message = crypto.getRandomValues(new Uint8Array(32))
-    const hmac = await generateHmac(secret, salt, message)
-    const valid = await validateHmac(
+    const hmac = await generateHmacSignature(secret, salt, message)
+    const valid = await verifyHmacSignature(
       await hkdfHmacKey(
         crypto.getRandomValues(new Uint8Array(32)),
         crypto.getRandomValues(new Uint8Array(32))

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -868,7 +868,7 @@ describe('InMemoryKeystore', () => {
   })
 
   describe('getV2ConversationHmacKeys', () => {
-    it('returns conversation HMAC keys', async () => {
+    it('returns all conversation HMAC keys', async () => {
       const baseTime = new Date()
       const timestamps = Array.from(
         { length: 5 },
@@ -915,6 +915,111 @@ describe('InMemoryKeystore', () => {
 
       await Promise.all(
         invites.map(async (invite) => {
+          const topic = invite.conversation!.topic
+          const payload = new TextEncoder().encode('Hello, world!')
+
+          const {
+            responses: [encrypted],
+          } = await aliceKeystore.encryptV2({
+            requests: [
+              {
+                contentTopic: topic,
+                payload,
+                headerBytes,
+              },
+            ],
+          })
+
+          if (encrypted.error) {
+            throw encrypted.error
+          }
+
+          const topicData = aliceKeystore.lookupTopic(topic)
+          const keyMaterial = getKeyMaterial(topicData!.invitation)
+          const info = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
+          const hmac = await generateHmacSignature(
+            keyMaterial,
+            new TextEncoder().encode(info),
+            headerBytes
+          )
+
+          topicHmacs[topic] = hmac
+        })
+      )
+
+      await Promise.all(
+        Object.keys(hmacKeys).map(async (topic) => {
+          const hmacData = hmacKeys[topic]
+
+          await Promise.all(
+            hmacData.values.map(
+              async ({ hmacKey, thirtyDayPeriodsSinceEpoch }, idx) => {
+                expect(thirtyDayPeriodsSinceEpoch).toBe(periods[idx])
+                const valid = await verifyHmacSignature(
+                  await importHmacKey(hmacKey),
+                  topicHmacs[topic],
+                  headerBytes
+                )
+                expect(valid).toBe(idx === 1 ? true : false)
+              }
+            )
+          )
+        })
+      )
+    })
+
+    it('returns specific conversation HMAC keys', async () => {
+      const baseTime = new Date()
+      const timestamps = Array.from(
+        { length: 10 },
+        (_, i) => new Date(baseTime.getTime() + i)
+      )
+
+      const invites = await Promise.all(
+        [...timestamps].map(async (createdAt) => {
+          let keys = await PrivateKeyBundleV1.generate(newWallet())
+
+          const recipient = SignedPublicKeyBundle.fromLegacyBundle(
+            keys.getPublicKeyBundle()
+          )
+
+          return aliceKeystore.createInvite({
+            recipient,
+            createdNs: dateToNs(createdAt),
+            context: undefined,
+          })
+        })
+      )
+
+      const thirtyDayPeriodsSinceEpoch = Math.floor(
+        Date.now() / 1000 / 60 / 60 / 24 / 30
+      )
+
+      const periods = [
+        thirtyDayPeriodsSinceEpoch - 1,
+        thirtyDayPeriodsSinceEpoch,
+        thirtyDayPeriodsSinceEpoch + 1,
+      ]
+
+      const randomInvites = invites.slice(3, 8)
+
+      const { hmacKeys } = await aliceKeystore.getV2ConversationHmacKeys({
+        topics: randomInvites.map((invite) => invite.conversation!.topic),
+      })
+
+      const topics = Object.keys(hmacKeys)
+      expect(topics.length).toBe(randomInvites.length)
+      randomInvites.forEach((invite) => {
+        expect(topics.includes(invite.conversation!.topic)).toBeTruthy()
+      })
+
+      const topicHmacs: {
+        [topic: string]: Uint8Array
+      } = {}
+      const headerBytes = new Uint8Array(10)
+
+      await Promise.all(
+        randomInvites.map(async (invite) => {
           const topic = invite.conversation!.topic
           const payload = new TextEncoder().encode('Hello, world!')
 

--- a/test/keystore/InMemoryKeystore.test.ts
+++ b/test/keystore/InMemoryKeystore.test.ts
@@ -936,10 +936,10 @@ describe('InMemoryKeystore', () => {
 
           const topicData = aliceKeystore.lookupTopic(topic)
           const keyMaterial = getKeyMaterial(topicData!.invitation)
-          const salt = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
+          const info = `${thirtyDayPeriodsSinceEpoch}-${aliceKeystore.walletAddress}`
           const hmac = await generateHmacSignature(
             keyMaterial,
-            new TextEncoder().encode(salt),
+            new TextEncoder().encode(info),
             headerBytes
           )
 


### PR DESCRIPTION
# Summary

- Added `shouldPush` to `ContentCodec` type
- Added `shouldPush` method to `TextCodec` and `CompositeCodec`
- Added `senderHmac` and `shouldPush` to `MessageV2`
- Added encryption methods for generating, importing, and exporting HMAC keys
- Added encryption methods for generating and verifying HMAC signatures
- Added `getV2ConversationHmacKeys` to `InMemoryKeystore` to retrieve conversation topics and their associated HMAC keys

A lot has changed since the `beta` branch was last touched. This PR incorporates the changes from the `beta` branch plus some fixes / conflict resolutions. Once this lands, I'll force-push `main` into the `beta` branch.