### PR TITLE
Add streamAllMessages to Conversations

### DIFF
--- a/.changeset/hip-plums-run.md
+++ b/.changeset/hip-plums-run.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Add streamAllMessages to Conversations

--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -52,7 +52,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@xmtp/mls-client-bindings-node": "^0.0.3",
+    "@xmtp/mls-client-bindings-node": "^0.0.4",
     "@xmtp/proto": "^3.61.1",
     "@xmtp/xmtp-js": "^11.6.2"
   },

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -80,7 +80,7 @@ export class Conversation {
 
   stream() {
     const asyncStream = new AsyncStream<NapiMessage, DecodedMessage>(
-      (message) => new DecodedMessage(this.#client, this, message)
+      (message) => new DecodedMessage(this.#client, message)
     )
     const stream = this.#group.stream(asyncStream.callback)
     asyncStream.stopCallback = stream.end.bind(stream)
@@ -126,6 +126,6 @@ export class Conversation {
   messages(options?: NapiListMessagesOptions): DecodedMessage[] {
     return this.#group
       .findMessages(options)
-      .map((message) => new DecodedMessage(this.#client, this, message))
+      .map((message) => new DecodedMessage(this.#client, message))
   }
 }

--- a/packages/mls-client/src/DecodedMessage.ts
+++ b/packages/mls-client/src/DecodedMessage.ts
@@ -5,7 +5,6 @@ import {
 } from '@xmtp/mls-client-bindings-node'
 import { ContentTypeId } from '@xmtp/xmtp-js'
 import type { Client } from '@/Client'
-import type { Conversation } from '@/Conversation'
 import { nsToDate } from '@/helpers/date'
 
 export type MessageKind = 'application' | 'membership_change'
@@ -15,7 +14,6 @@ export class DecodedMessage {
   #client: Client
   content: any
   contentType: ContentTypeId
-  conversation: Conversation
   conversationId: string
   deliveryStatus: MessageDeliveryStatus
   fallback?: string
@@ -27,13 +25,8 @@ export class DecodedMessage {
   sentAt: Date
   sentAtNs: number
 
-  constructor(
-    client: Client,
-    conversation: Conversation,
-    message: NapiMessage
-  ) {
+  constructor(client: Client, message: NapiMessage) {
     this.#client = client
-    this.conversation = conversation
     this.id = message.id
     this.sentAtNs = message.sentAtNs
     this.sentAt = nsToDate(message.sentAtNs)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,10 +2863,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/mls-client-bindings-node@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.3"
-  checksum: 10/3e1d578e462965d992b23020c69619231af5022b2f015ec67187f0fabb2b657ace68f013df65ed057b2716801099aa6f7679cd86818b90168de7ef51abb72be1
+"@xmtp/mls-client-bindings-node@npm:^0.0.4":
+  version: 0.0.4
+  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.4"
+  checksum: 10/508839e57a7126f8f2d9898c62c117cd2626279c244b57c2a257bb7681755e19bde985df4a666c61b665b7bb23b9aa8d784527c601797845271c1cf61af26808
   languageName: node
   linkType: hard
 
@@ -2881,7 +2881,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.8.0"
     "@typescript-eslint/parser": "npm:^7.8.0"
     "@vitest/coverage-v8": "npm:^1.6.0"
-    "@xmtp/mls-client-bindings-node": "npm:^0.0.3"
+    "@xmtp/mls-client-bindings-node": "npm:^0.0.4"
     "@xmtp/proto": "npm:^3.61.1"
     "@xmtp/xmtp-js": "npm:^11.6.2"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION
# Summary

* Upgraded to latest node bindings
* Added `streamAllMessages` to `Conversations` class
* Added tests for `streamAllMessages`
* Removed reference to `Conversation` instance in `DecodedMessage`

### Notes

The `Conversation` reference was removed from `DecodedMessage` because it would add too much overhead to retrieve it when streaming all messages as getting access to the underlying `NapiGroup` would requiring syncing with the network and then iterating over the group list to find it.