### PR TITLE
fix: update priority in newConversation method

### DIFF
--- a/.changeset/breezy-trains-fetch.md
+++ b/.changeset/breezy-trains-fetch.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp-js": patch
+---
+
+Updated priorities on newConversation method


### PR DESCRIPTION
Update to check the keystore for existing conversations before sending a query for v1 conversations
Reduces a small amount of network traffic, but for broadcasters this should be a bit more noticable reduction in overall network requests