### PR TITLE
fix: HMAC keys correctly fetch address so that keys are correct

### DIFF
--- a/src/keystore/InMemoryKeystore.ts
+++ b/src/keystore/InMemoryKeystore.ts
@@ -311,7 +311,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
         const thirtyDayPeriodsSinceEpoch = Math.floor(
           Date.now() / 1000 / 60 / 60 / 24 / 30
         )
-        const info = `${thirtyDayPeriodsSinceEpoch}-${this.accountAddress}`
+        const info = `${thirtyDayPeriodsSinceEpoch}-${await this.getAccountAddress()}`
         const hmac = await generateHmacSignature(
           keyMaterial,
           new TextEncoder().encode(info),
@@ -631,7 +631,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
               thirtyDayPeriodsSinceEpoch,
               thirtyDayPeriodsSinceEpoch + 1,
             ].map(async (value) => {
-              const info = `${value}-${this.accountAddress}`
+              const info = `${value}-${await this.getAccountAddress()}`
               const hmacKey = await hkdfHmacKey(
                 keyMaterial,
                 new TextEncoder().encode(info)


### PR DESCRIPTION
Sometimes this method wouldn't have the address stored yet and then the keys would be null with null keys all hmac keys for all users would be the same. This makes sure the address is always present.