### PR TITLE
Add conversation reference to messages

### DIFF
--- a/.changeset/rude-avocados-flow.md
+++ b/.changeset/rude-avocados-flow.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Add conversation reference to messages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -80,7 +80,7 @@ export class Conversation {
 
   stream() {
     const asyncStream = new AsyncStream<NapiMessage, DecodedMessage>(
-      (message) => new DecodedMessage(this.#client, message)
+      (message) => new DecodedMessage(this.#client, this, message)
     )
     const stream = this.#group.stream(asyncStream.callback)
     asyncStream.stopCallback = stream.end.bind(stream)
@@ -126,6 +126,6 @@ export class Conversation {
   messages(options?: NapiListMessagesOptions): DecodedMessage[] {
     return this.#group
       .findMessages(options)
-      .map((message) => new DecodedMessage(this.#client, message))
+      .map((message) => new DecodedMessage(this.#client, this, message))
   }
 }

--- a/packages/mls-client/src/DecodedMessage.ts
+++ b/packages/mls-client/src/DecodedMessage.ts
@@ -5,6 +5,7 @@ import {
 } from '@xmtp/mls-client-bindings-node'
 import { ContentTypeId } from '@xmtp/xmtp-js'
 import type { Client } from '@/Client'
+import type { Conversation } from '@/Conversation'
 import { nsToDate } from '@/helpers/date'
 
 export type MessageKind = 'application' | 'membership_change'
@@ -14,6 +15,7 @@ export class DecodedMessage {
   #client: Client
   content: any
   contentType: ContentTypeId
+  conversation: Conversation
   conversationId: string
   deliveryStatus: MessageDeliveryStatus
   fallback?: string
@@ -25,8 +27,13 @@ export class DecodedMessage {
   sentAt: Date
   sentAtNs: number
 
-  constructor(client: Client, message: NapiMessage) {
+  constructor(
+    client: Client,
+    conversation: Conversation,
+    message: NapiMessage
+  ) {
     this.#client = client
+    this.conversation = conversation
     this.id = message.id
     this.sentAtNs = message.sentAtNs
     this.sentAt = nsToDate(message.sentAtNs)


### PR DESCRIPTION
# Summary

When creating new instances of `DecodedMessage`, pass in a reference to the conversation it's a part of. This will be useful for BotKit.

Also, maybe fix the release workflow which has issues with triggering subsequent workflows when PRs are created by `github-bot`.