### PR TITLE
Make sure workflow step names are consistent

### DIFF
--- a/.github/workflows/js-sdk.yml
+++ b/.github/workflows/js-sdk.yml
@@ -75,8 +75,8 @@ jobs:
           cd packages/js-sdk
           yarn format:check
 
-  node:
-    name: Test node
+  test:
+    name: Test
     # TODO: Investigate why fetch is failing for some of these tests on warp build runners
     runs-on: ubuntu-latest
     steps:
@@ -101,24 +101,6 @@ jobs:
           DD_SERVICE: xmtp-js
           DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-
-  browser:
-    name: Test browser
-    # TODO: Investigate why fetch is failing for some of these tests on warp build runners
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-        env:
-          SKIP_YARN_COREPACK_CHECK: '1'
-      - name: Enable corepack
-        run: corepack enable
-      - name: Install dependencies
-        run: yarn
-      - run: ./dev/up
       - run: |
           cd packages/js-sdk
           yarn test:browser

--- a/.github/workflows/mls-client.yml
+++ b/.github/workflows/mls-client.yml
@@ -75,6 +75,12 @@ jobs:
           cd packages/mls-client
           yarn format:check
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No tests for MLS Client yet."
+
   build:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x


### PR DESCRIPTION
# Summary

* Added noop `Test` step for MLS Client
* Updated `Test` step for JS SDK to run both node and browser environments

If the `Test` step is required, it _must_ be run. [This is a limitation when using path filtering](https://github.com/orgs/community/discussions/13690). [Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) are supposed to help, but they don't seem to support this quite yet.

We could potentially explore something like [Policy Bot](https://github.com/palantir/policy-bot) until GitHub sorts this out.