### PR TITLE
Add streaming callbacks

### DIFF
--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -52,9 +52,9 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@xmtp/content-type-primitives": "^1.0.1",
     "@xmtp/mls-client-bindings-node": "^0.0.4",
-    "@xmtp/proto": "^3.61.1",
-    "@xmtp/xmtp-js": "^11.6.2"
+    "@xmtp/proto": "^3.61.1"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",

--- a/packages/mls-client/src/codecs/GroupUpdatedCodec.ts
+++ b/packages/mls-client/src/codecs/GroupUpdatedCodec.ts
@@ -1,9 +1,9 @@
-import { mlsTranscriptMessages } from '@xmtp/proto'
 import {
   ContentTypeId,
   type ContentCodec,
   type EncodedContent,
-} from '@xmtp/xmtp-js'
+} from '@xmtp/content-type-primitives'
+import { mlsTranscriptMessages } from '@xmtp/proto'
 
 export const ContentTypeGroupUpdated = new ContentTypeId({
   authorityId: 'xmtp.org',

--- a/packages/mls-client/src/index.ts
+++ b/packages/mls-client/src/index.ts
@@ -13,3 +13,4 @@ export {
   ContentTypeGroupUpdated,
   GroupUpdatedCodec,
 } from './codecs/GroupUpdatedCodec'
+export type { StreamCallback } from './AsyncStream'

--- a/packages/mls-client/test/Conversations.test.ts
+++ b/packages/mls-client/test/Conversations.test.ts
@@ -19,6 +19,7 @@ describe('Conversations', () => {
       user2.account.address,
     ])
     expect(conversation).toBeDefined()
+    expect(client1.conversations.get(conversation.id)?.id).toBe(conversation.id)
     expect(conversation.id).toBeDefined()
     expect(conversation.createdAt).toBeDefined()
     expect(conversation.createdAtNs).toBeDefined()
@@ -75,6 +76,12 @@ describe('Conversations', () => {
       }
     }
     stream.stop()
+    expect(client3.conversations.get(conversation1.id)?.id).toBe(
+      conversation1.id
+    )
+    expect(client3.conversations.get(conversation2.id)?.id).toBe(
+      conversation2.id
+    )
   })
 
   it('should stream all messages', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,6 +2863,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/content-type-primitives@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@xmtp/content-type-primitives@npm:1.0.1"
+  dependencies:
+    "@xmtp/proto": "npm:^3.61.1"
+  checksum: 10/656826cda74328e3079c7f5937eeb694260bd68a66090303fdf6abf4c54c8bbf924064eb6895b9e66addee1269779dfe1c3f0e836fcd8857f784c5645c7b7bf5
+  languageName: node
+  linkType: hard
+
 "@xmtp/mls-client-bindings-node@npm:^0.0.4":
   version: 0.0.4
   resolution: "@xmtp/mls-client-bindings-node@npm:0.0.4"
@@ -2881,9 +2890,9 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^7.8.0"
     "@typescript-eslint/parser": "npm:^7.8.0"
     "@vitest/coverage-v8": "npm:^1.6.0"
+    "@xmtp/content-type-primitives": "npm:^1.0.1"
     "@xmtp/mls-client-bindings-node": "npm:^0.0.4"
     "@xmtp/proto": "npm:^3.61.1"
-    "@xmtp/xmtp-js": "npm:^11.6.2"
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-config-standard: "npm:^17.1.0"
@@ -2963,7 +2972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/xmtp-js@npm:^11.6.2, @xmtp/xmtp-js@workspace:packages/js-sdk":
+"@xmtp/xmtp-js@workspace:packages/js-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/xmtp-js@workspace:packages/js-sdk"
   dependencies:


### PR DESCRIPTION
# Summary

* Simplified `AsyncStream` types, removed value transformer
* Added `isDone` getter to `AsyncStream`
* Added optional callback parameter to all streaming functions for more flexibility in handling streams
* Added stream data transforms before calling stream callback
* Added conversations map and `get` function to `Conversations` to allow for quick access to conversations that are created, listed, or streamed during a client session
* Replaced usage of `@xmtp/xmtp-js` in favor of `@xmtp/content-type-primitives`