### PR TITLE
Upgrade MLS node bindings, add features and tests

### DIFF
--- a/.changeset/weak-fans-cheer.md
+++ b/.changeset/weak-fans-cheer.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Upgrade MLS node bindings, add admin features and tests

--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -52,7 +52,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/mls-client-bindings-node": "^0.0.1",
+    "@xmtp/mls-client-bindings-node": "^0.0.3",
     "@xmtp/proto": "^3.61.1",
     "@xmtp/xmtp-js": "^11.6.2"
   },

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -2,6 +2,8 @@ import { join } from 'node:path'
 import process from 'node:process'
 import {
   createClient,
+  generateInboxId,
+  getInboxIdForAddress,
   NapiGroupMessageKind,
   type NapiClient,
   type NapiMessage,
@@ -91,11 +93,19 @@ export class Client {
     const dbPath =
       options?.dbPath ?? join(process.cwd(), `${accountAddress}.db3`)
 
+    const inboxId =
+      (await getInboxIdForAddress(
+        'http://localhost:5556',
+        false,
+        accountAddress
+      )) || generateInboxId(accountAddress)
+
     return new Client(
       await createClient(
         host,
         isSecure,
         dbPath,
+        inboxId,
         accountAddress,
         options?.encryptionKey
       ),

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -58,6 +58,22 @@ export class Conversation {
     return this.#group.listMembers()
   }
 
+  get admins() {
+    return this.#group.adminList()
+  }
+
+  get superAdmins() {
+    return this.#group.superAdminList()
+  }
+
+  isAdmin(inboxId: string) {
+    return this.#group.isAdmin(inboxId)
+  }
+
+  isSuperAdmin(inboxId: string) {
+    return this.#group.isSuperAdmin(inboxId)
+  }
+
   async sync() {
     return this.#group.sync()
   }
@@ -66,7 +82,6 @@ export class Conversation {
     const asyncStream = new AsyncStream<NapiMessage, DecodedMessage>(
       (message) => new DecodedMessage(this.#client, message)
     )
-    // @ts-expect-error type is incorrect in the bindings
     const stream = this.#group.stream(asyncStream.callback)
     asyncStream.stopCallback = stream.end.bind(stream)
     return asyncStream
@@ -86,6 +101,22 @@ export class Conversation {
 
   async removeMembersByInboxId(inboxIds: string[]) {
     return this.#group.removeMembersByInboxId(inboxIds)
+  }
+
+  async addAdmin(inboxId: string) {
+    return this.#group.addAdmin(inboxId)
+  }
+
+  async removeAdmin(inboxId: string) {
+    return this.#group.removeAdmin(inboxId)
+  }
+
+  async addSuperAdmin(inboxId: string) {
+    return this.#group.addSuperAdmin(inboxId)
+  }
+
+  async removeSuperAdmin(inboxId: string) {
+    return this.#group.removeSuperAdmin(inboxId)
   }
 
   async send(content: any, contentType: ContentTypeId) {

--- a/packages/mls-client/test/Conversation.test.ts
+++ b/packages/mls-client/test/Conversation.test.ts
@@ -158,4 +158,56 @@ describe('Conversation', () => {
     }
     stream.stop()
   })
+
+  it('should add and remove admins', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+    const conversation = await client1.conversations.newConversation([
+      user2.account.address,
+    ])
+
+    expect(conversation.isAdmin(client1.inboxId)).toBe(true)
+    expect(conversation.isAdmin(client2.inboxId)).toBe(false)
+    expect(conversation.admins.length).toBe(1)
+    expect(conversation.admins).toContain(client1.inboxId)
+
+    await conversation.addAdmin(client2.inboxId)
+    expect(conversation.isAdmin(client2.inboxId)).toBe(true)
+    expect(conversation.admins.length).toBe(2)
+    expect(conversation.admins).toContain(client1.inboxId)
+    expect(conversation.admins).toContain(client2.inboxId)
+
+    await conversation.removeAdmin(client2.inboxId)
+    expect(conversation.isAdmin(client2.inboxId)).toBe(false)
+    expect(conversation.admins.length).toBe(1)
+    expect(conversation.admins).toContain(client1.inboxId)
+  })
+
+  it('should add and remove super admins', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+    const conversation = await client1.conversations.newConversation([
+      user2.account.address,
+    ])
+
+    expect(conversation.isSuperAdmin(client1.inboxId)).toBe(true)
+    expect(conversation.isSuperAdmin(client2.inboxId)).toBe(false)
+    expect(conversation.superAdmins.length).toBe(1)
+    expect(conversation.superAdmins).toContain(client1.inboxId)
+
+    await conversation.addSuperAdmin(client2.inboxId)
+    expect(conversation.isSuperAdmin(client2.inboxId)).toBe(true)
+    expect(conversation.superAdmins.length).toBe(2)
+    expect(conversation.superAdmins).toContain(client1.inboxId)
+    expect(conversation.superAdmins).toContain(client2.inboxId)
+
+    await conversation.removeSuperAdmin(client2.inboxId)
+    expect(conversation.isSuperAdmin(client2.inboxId)).toBe(false)
+    expect(conversation.superAdmins.length).toBe(1)
+    expect(conversation.superAdmins).toContain(client1.inboxId)
+  })
 })

--- a/packages/mls-client/test/Conversations.test.ts
+++ b/packages/mls-client/test/Conversations.test.ts
@@ -22,7 +22,7 @@ describe('Conversations', () => {
     expect(conversation.createdAt).toBeDefined()
     expect(conversation.createdAtNs).toBeDefined()
     expect(conversation.isActive).toBe(true)
-    expect(conversation.name).toBe('New Group')
+    expect(conversation.name).toBe('')
     expect(conversation.addedByInboxId).toBe(client1.inboxId)
     expect(conversation.messages().length).toBe(1)
     expect(conversation.members.length).toBe(2)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,10 +2863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/mls-client-bindings-node@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.1"
-  checksum: 10/bf6f5fcdbf80dade51cdf94db3218b4bb31b659ac1480cdead165cae78e0882d35732a6e5fa3a2d45419eaab63fcf482034720bcd80bb6acc1b9069addf4fabd
+"@xmtp/mls-client-bindings-node@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.3"
+  checksum: 10/3e1d578e462965d992b23020c69619231af5022b2f015ec67187f0fabb2b657ace68f013df65ed057b2716801099aa6f7679cd86818b90168de7ef51abb72be1
   languageName: node
   linkType: hard
 
@@ -2881,7 +2881,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.8.0"
     "@typescript-eslint/parser": "npm:^7.8.0"
     "@vitest/coverage-v8": "npm:^1.6.0"
-    "@xmtp/mls-client-bindings-node": "npm:^0.0.1"
+    "@xmtp/mls-client-bindings-node": "npm:^0.0.3"
     "@xmtp/proto": "npm:^3.61.1"
     "@xmtp/xmtp-js": "npm:^11.6.2"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION
# Summary

* Upgraded `@xmtp/mls-client-bindings-node`
* Refactored `Client.create` to pass in inbox ID
* Added admin functions to `Conversation`
* Added tests