### PR TITLE
Upgrade to latest node bindings

### DIFF
--- a/.changeset/shaggy-buckets-fetch.md
+++ b/.changeset/shaggy-buckets-fetch.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/mls-client": patch
+---
+
+Upgrade to latest node bindings

--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@xmtp/content-type-primitives": "^1.0.1",
     "@xmtp/content-type-text": "^1.0.0",
-    "@xmtp/mls-client-bindings-node": "^0.0.4",
+    "@xmtp/mls-client-bindings-node": "^0.0.5",
     "@xmtp/proto": "^3.61.1"
   },
   "devDependencies": {

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -139,14 +139,14 @@ export class Client {
     this.#innerClient.addEcdsaSignature(signatureBytes)
   }
 
-  addErc1271Signature(
+  addScwSignature(
     signatureBytes: Uint8Array,
     chainId: string,
     accountAddress: string,
     chainRpcUrl: string,
     blockNumber: bigint
   ) {
-    this.#innerClient.addErc1271Signature(
+    this.#innerClient.addScwSignature(
       signatureBytes,
       chainId,
       accountAddress,

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -73,6 +73,12 @@ export class Conversation {
     return this.#group.superAdminList()
   }
 
+  get permissions() {
+    return {
+      policyType: this.#group.groupPermissions().policyType(),
+    }
+  }
+
   isAdmin(inboxId: string) {
     return this.#group.isAdmin(inboxId)
   }

--- a/packages/mls-client/src/Conversation.ts
+++ b/packages/mls-client/src/Conversation.ts
@@ -29,6 +29,14 @@ export class Conversation {
     return this.#group.updateGroupName(name)
   }
 
+  get imageUrl() {
+    return this.#group.groupImageUrlSquare()
+  }
+
+  async updateImageUrl(imageUrl: string) {
+    return this.#group.updateGroupImageUrlSquare(imageUrl)
+  }
+
   get isActive() {
     return this.#group.isActive()
   }

--- a/packages/mls-client/src/Conversations.ts
+++ b/packages/mls-client/src/Conversations.ts
@@ -1,6 +1,6 @@
 import type {
-  GroupPermissions,
   NapiConversations,
+  NapiCreateGroupOptions,
   NapiListMessagesOptions,
 } from '@xmtp/mls-client-bindings-node'
 import { AsyncStream, type StreamCallback } from '@/AsyncStream'
@@ -25,11 +25,11 @@ export class Conversations {
 
   async newConversation(
     accountAddresses: string[],
-    permissions?: GroupPermissions
+    options?: NapiCreateGroupOptions
   ) {
     const group = await this.#conversations.createGroup(
       accountAddresses,
-      permissions
+      options
     )
     const conversation = new Conversation(this.#client, group)
     this.#map.set(conversation.id, conversation)

--- a/packages/mls-client/src/index.ts
+++ b/packages/mls-client/src/index.ts
@@ -14,3 +14,4 @@ export {
   GroupUpdatedCodec,
 } from './codecs/GroupUpdatedCodec'
 export type { StreamCallback } from './AsyncStream'
+export { GroupPermissions } from '@xmtp/mls-client-bindings-node'

--- a/packages/mls-client/test/Conversation.test.ts
+++ b/packages/mls-client/test/Conversation.test.ts
@@ -29,6 +29,32 @@ describe('Conversation', () => {
     expect(conversation2.messages().length).toBe(1)
   })
 
+  it('should update conversation image URL', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    const client2 = await createRegisteredClient(user2)
+    const conversation = await client1.conversations.newConversation([
+      user2.account.address,
+    ])
+    const imageUrl = 'https://foo/bar.jpg'
+    await conversation.updateImageUrl(imageUrl)
+    expect(conversation.imageUrl).toBe(imageUrl)
+    const messages = conversation.messages()
+    expect(messages.length).toBe(2)
+
+    await client2.conversations.sync()
+    const conversations = await client2.conversations.list()
+    expect(conversations.length).toBe(1)
+
+    const conversation2 = conversations[0]
+    expect(conversation2).toBeDefined()
+    await conversation2.sync()
+    expect(conversation2.id).toBe(conversation.id)
+    expect(conversation2.imageUrl).toBe(imageUrl)
+    expect(conversation2.messages().length).toBe(1)
+  })
+
   it('should add and remove members', async () => {
     const user1 = createUser()
     const user2 = createUser()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/mls-client-bindings-node@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.4"
-  checksum: 10/508839e57a7126f8f2d9898c62c117cd2626279c244b57c2a257bb7681755e19bde985df4a666c61b665b7bb23b9aa8d784527c601797845271c1cf61af26808
+"@xmtp/mls-client-bindings-node@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.5"
+  checksum: 10/b00582aec3e328106dc8fb95ef2e637d591c91ef7b9b4c8e1f84d8f5323794f3b36ccd96ded5f65390a37ea40203582b6cdb379d60f6d59fa3128c37661110d7
   languageName: node
   linkType: hard
 
@@ -2901,7 +2901,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^1.6.0"
     "@xmtp/content-type-primitives": "npm:^1.0.1"
     "@xmtp/content-type-text": "npm:^1.0.0"
-    "@xmtp/mls-client-bindings-node": "npm:^0.0.4"
+    "@xmtp/mls-client-bindings-node": "npm:^0.0.5"
     "@xmtp/proto": "npm:^3.61.1"
     "@xmtp/xmtp-js": "workspace:^"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION
# Summary

* Renamed `addErc1271Signature` to `addScwSignature`
* Added more options when creating a group with `client.conversations.newConversation`
* Added getter and setter for group image URL
* Added getter for group permissions
* Added more tests
* Added `GroupPermissions` to exports