### PR TITLE
Ensure correct inbox ID for all environments

### DIFF
--- a/.changeset/brown-ties-film.md
+++ b/.changeset/brown-ties-film.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Ensure correct inbox ID for all environments

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -94,11 +94,8 @@ export class Client {
       options?.dbPath ?? join(process.cwd(), `${accountAddress}.db3`)
 
     const inboxId =
-      (await getInboxIdForAddress(
-        'http://localhost:5556',
-        false,
-        accountAddress
-      )) || generateInboxId(accountAddress)
+      (await getInboxIdForAddress(host, isSecure, accountAddress)) ||
+      generateInboxId(accountAddress)
 
     return new Client(
       await createClient(


### PR DESCRIPTION
# Summary

The inbox ID was being incorrectly calculated for the `dev` environment because hardcoded values were being used for the `host` and `isSecure` parameters.