### PR TITLE
Add production environment, update content types

### DIFF
--- a/.changeset/mean-emus-wait.md
+++ b/.changeset/mean-emus-wait.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Add production environment

--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-primitives": "^1.0.1",
+    "@xmtp/content-type-text": "^1.0.0",
     "@xmtp/mls-client-bindings-node": "^0.0.4",
     "@xmtp/proto": "^3.61.1"
   },

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -1,5 +1,11 @@
 import { join } from 'node:path'
 import process from 'node:process'
+import type {
+  ContentCodec,
+  ContentTypeId,
+  EncodedContent,
+} from '@xmtp/content-type-primitives'
+import { TextCodec } from '@xmtp/content-type-text'
 import {
   createClient,
   generateInboxId,
@@ -8,12 +14,6 @@ import {
   type NapiClient,
   type NapiMessage,
 } from '@xmtp/mls-client-bindings-node'
-import {
-  TextCodec,
-  type ContentCodec,
-  type ContentTypeId,
-  type EncodedContent,
-} from '@xmtp/xmtp-js'
 import {
   ContentTypeGroupUpdated,
   GroupUpdatedCodec,

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -23,6 +23,7 @@ import { Conversations } from '@/Conversations'
 export const ApiUrls = {
   local: 'http://localhost:5556',
   dev: 'https://grpc.dev.xmtp.network:443',
+  production: 'https://grpc.production.xmtp.network:443',
 } as const
 
 export type XmtpEnv = keyof typeof ApiUrls

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -1,8 +1,8 @@
+import type { ContentTypeId } from '@xmtp/content-type-primitives'
 import type {
   NapiGroup,
   NapiListMessagesOptions,
 } from '@xmtp/mls-client-bindings-node'
-import type { ContentTypeId } from '@xmtp/xmtp-js'
 import { AsyncStream, type StreamCallback } from '@/AsyncStream'
 import type { Client } from '@/Client'
 import { DecodedMessage } from '@/DecodedMessage'

--- a/packages/mls-client/src/DecodedMessage.ts
+++ b/packages/mls-client/src/DecodedMessage.ts
@@ -1,9 +1,9 @@
+import { ContentTypeId } from '@xmtp/content-type-primitives'
 import {
   NapiDeliveryStatus,
   NapiGroupMessageKind,
   type NapiMessage,
 } from '@xmtp/mls-client-bindings-node'
-import { ContentTypeId } from '@xmtp/xmtp-js'
 import type { Client } from '@/Client'
 import { nsToDate } from '@/helpers/date'
 

--- a/packages/mls-client/test/Conversation.test.ts
+++ b/packages/mls-client/test/Conversation.test.ts
@@ -1,4 +1,4 @@
-import { ContentTypeText } from '@xmtp/xmtp-js'
+import { ContentTypeText } from '@xmtp/content-type-text'
 import { describe, expect, it } from 'vitest'
 import { createRegisteredClient, createUser } from '@test/helpers'
 

--- a/packages/mls-client/test/Conversations.test.ts
+++ b/packages/mls-client/test/Conversations.test.ts
@@ -1,4 +1,4 @@
-import { ContentTypeText } from '@xmtp/xmtp-js'
+import { ContentTypeText } from '@xmtp/content-type-text'
 import { describe, expect, it } from 'vitest'
 import { createRegisteredClient, createUser } from '@test/helpers'
 

--- a/packages/mls-client/test/helpers.ts
+++ b/packages/mls-client/test/helpers.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { createWalletClient, http, toBytes } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { sepolia } from 'viem/chains'
-import { Client } from '@/Client'
+import { Client, type XmtpEnv } from '@/Client'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -33,14 +33,14 @@ export const getSignature = async (client: Client, user: User) => {
   return null
 }
 
-export const createClient = async (user: User) =>
+export const createClient = async (user: User, env?: XmtpEnv) =>
   Client.create(user.account.address, {
-    env: 'local',
+    env: env ?? 'local',
     dbPath: join(__dirname, `./test-${user.account.address}.db3`),
   })
 
-export const createRegisteredClient = async (user: User) => {
-  const client = await createClient(user)
+export const createRegisteredClient = async (user: User, env?: XmtpEnv) => {
+  const client = await createClient(user, env)
   if (!client.isRegistered) {
     const signature = await getSignature(client, user)
     if (signature) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,6 +2872,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/content-type-text@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@xmtp/content-type-text@npm:1.0.0"
+  dependencies:
+    "@xmtp/content-type-primitives": "npm:^1.0.1"
+  checksum: 10/b195060ad5686a6ace2772d5208d535d1f5062820629764aec52cedf3f2630885b5913aea6d2f0186a49139845c20d2ded783c6bf998884f09374c07b183141f
+  languageName: node
+  linkType: hard
+
 "@xmtp/mls-client-bindings-node@npm:^0.0.4":
   version: 0.0.4
   resolution: "@xmtp/mls-client-bindings-node@npm:0.0.4"
@@ -2891,6 +2900,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^7.8.0"
     "@vitest/coverage-v8": "npm:^1.6.0"
     "@xmtp/content-type-primitives": "npm:^1.0.1"
+    "@xmtp/content-type-text": "npm:^1.0.0"
     "@xmtp/mls-client-bindings-node": "npm:^0.0.4"
     "@xmtp/proto": "npm:^3.61.1"
     "@xmtp/xmtp-js": "workspace:^"


### PR DESCRIPTION
# Summary

* Added `production` environment option when creating a client
* Removed dependency on `@xmtp/xmtp-js` for content types