### PR TITLE
Use dependency versions with proper attestations

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "async-mutex": "^0.5.0",
     "elliptic": "^6.5.4",
     "long": "^5.2.3",
-    "viem": "^2.7.22"
+    "viem": "2.7.15"
   },
   "devDependencies": {
     "@commitlint/cli": "19.0.3",
@@ -122,7 +122,7 @@
     "@vitest/coverage-v8": "^1.3.1",
     "@xmtp/rollup-plugin-resolve-extensions": "1.0.1",
     "benny": "^3.7.1",
-    "dd-trace": "^5.6.0",
+    "dd-trace": "5.5.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",
@@ -143,7 +143,7 @@
     "semantic-release": "^21.1.2",
     "typedoc": "^0.25.12",
     "typescript": "^5.4.2",
-    "vite": "^5.1.6",
+    "vite": "5.1.4",
     "vitest": "^1.3.1"
   },
   "packageManager": "yarn@4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -342,13 +342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/native-appsec@npm:7.1.0":
-  version: 7.1.0
-  resolution: "@datadog/native-appsec@npm:7.1.0"
+"@datadog/native-appsec@npm:7.0.0":
+  version: 7.0.0
+  resolution: "@datadog/native-appsec@npm:7.0.0"
   dependencies:
     node-gyp: "npm:latest"
     node-gyp-build: "npm:^3.9.0"
-  checksum: 10/cef26ed47a5fa46055d8c5a337a03b5a24c61d9d05d8f1429108701889d3a39a0bb6f56cff2e6c9595fd1a14cfdf8be1ace76bf2176b2f814a566f465a5b8d3f
+  checksum: 10/ef72d89e9be686c4682e9e2b3cb89cf4ac1ce0130131b067a563a3687ae297740263b0640b3019b27fb6191c408e644f7e1376785b4e1bacf60e1897c433f63a
   languageName: node
   linkType: hard
 
@@ -383,9 +383,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/pprof@npm:5.1.0":
-  version: 5.1.0
-  resolution: "@datadog/pprof@npm:5.1.0"
+"@datadog/pprof@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@datadog/pprof@npm:5.0.0"
   dependencies:
     delay: "npm:^5.0.0"
     node-gyp: "npm:latest"
@@ -393,7 +393,7 @@ __metadata:
     p-limit: "npm:^3.1.0"
     pprof-format: "npm:^2.0.7"
     source-map: "npm:^0.7.4"
-  checksum: 10/e81a7ee80ca0c12573af520124481ebae7c2f37d4462ad0e34400c8369eb00d27857f6b936db26dfb743acffb75d043f45102db77c4ca3dd0067c733fe04a08e
+  checksum: 10/525d6d46375372f5d9786731b0167bb323e9a00eb6eaeb743dfddfdfc1601b5e17033fb824d9c255fc2901325973d756e27979f783f14f6809232d0f95cdc14b
   languageName: node
   linkType: hard
 
@@ -2689,7 +2689,7 @@ __metadata:
     "@xmtp/user-preferences-bindings-wasm": "npm:^0.3.6"
     async-mutex: "npm:^0.5.0"
     benny: "npm:^3.7.1"
-    dd-trace: "npm:^5.6.0"
+    dd-trace: "npm:5.5.0"
     elliptic: "npm:^6.5.4"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -2712,8 +2712,8 @@ __metadata:
     semantic-release: "npm:^21.1.2"
     typedoc: "npm:^0.25.12"
     typescript: "npm:^5.4.2"
-    viem: "npm:^2.7.22"
-    vite: "npm:^5.1.6"
+    viem: "npm:2.7.15"
+    vite: "npm:5.1.4"
     vitest: "npm:^1.3.1"
   languageName: unknown
   linkType: soft
@@ -3965,15 +3965,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dd-trace@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "dd-trace@npm:5.6.0"
+"dd-trace@npm:5.5.0":
+  version: 5.5.0
+  resolution: "dd-trace@npm:5.5.0"
   dependencies:
-    "@datadog/native-appsec": "npm:7.1.0"
+    "@datadog/native-appsec": "npm:7.0.0"
     "@datadog/native-iast-rewriter": "npm:2.2.3"
     "@datadog/native-iast-taint-tracking": "npm:1.7.0"
     "@datadog/native-metrics": "npm:^2.0.0"
-    "@datadog/pprof": "npm:5.1.0"
+    "@datadog/pprof": "npm:5.0.0"
     "@datadog/sketches-js": "npm:^2.1.0"
     "@opentelemetry/api": "npm:^1.0.0"
     "@opentelemetry/core": "npm:^1.14.0"
@@ -4001,7 +4001,7 @@ __metadata:
     semver: "npm:^7.5.4"
     shell-quote: "npm:^1.8.1"
     tlhunter-sorted-set: "npm:^0.1.0"
-  checksum: 10/f6e07effb9505d1564ed4ae60475d137794496fede556da33593309406e48de08c2bb1741949ee57ccdb0ba81873c2627039b8f58818bba372f850f1382bde72
+  checksum: 10/7d7b8842a3976aba8f0beda7a052af877af0a8536c17748766c143ac6008342950878c0cd2cfafea3c12e17ce2e78d8fa24a8ae4ab4beee65b602586bb085a85
   languageName: node
   linkType: hard
 
@@ -10381,9 +10381,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:^2.7.22":
-  version: 2.7.22
-  resolution: "viem@npm:2.7.22"
+"viem@npm:2.7.15":
+  version: 2.7.15
+  resolution: "viem@npm:2.7.15"
   dependencies:
     "@adraffy/ens-normalize": "npm:1.10.0"
     "@noble/curves": "npm:1.2.0"
@@ -10398,7 +10398,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10/2b4b8913ccf0a4b1ffc458581fd02ade73607158a36f736664860bd15c8a76cf437b8415adb554541f8f9260d8ffc227280d408a20460fc283875d50a11b30d6
+  checksum: 10/cf6923e8e042d626fc03e678757529dfa8e977d8079a744ffec88cdbdde7505bb9aadc73882ddf4c732eb6b380af478b13cc4363fdaa960d0ce2628da6941612
   languageName: node
   linkType: hard
 
@@ -10417,7 +10417,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
+"vite@npm:5.1.4, vite@npm:^5.0.0":
   version: 5.1.4
   resolution: "vite@npm:5.1.4"
   dependencies:
@@ -10454,46 +10454,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10/e9003b853f0784260f4fe7ce0190124b347fd8fd6bf889a07080facd0d9a9667eaff4022eddb1ba3f0283ef69d15d77f84bca832082e48874a7a62e7f6d66b08
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.1.6":
-  version: 5.1.6
-  resolution: "vite@npm:5.1.6"
-  dependencies:
-    esbuild: "npm:^0.19.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.35"
-    rollup: "npm:^4.2.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10/f48073e93ead62fa58034398442de4517c824b3e50184f8b4059fb24077a26f2c04e910e29d7fb7ec51ea53eb61b9c7d94d56b14a38851de80c67480094cc79d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

Some dependencies recently upgraded do not pass attestation checks. This PR downgrades to the latest versions that do.

This seems to be an [issue with NPM](https://github.com/npm/cli/issues/7279) and not the packages.