### PR TITLE
Upgraded MLS bindings, added getters

### DIFF
--- a/.changeset/rare-pants-promise.md
+++ b/.changeset/rare-pants-promise.md
@@ -1,0 +1,8 @@
+---
+"@xmtp/mls-client": patch
+---
+
+- Upgraded to latest MLS node bindings
+- Added `requestHistorySync` and `getInboxIdByAddress` to `Client`
+- Renamed `get` to `getConversationById` in `Conversations`
+- Added `getMessageById` to `Conversations`

--- a/packages/mls-client/package.json
+++ b/packages/mls-client/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@xmtp/content-type-primitives": "^1.0.1",
     "@xmtp/content-type-text": "^1.0.0",
-    "@xmtp/mls-client-bindings-node": "^0.0.6",
+    "@xmtp/mls-client-bindings-node": "^0.0.7",
     "@xmtp/proto": "^3.61.1"
   },
   "devDependencies": {

--- a/packages/mls-client/src/Client.ts
+++ b/packages/mls-client/src/Client.ts
@@ -196,4 +196,12 @@ export class Client {
 
     return codec.decode(message.content as EncodedContent, this)
   }
+
+  async requestHistorySync() {
+    return this.#innerClient.requestHistorySync()
+  }
+
+  async getInboxIdByAddress(accountAddress: string) {
+    return this.#innerClient.findInboxIdByAddress(accountAddress)
+  }
 }

--- a/packages/mls-client/src/Conversations.ts
+++ b/packages/mls-client/src/Conversations.ts
@@ -11,16 +11,30 @@ import { DecodedMessage } from '@/DecodedMessage'
 export class Conversations {
   #client: Client
   #conversations: NapiConversations
-  #map: Map<string, Conversation>
 
   constructor(client: Client, conversations: NapiConversations) {
     this.#client = client
     this.#conversations = conversations
-    this.#map = new Map()
   }
 
-  get(id: string) {
-    return this.#map.get(id)
+  getConversationById(id: string) {
+    try {
+      // findGroupById will throw if group is not found
+      const group = this.#conversations.findGroupById(id)
+      return new Conversation(this.#client, group)
+    } catch {
+      return null
+    }
+  }
+
+  getMessageById(id: string) {
+    try {
+      // findMessageById will throw if message is not found
+      const message = this.#conversations.findMessageById(id)
+      return new DecodedMessage(this.#client, message)
+    } catch {
+      return null
+    }
   }
 
   async newConversation(
@@ -32,7 +46,6 @@ export class Conversations {
       options
     )
     const conversation = new Conversation(this.#client, group)
-    this.#map.set(conversation.id, conversation)
     return conversation
   }
 
@@ -40,7 +53,6 @@ export class Conversations {
     const groups = await this.#conversations.list(options)
     return groups.map((group) => {
       const conversation = new Conversation(this.#client, group)
-      this.#map.set(conversation.id, conversation)
       return conversation
     })
   }
@@ -54,7 +66,6 @@ export class Conversations {
 
     const stream = this.#conversations.stream((err, group) => {
       const conversation = new Conversation(this.#client, group)
-      this.#map.set(conversation.id, conversation)
       asyncStream.callback(err, conversation)
       callback?.(err, conversation)
     })

--- a/packages/mls-client/test/Client.test.ts
+++ b/packages/mls-client/test/Client.test.ts
@@ -22,4 +22,11 @@ describe('Client', () => {
       [user.account.address.toLowerCase()]: true,
     })
   })
+
+  it('should get an inbox ID from an address', async () => {
+    const user = createUser()
+    const client = await createRegisteredClient(user)
+    const inboxId = await client.getInboxIdByAddress(user.account.address)
+    expect(inboxId).toBe(client.inboxId)
+  })
 })

--- a/packages/mls-client/test/Conversations.test.ts
+++ b/packages/mls-client/test/Conversations.test.ts
@@ -20,7 +20,9 @@ describe('Conversations', () => {
       user2.account.address,
     ])
     expect(conversation).toBeDefined()
-    expect(client1.conversations.get(conversation.id)?.id).toBe(conversation.id)
+    expect(client1.conversations.getConversationById(conversation.id)?.id).toBe(
+      conversation.id
+    )
     expect(conversation.id).toBeDefined()
     expect(conversation.createdAt).toBeDefined()
     expect(conversation.createdAtNs).toBeDefined()
@@ -51,6 +53,37 @@ describe('Conversations', () => {
     const conversations2 = await client2.conversations.list()
     expect(conversations2.length).toBe(1)
     expect(conversations2[0].id).toBe(conversation.id)
+  })
+
+  it('should get a group by ID', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    await createRegisteredClient(user2)
+    const group = await client1.conversations.newConversation([
+      user2.account.address,
+    ])
+    expect(group).toBeDefined()
+    expect(group.id).toBeDefined()
+    const foundGroup = client1.conversations.getConversationById(group.id)
+    expect(foundGroup).toBeDefined()
+    expect(foundGroup!.id).toBe(group.id)
+  })
+
+  it('should get a message by ID', async () => {
+    const user1 = createUser()
+    const user2 = createUser()
+    const client1 = await createRegisteredClient(user1)
+    await createRegisteredClient(user2)
+    const group = await client1.conversations.newConversation([
+      user2.account.address,
+    ])
+    const messageId = await group.send('gm!', ContentTypeText)
+    expect(messageId).toBeDefined()
+
+    const message = client1.conversations.getMessageById(messageId)
+    expect(message).toBeDefined()
+    expect(message!.id).toBe(messageId)
   })
 
   it('should create a new conversation with options', async () => {
@@ -134,12 +167,12 @@ describe('Conversations', () => {
       }
     }
     stream.stop()
-    expect(client3.conversations.get(conversation1.id)?.id).toBe(
-      conversation1.id
-    )
-    expect(client3.conversations.get(conversation2.id)?.id).toBe(
-      conversation2.id
-    )
+    expect(
+      client3.conversations.getConversationById(conversation1.id)?.id
+    ).toBe(conversation1.id)
+    expect(
+      client3.conversations.getConversationById(conversation2.id)?.id
+    ).toBe(conversation2.id)
   })
 
   it('should stream all messages', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,10 +2881,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/mls-client-bindings-node@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.6"
-  checksum: 10/8c7c555e518d497c90be553f60e7c0d01225dfa9250df20383cb92d2079a75ab30892b0e0ffd37c3e593e0215f9abf34fedccabf6cc10ffa6a9eb7723130e109
+"@xmtp/mls-client-bindings-node@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@xmtp/mls-client-bindings-node@npm:0.0.7"
+  checksum: 10/5730868ebac704b967cb0763affc38e2116db69568307d97d77eaf1301718a39c308be9b9aa5f3a2550123e0df8e9ff351a06d9f4bedcd4d4723e5764dfec786
   languageName: node
   linkType: hard
 
@@ -2901,7 +2901,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^1.6.0"
     "@xmtp/content-type-primitives": "npm:^1.0.1"
     "@xmtp/content-type-text": "npm:^1.0.0"
-    "@xmtp/mls-client-bindings-node": "npm:^0.0.6"
+    "@xmtp/mls-client-bindings-node": "npm:^0.0.7"
     "@xmtp/proto": "npm:^3.61.1"
     "@xmtp/xmtp-js": "workspace:^"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION
# Summary

* Upgraded to latest MLS node bindings
* Added `requestHistorySync` and `getInboxIdByAddress` to `Client`
* Renamed `get` to `getConversationById` in `Conversations`
* Added `getMessageById` to `Conversations`
* Removed internal group referencing
* Added/updated tests