### PR TITLE
Persist private preferences to keystore

### DIFF
--- a/.changeset/witty-olives-hunt.md
+++ b/.changeset/witty-olives-hunt.md
@@ -1,5 +1,5 @@
 ---
-"@xmtp/xmtp-js": minor
+"@xmtp/xmtp-js": major
 ---
 
 Persist private preferences to keystore

--- a/.changeset/witty-olives-hunt.md
+++ b/.changeset/witty-olives-hunt.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp-js": minor
+---
+
+Persist private preferences to keystore

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -101,7 +101,7 @@
     "@xmtp/consent-proof-signature": "^0.1.3",
     "@xmtp/content-type-primitives": "^1.0.1",
     "@xmtp/content-type-text": "^1.0.0",
-    "@xmtp/proto": "^3.62.1",
+    "@xmtp/proto": "^3.68.0",
     "@xmtp/user-preferences-bindings-wasm": "^0.3.6",
     "async-mutex": "^0.5.0",
     "elliptic": "^6.5.7",

--- a/packages/js-sdk/src/Contacts.ts
+++ b/packages/js-sdk/src/Contacts.ts
@@ -1,11 +1,12 @@
 import { createConsentMessage } from '@xmtp/consent-proof-signature'
-import { privatePreferences, type invitation } from '@xmtp/proto'
+import { messageApi, privatePreferences, type invitation } from '@xmtp/proto'
+// eslint-disable-next-line camelcase
+import type { DecryptResponse_Response } from '@xmtp/proto/ts/dist/types/keystore_api/v1/keystore.pb'
 import { hashMessage, hexToBytes } from 'viem'
 import { ecdsaSignerKey } from '@/crypto/Signature'
 import { splitSignature } from '@/crypto/utils'
+import type { ActionsMap } from '@/keystore/privatePreferencesStore'
 import type { EnvelopeWithMessage } from '@/utils/async'
-import { fromNanoString } from '@/utils/date'
-import { buildUserPrivatePreferencesTopic } from '@/utils/topic'
 import type { OnConnectionLostCallback } from './ApiClient'
 import type Client from './Client'
 import JobRunner from './conversations/JobRunner'
@@ -70,8 +71,6 @@ export class ConsentListEntry {
 export class ConsentList {
   client: Client
   entries: Map<string, ConsentState>
-  lastEntryTimestamp?: Date
-  #identifier: string | undefined
 
   constructor(client: Client) {
     this.entries = new Map<string, ConsentState>()
@@ -129,40 +128,58 @@ export class ConsentList {
     return this.entries.get(entry.key) ?? 'unknown'
   }
 
-  async getIdentifier(): Promise<string> {
-    if (!this.#identifier) {
-      const { identifier } =
-        await this.client.keystore.getPrivatePreferencesTopicIdentifier()
-      this.#identifier = identifier
-    }
-    return this.#identifier
-  }
-
-  async decodeMessages(messages: Uint8Array[]) {
+  /**
+   * Decode messages and save them to the keystore
+   */
+  async decodeMessages(messageMap: Map<string, Uint8Array>) {
+    const messages = Array.from(messageMap.values())
     // decrypt messages
     const { responses } = await this.client.keystore.selfDecrypt({
       requests: messages.map((message) => ({ payload: message })),
     })
 
-    // decoded actions
-    const actions = responses.reduce((result, response) => {
-      return response.result?.decrypted
-        ? result.concat(
-            privatePreferences.PrivatePreferencesAction.decode(
-              response.result.decrypted
-            )
-          )
-        : result
-    }, [] as PrivatePreferencesAction[])
+    const decryptedMessageEntries = Array.from(messageMap.keys()).map(
+      (key, index) =>
+        // eslint-disable-next-line camelcase
+        [key, responses[index]] as [string, DecryptResponse_Response]
+    )
 
-    return actions
+    // decode decrypted messages into actions, convert to map
+    const actionsMap = decryptedMessageEntries.reduce(
+      (result, [key, response]) => {
+        if (response.result?.decrypted) {
+          const action = privatePreferences.PrivatePreferencesAction.decode(
+            response.result.decrypted
+          )
+          result.set(key, action)
+        }
+        return result
+      },
+      new Map<string, privatePreferences.PrivatePreferencesAction>()
+    )
+
+    // save actions to keystore
+    await this.client.keystore.savePrivatePreferences(actionsMap)
+
+    return actionsMap
   }
 
-  processActions(
-    actions: privatePreferences.PrivatePreferencesAction[],
-    lastTimestampNs?: string
-  ) {
+  /*
+   * Process actions and update internal consent list
+   */
+  processActions(actionsMap?: ActionsMap) {
     const entries: ConsentListEntry[] = []
+    // actions to process
+    const actions = actionsMap
+      ? Array.from(actionsMap.values())
+      : this.client.keystore.getPrivatePreferences()
+
+    // processing all actions, reset consent list
+    if (!actionsMap) {
+      this.reset()
+    }
+
+    // update the consent list
     actions.forEach((action) => {
       action.allowAddress?.walletAddresses.forEach((address) => {
         entries.push(this.allow(address))
@@ -184,30 +201,31 @@ export class ConsentList {
       })
     })
 
-    if (lastTimestampNs) {
-      this.lastEntryTimestamp = fromNanoString(lastTimestampNs)
-    }
-
     return entries
   }
 
   async stream(onConnectionLost?: OnConnectionLostCallback) {
-    const identifier = await this.getIdentifier()
-    const contentTopic = buildUserPrivatePreferencesTopic(identifier)
+    const contentTopic = await this.client.keystore.getPrivatePreferencesTopic()
 
     return Stream.create<privatePreferences.PrivatePreferencesAction>(
       this.client,
       [contentTopic],
       async (envelope) => {
-        if (!envelope.message) {
+        // ignore envelopes without message or timestamp
+        if (!envelope.message || !envelope.timestampNs) {
           return undefined
         }
-        const actions = await this.decodeMessages([envelope.message])
+
+        // decode message and save to keystore
+        const actionsMap = await this.decodeMessages(
+          new Map([[envelope.timestampNs, envelope.message]])
+        )
 
         // update consent list
-        this.processActions(actions, envelope.timestampNs)
+        this.processActions(actionsMap)
 
-        return actions[0]
+        // return the action
+        return actionsMap.get(envelope.timestampNs)
       },
       undefined,
       onConnectionLost
@@ -220,33 +238,34 @@ export class ConsentList {
   }
 
   async load(startTime?: Date) {
-    const identifier = await this.getIdentifier()
-    const contentTopic = buildUserPrivatePreferencesTopic(identifier)
+    const contentTopic = await this.client.keystore.getPrivatePreferencesTopic()
 
-    let lastTimestampNs: string | undefined
-
-    const messages = await this.client.listEnvelopes(
-      contentTopic,
-      async ({ message, timestampNs }: EnvelopeWithMessage) => {
-        if (timestampNs) {
-          lastTimestampNs = timestampNs
+    // get private preferences from the network
+    const messageEntries = (
+      await this.client.listEnvelopes(
+        contentTopic,
+        async ({ message, timestampNs }: EnvelopeWithMessage) =>
+          [timestampNs, message] as [string | undefined, Uint8Array],
+        {
+          // special exception for private preferences topic
+          limit: 500,
+          // ensure messages are in ascending order
+          direction: messageApi.SortDirection.SORT_DIRECTION_ASCENDING,
+          startTime,
         }
-        return message
-      },
-      {
-        startTime,
-      }
+      )
     )
+      // filter out messages with no timestamp
+      .filter(([timestampNs]) => Boolean(timestampNs)) as [string, Uint8Array][]
 
-    const actions = await this.decodeMessages(messages)
+    // decode messages and save them to keystore
+    const actionsMap = await this.decodeMessages(new Map(messageEntries))
 
-    // update consent list
-    return this.processActions(actions, lastTimestampNs)
+    // process actions and update consent list
+    return this.processActions(actionsMap)
   }
 
   async publish(entries: ConsentListEntry[]) {
-    const identifier = await this.getIdentifier()
-
     // this reduce is purposefully verbose for type safety
     const action = entries.reduce((result, entry) => {
       let actionKey: PrivatePreferencesActionKey
@@ -289,34 +308,16 @@ export class ConsentList {
       }
     }, {} as PrivatePreferencesAction)
 
-    // encoded action
-    const payload =
-      privatePreferences.PrivatePreferencesAction.encode(action).finish()
-
-    // encrypt payload
-    const { responses } = await this.client.keystore.selfEncrypt({
-      requests: [{ payload }],
-    })
-
-    // encrypted messages
-    const messages = responses.reduce((result, response) => {
-      return response.result?.encrypted
-        ? result.concat(response.result?.encrypted)
-        : result
-    }, [] as Uint8Array[])
-
-    const contentTopic = buildUserPrivatePreferencesTopic(identifier)
-    const timestamp = new Date()
-
-    // envelopes to publish
-    const envelopes = messages.map((message) => ({
-      contentTopic,
-      message,
-      timestamp,
-    }))
+    // get envelopes to publish (there should only be one)
+    const envelopes = await this.client.keystore.createPrivatePreference(action)
 
     // publish private preferences update
     await this.client.publishEnvelopes(envelopes)
+
+    // persist newly published private preference to keystore
+    this.client.keystore.savePrivatePreferences(
+      new Map([[envelopes[0].timestamp!.getTime().toString(), action]])
+    )
 
     // update local entries after publishing
     entries.forEach((entry) => {
@@ -415,13 +416,6 @@ export class Contacts {
 
   async streamConsentList(onConnectionLost?: OnConnectionLostCallback) {
     return this.#consentList.stream(onConnectionLost)
-  }
-
-  /**
-   * The timestamp of the last entry in the consent list
-   */
-  get lastConsentListEntryTimestamp() {
-    return this.#consentList.lastEntryTimestamp
   }
 
   setConsentListEntries(entries: ConsentListEntry[]) {

--- a/packages/js-sdk/src/Contacts.ts
+++ b/packages/js-sdk/src/Contacts.ts
@@ -167,17 +167,10 @@ export class ConsentList {
   /*
    * Process actions and update internal consent list
    */
-  processActions(actionsMap?: ActionsMap) {
+  processActions(actionsMap: ActionsMap) {
     const entries: ConsentListEntry[] = []
     // actions to process
-    const actions = actionsMap
-      ? Array.from(actionsMap.values())
-      : this.client.keystore.getPrivatePreferences()
-
-    // processing all actions, reset consent list
-    if (!actionsMap) {
-      this.reset()
-    }
+    const actions = Array.from(actionsMap.values())
 
     // update the consent list
     actions.forEach((action) => {
@@ -259,7 +252,13 @@ export class ConsentList {
       .filter(([timestampNs]) => Boolean(timestampNs)) as [string, Uint8Array][]
 
     // decode messages and save them to keystore
-    const actionsMap = await this.decodeMessages(new Map(messageEntries))
+    await this.decodeMessages(new Map(messageEntries))
+
+    // get all actions from keystore
+    const actionsMap = this.client.keystore.getPrivatePreferences()
+
+    // reset consent list
+    this.reset()
 
     // process actions and update consent list
     return this.processActions(actionsMap)

--- a/packages/js-sdk/src/Contacts.ts
+++ b/packages/js-sdk/src/Contacts.ts
@@ -168,33 +168,30 @@ export class ConsentList {
    * Process actions and update internal consent list
    */
   processActions(actionsMap: ActionsMap) {
-    const entries: ConsentListEntry[] = []
     // actions to process
     const actions = Array.from(actionsMap.values())
 
     // update the consent list
     actions.forEach((action) => {
       action.allowAddress?.walletAddresses.forEach((address) => {
-        entries.push(this.allow(address))
+        this.allow(address)
       })
       action.denyAddress?.walletAddresses.forEach((address) => {
-        entries.push(this.deny(address))
+        this.deny(address)
       })
       action.allowGroup?.groupIds.forEach((groupId) => {
-        entries.push(this.allowGroup(groupId))
+        this.allowGroup(groupId)
       })
       action.denyGroup?.groupIds.forEach((groupId) => {
-        entries.push(this.denyGroup(groupId))
+        this.denyGroup(groupId)
       })
       action.allowInboxId?.inboxIds.forEach((inboxId) => {
-        entries.push(this.allowInboxId(inboxId))
+        this.allowInboxId(inboxId)
       })
       action.denyInboxId?.inboxIds.forEach((inboxId) => {
-        entries.push(this.denyInboxId(inboxId))
+        this.denyInboxId(inboxId)
       })
     })
-
-    return entries
   }
 
   async stream(onConnectionLost?: OnConnectionLostCallback) {
@@ -261,7 +258,9 @@ export class ConsentList {
     this.reset()
 
     // process actions and update consent list
-    return this.processActions(actionsMap)
+    this.processActions(actionsMap)
+
+    return this.entries
   }
 
   async publish(entries: ConsentListEntry[]) {

--- a/packages/js-sdk/src/keystore/InMemoryKeystore.ts
+++ b/packages/js-sdk/src/keystore/InMemoryKeystore.ts
@@ -26,6 +26,10 @@ import {
 } from '@/crypto/selfEncryption'
 import { bytesToHex } from '@/crypto/utils'
 import { InvitationV1, SealedInvitation } from '@/Invitation'
+import {
+  PrivatePreferencesStore,
+  type ActionsMap,
+} from '@/keystore/privatePreferencesStore'
 import type { KeystoreInterface } from '@/keystore/rpcDefinitions'
 import { nsToDate } from '@/utils/date'
 import {
@@ -74,6 +78,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
   private v2Keys: PrivateKeyBundleV2 // Do I need this?
   private v1Store: V1Store
   private v2Store: V2Store
+  private privatePreferencesStore: PrivatePreferencesStore
   private authenticator: LocalAuthenticator
   private accountAddress: string | undefined
   private jobStatePersistence: Persistence
@@ -82,12 +87,14 @@ export default class InMemoryKeystore implements KeystoreInterface {
     keys: PrivateKeyBundleV1,
     v1Store: V1Store,
     v2Store: V2Store,
+    privatePreferencesStore: PrivatePreferencesStore,
     persistence: Persistence
   ) {
     this.v1Keys = keys
     this.v2Keys = PrivateKeyBundleV2.fromLegacyBundle(keys)
     this.v1Store = v1Store
     this.v2Store = v2Store
+    this.privatePreferencesStore = privatePreferencesStore
     this.authenticator = new LocalAuthenticator(keys.identityKey)
     this.jobStatePersistence = persistence
   }
@@ -97,6 +104,7 @@ export default class InMemoryKeystore implements KeystoreInterface {
       keys,
       await V1Store.create(persistence),
       await V2Store.create(persistence),
+      await PrivatePreferencesStore.create(persistence),
       persistence
     )
   }
@@ -654,5 +662,13 @@ export default class InMemoryKeystore implements KeystoreInterface {
     )
 
     return { hmacKeys }
+  }
+
+  getPrivatePreferences() {
+    return this.privatePreferencesStore.actions
+  }
+
+  savePrivatePreferences(data: ActionsMap) {
+    return this.privatePreferencesStore.add(data)
   }
 }

--- a/packages/js-sdk/src/keystore/SnapKeystore.ts
+++ b/packages/js-sdk/src/keystore/SnapKeystore.ts
@@ -28,7 +28,7 @@ export function SnapKeystore(
         return snapRPC(method, rpc, undefined, snapMeta, snapId) as any
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return snapRPC(method, rpc, req, snapMeta, snapId) as any
+      return snapRPC(method, rpc, req as any, snapMeta, snapId) as any
     }
   }
 

--- a/packages/js-sdk/src/keystore/privatePreferencesStore.ts
+++ b/packages/js-sdk/src/keystore/privatePreferencesStore.ts
@@ -12,8 +12,8 @@ export type ActionsMap = Map<
 >
 
 /**
- * PrivatePreferencesStore holds a mapping of message hash -> private preference action and
- * writes to the persistence layer on changes
+ * PrivatePreferencesStore holds a mapping of message timestamp -> private
+ * preference action and writes to the persistence layer on changes
  */
 export class PrivatePreferencesStore {
   #persistence: Persistence
@@ -123,10 +123,8 @@ export class PrivatePreferencesStore {
     return Array.from(sortedActions.values())
   }
 
-  lookup(
-    hash: string
-  ): privatePreferences.PrivatePreferencesAction | undefined {
-    return this.actionsMap.get(hash)
+  lookup(key: string): privatePreferences.PrivatePreferencesAction | undefined {
+    return this.actionsMap.get(key)
   }
 
   #toBytes(): Uint8Array {

--- a/packages/js-sdk/src/keystore/privatePreferencesStore.ts
+++ b/packages/js-sdk/src/keystore/privatePreferencesStore.ts
@@ -1,0 +1,129 @@
+import { keystore, type privatePreferences } from '@xmtp/proto'
+import { Mutex } from 'async-mutex'
+import { numberToUint8Array, uint8ArrayToNumber } from '@/utils/bytes'
+import type { Persistence } from './persistence/interface'
+
+const PRIVATE_PREFERENCES_ACTIONS_STORAGE_KEY = 'private-preferences/actions'
+
+export type ActionsMap = Map<
+  string,
+  privatePreferences.PrivatePreferencesAction
+>
+
+/**
+ * PrivatePreferencesStore holds a mapping of message hash -> private preference action and
+ * writes to the persistence layer on changes
+ */
+export class PrivatePreferencesStore {
+  #persistence: Persistence
+  #persistenceKey: string
+  #mutex: Mutex
+  #revision: number
+  actionsMap: ActionsMap
+
+  constructor(
+    persistence: Persistence,
+    persistenceKey: string,
+    initialData: ActionsMap = new Map()
+  ) {
+    this.#persistenceKey = persistenceKey
+    this.#persistence = persistence
+    this.#revision = 0
+    this.#mutex = new Mutex()
+    this.actionsMap = initialData
+  }
+
+  get revisionKey(): string {
+    return this.#persistenceKey + '/revision'
+  }
+
+  static async create(
+    persistence: Persistence
+  ): Promise<PrivatePreferencesStore> {
+    const store = new PrivatePreferencesStore(
+      persistence,
+      PRIVATE_PREFERENCES_ACTIONS_STORAGE_KEY
+    )
+    await store.refresh()
+    return store
+  }
+
+  async refresh() {
+    const currentRevision = await this.getRevision()
+    if (currentRevision > this.#revision) {
+      this.actionsMap = await this.loadFromPersistence()
+    }
+    this.#revision = currentRevision
+  }
+
+  async getRevision(): Promise<number> {
+    const data = await this.#persistence.getItem(this.revisionKey)
+    if (!data) {
+      return 0
+    }
+    return uint8ArrayToNumber(data)
+  }
+
+  async setRevision(number: number) {
+    await this.#persistence.setItem(
+      this.revisionKey,
+      numberToUint8Array(number)
+    )
+  }
+
+  async loadFromPersistence(): Promise<ActionsMap> {
+    const rawData = await this.#persistence.getItem(this.#persistenceKey)
+    if (!rawData) {
+      return new Map()
+    }
+    const data = keystore.PrivatePreferencesActionMap.decode(rawData)
+    const actionsMap: ActionsMap = new Map()
+    const entries = Object.entries(data.actions)
+    for (let i = 0; i < entries.length; i++) {
+      actionsMap.set(entries[i][0], entries[i][1])
+    }
+    return actionsMap
+  }
+
+  async store() {
+    await this.#persistence.setItem(this.#persistenceKey, this.#toBytes())
+    this.#revision++
+    await this.setRevision(this.#revision)
+  }
+
+  async add(actionsMap: ActionsMap): Promise<void> {
+    await this.#mutex.runExclusive(async () => {
+      await this.refresh()
+      let isDirty = false
+      const keys = Array.from(actionsMap.keys())
+      for (let i = 0; i < keys.length; i++) {
+        // ignore duplicate actions
+        if (!this.actionsMap.has(keys[i])) {
+          this.actionsMap.set(keys[i], actionsMap.get(keys[i])!)
+          // indicate new value added
+          isDirty = true
+        }
+      }
+      // only write to persistence if new values were added
+      if (isDirty) {
+        await this.store()
+      }
+    })
+  }
+
+  get actions(): privatePreferences.PrivatePreferencesAction[] {
+    return Array.from(this.actionsMap.values())
+  }
+
+  lookup(
+    hash: string
+  ): privatePreferences.PrivatePreferencesAction | undefined {
+    return this.actionsMap.get(hash)
+  }
+
+  #toBytes(): Uint8Array {
+    return keystore.PrivatePreferencesActionMap.encode({
+      actions: Object.fromEntries(this.actionsMap),
+    }).finish()
+  }
+}

--- a/packages/js-sdk/src/keystore/privatePreferencesStore.ts
+++ b/packages/js-sdk/src/keystore/privatePreferencesStore.ts
@@ -112,7 +112,7 @@ export class PrivatePreferencesStore {
     })
   }
 
-  get actions(): privatePreferences.PrivatePreferencesAction[] {
+  get actions(): ActionsMap {
     // sort actions by their keys (timestamps) in ascending order
     const sortedActions = new Map(
       [...this.actionsMap.entries()].sort(
@@ -120,7 +120,7 @@ export class PrivatePreferencesStore {
           fromNanoString(a[0])!.getTime() - fromNanoString(b[0])!.getTime()
       )
     )
-    return Array.from(sortedActions.values())
+    return sortedActions
   }
 
   lookup(key: string): privatePreferences.PrivatePreferencesAction | undefined {

--- a/packages/js-sdk/src/keystore/privatePreferencesStore.ts
+++ b/packages/js-sdk/src/keystore/privatePreferencesStore.ts
@@ -1,6 +1,7 @@
 import { keystore, type privatePreferences } from '@xmtp/proto'
 import { Mutex } from 'async-mutex'
 import { numberToUint8Array, uint8ArrayToNumber } from '@/utils/bytes'
+import { fromNanoString } from '@/utils/date'
 import type { Persistence } from './persistence/interface'
 
 const PRIVATE_PREFERENCES_ACTIONS_STORAGE_KEY = 'private-preferences/actions'
@@ -112,7 +113,14 @@ export class PrivatePreferencesStore {
   }
 
   get actions(): privatePreferences.PrivatePreferencesAction[] {
-    return Array.from(this.actionsMap.values())
+    // sort actions by their keys (timestamps) in ascending order
+    const sortedActions = new Map(
+      [...this.actionsMap.entries()].sort(
+        (a, b) =>
+          fromNanoString(a[0])!.getTime() - fromNanoString(b[0])!.getTime()
+      )
+    )
+    return Array.from(sortedActions.values())
   }
 
   lookup(

--- a/packages/js-sdk/src/keystore/rpcDefinitions.ts
+++ b/packages/js-sdk/src/keystore/rpcDefinitions.ts
@@ -44,7 +44,7 @@ type PrivatePreferenceKeystoreMethods = {
   createPrivatePreference: (
     action: privatePreferences.PrivatePreferencesAction
   ) => Promise<PublishParams[]>
-  getPrivatePreferences: () => privatePreferences.PrivatePreferencesAction[]
+  getPrivatePreferences: () => ActionsMap
   getPrivatePreferencesTopic: () => Promise<string>
   savePrivatePreferences: (data: ActionsMap) => Promise<void>
 }

--- a/packages/js-sdk/src/keystore/rpcDefinitions.ts
+++ b/packages/js-sdk/src/keystore/rpcDefinitions.ts
@@ -40,6 +40,15 @@ type ApiInterface = {
   [key: string]: (...args: any[]) => any
 }
 
+type PrivatePreferenceKeystoreMethods = {
+  createPrivatePreference: (
+    action: privatePreferences.PrivatePreferencesAction
+  ) => Promise<PublishParams[]>
+  getPrivatePreferences: () => privatePreferences.PrivatePreferencesAction[]
+  getPrivatePreferencesTopic: () => Promise<string>
+  savePrivatePreferences: (data: ActionsMap) => Promise<void>
+}
+
 type OtherKeyStoreMethods = {
   /**
    * Get the account address of the wallet used to create the Keystore
@@ -54,7 +63,8 @@ type ExtractInterface<T extends ApiDefs> = Flatten<
         ? () => Promise<Res>
         : (req: Req) => Promise<Res>
       : never
-  } & OtherKeyStoreMethods
+  } & OtherKeyStoreMethods &
+    PrivatePreferenceKeystoreMethods
 >
 
 type ExtractInterfaceRequestEncoders<T extends ApiDefs> = {
@@ -218,19 +228,9 @@ export const apiDefs = {
   },
 }
 
-export type PrivatePreferenceKeystoreInterface = {
-  createPrivatePreference: (
-    action: privatePreferences.PrivatePreferencesAction
-  ) => Promise<PublishParams[]>
-  getPrivatePreferences: () => privatePreferences.PrivatePreferencesAction[]
-  getPrivatePreferencesTopic: () => Promise<string>
-  savePrivatePreferences: (data: ActionsMap) => Promise<void>
-}
-
 export type KeystoreApiDefs = typeof apiDefs
 export type KeystoreApiMethods = keyof KeystoreApiDefs
-export type KeystoreInterface = ExtractInterface<KeystoreApiDefs> &
-  PrivatePreferenceKeystoreInterface
+export type KeystoreInterface = ExtractInterface<KeystoreApiDefs>
 export type KeystoreApiEntries = Entries<KeystoreApiDefs>
 export type KeystoreApiRequestEncoders =
   ExtractInterfaceRequestEncoders<KeystoreApiDefs>
@@ -251,10 +251,9 @@ export const snapApiDefs = {
   },
 }
 
-export type SnapKeystoreApiDefs = typeof snapApiDefs
+export type SnapKeystoreApiDefs = typeof snapApiDefs & KeystoreApiDefs
 export type SnapKeystoreApiMethods = keyof SnapKeystoreApiDefs
-export type SnapKeystoreInterface = KeystoreInterface &
-  ExtractInterface<SnapKeystoreApiDefs>
+export type SnapKeystoreInterface = ExtractInterface<SnapKeystoreApiDefs>
 export type SnapKeystoreApiEntries = Entries<SnapKeystoreApiDefs>
 export type SnapKeystoreApiRequestEncoders =
   ExtractInterfaceRequestEncoders<SnapKeystoreApiDefs>

--- a/packages/js-sdk/src/keystore/rpcDefinitions.ts
+++ b/packages/js-sdk/src/keystore/rpcDefinitions.ts
@@ -7,6 +7,7 @@ import {
   type privatePreferences,
 } from '@xmtp/proto'
 import type { Reader, Writer } from 'protobufjs/minimal'
+import type { PublishParams } from '@/ApiClient'
 import type { ActionsMap } from '@/keystore/privatePreferencesStore'
 import type { Flatten } from '@/utils/typedefs'
 
@@ -218,7 +219,11 @@ export const apiDefs = {
 }
 
 export type PrivatePreferenceKeystoreInterface = {
+  createPrivatePreference: (
+    action: privatePreferences.PrivatePreferencesAction
+  ) => Promise<PublishParams[]>
   getPrivatePreferences: () => privatePreferences.PrivatePreferencesAction[]
+  getPrivatePreferencesTopic: () => Promise<string>
   savePrivatePreferences: (data: ActionsMap) => Promise<void>
 }
 

--- a/packages/js-sdk/src/keystore/rpcDefinitions.ts
+++ b/packages/js-sdk/src/keystore/rpcDefinitions.ts
@@ -1,5 +1,13 @@
-import { authn, keystore, privateKey, publicKey, signature } from '@xmtp/proto'
+import {
+  authn,
+  keystore,
+  privateKey,
+  publicKey,
+  signature,
+  type privatePreferences,
+} from '@xmtp/proto'
 import type { Reader, Writer } from 'protobufjs/minimal'
+import type { ActionsMap } from '@/keystore/privatePreferencesStore'
 import type { Flatten } from '@/utils/typedefs'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -209,9 +217,15 @@ export const apiDefs = {
   },
 }
 
+export type PrivatePreferenceKeystoreInterface = {
+  getPrivatePreferences: () => privatePreferences.PrivatePreferencesAction[]
+  savePrivatePreferences: (data: ActionsMap) => Promise<void>
+}
+
 export type KeystoreApiDefs = typeof apiDefs
 export type KeystoreApiMethods = keyof KeystoreApiDefs
-export type KeystoreInterface = ExtractInterface<KeystoreApiDefs>
+export type KeystoreInterface = ExtractInterface<KeystoreApiDefs> &
+  PrivatePreferenceKeystoreInterface
 export type KeystoreApiEntries = Entries<KeystoreApiDefs>
 export type KeystoreApiRequestEncoders =
   ExtractInterfaceRequestEncoders<KeystoreApiDefs>
@@ -222,7 +236,6 @@ export type KeystoreInterfaceRequestValues =
 export type KeystoreApiRequestValues = Values<KeystoreInterfaceRequestValues>
 
 export const snapApiDefs = {
-  ...apiDefs,
   getKeystoreStatus: {
     req: keystore.GetKeystoreStatusRequest,
     res: keystore.GetKeystoreStatusResponse,
@@ -235,7 +248,8 @@ export const snapApiDefs = {
 
 export type SnapKeystoreApiDefs = typeof snapApiDefs
 export type SnapKeystoreApiMethods = keyof SnapKeystoreApiDefs
-export type SnapKeystoreInterface = ExtractInterface<SnapKeystoreApiDefs>
+export type SnapKeystoreInterface = KeystoreInterface &
+  ExtractInterface<SnapKeystoreApiDefs>
 export type SnapKeystoreApiEntries = Entries<SnapKeystoreApiDefs>
 export type SnapKeystoreApiRequestEncoders =
   ExtractInterfaceRequestEncoders<SnapKeystoreApiDefs>

--- a/packages/js-sdk/test/Contacts.test.ts
+++ b/packages/js-sdk/test/Contacts.test.ts
@@ -132,7 +132,7 @@ describe('Contacts', () => {
   it('should retrieve consent state', async () => {
     const entries = await bobClient.contacts.refreshConsentList()
 
-    expect(entries.length).toBe(0)
+    expect(entries.size).toBe(0)
 
     await bobClient.contacts.deny([alice.address])
     await bobClient.contacts.allow([carol.address])
@@ -143,6 +143,7 @@ describe('Contacts', () => {
     await bobClient.contacts.allowGroups(['foo', 'bar'])
     await bobClient.contacts.denyGroups(['foo'])
     await bobClient.contacts.allowGroups(['foo'])
+    await bobClient.contacts.denyGroups(['bar'])
     await bobClient.contacts.allowInboxes(['baz', 'qux'])
     await bobClient.contacts.denyInboxes(['baz'])
     await bobClient.contacts.allowInboxes(['baz'])
@@ -158,86 +159,24 @@ describe('Contacts', () => {
     expect(bobClient.contacts.inboxConsentState('baz')).toBe('unknown')
     expect(bobClient.contacts.inboxConsentState('qux')).toBe('unknown')
 
-    const latestEntries = await bobClient.contacts.refreshConsentList()
+    const latestEntries = await bobClient.contacts.loadConsentList()
 
-    expect(latestEntries.length).toBe(14)
-    expect(latestEntries).toEqual([
-      {
-        entryType: 'address',
-        permissionType: 'denied',
-        value: alice.address,
-      },
-      {
-        entryType: 'address',
-        permissionType: 'allowed',
-        value: carol.address,
-      },
-      {
-        entryType: 'address',
-        permissionType: 'allowed',
-        value: alice.address,
-      },
-      {
-        entryType: 'address',
-        permissionType: 'denied',
-        value: carol.address,
-      },
-      {
-        entryType: 'address',
-        permissionType: 'denied',
-        value: alice.address,
-      },
-      {
-        entryType: 'address',
-        permissionType: 'allowed',
-        value: carol.address,
-      },
-      {
-        entryType: 'groupId',
-        permissionType: 'allowed',
-        value: 'foo',
-      },
-      {
-        entryType: 'groupId',
-        permissionType: 'allowed',
-        value: 'bar',
-      },
-      {
-        entryType: 'groupId',
-        permissionType: 'denied',
-        value: 'foo',
-      },
-      {
-        entryType: 'groupId',
-        permissionType: 'allowed',
-        value: 'foo',
-      },
-      {
-        entryType: 'inboxId',
-        permissionType: 'allowed',
-        value: 'baz',
-      },
-      {
-        entryType: 'inboxId',
-        permissionType: 'allowed',
-        value: 'qux',
-      },
-      {
-        entryType: 'inboxId',
-        permissionType: 'denied',
-        value: 'baz',
-      },
-      {
-        entryType: 'inboxId',
-        permissionType: 'allowed',
-        value: 'baz',
-      },
-    ])
+    expect(latestEntries.size).toBe(6)
+    expect(latestEntries).toEqual(
+      new Map([
+        [`address-${alice.address}`, 'denied'],
+        [`address-${carol.address}`, 'allowed'],
+        [`groupId-foo`, 'allowed'],
+        [`groupId-bar`, 'denied'],
+        [`inboxId-baz`, 'allowed'],
+        [`inboxId-qux`, 'allowed'],
+      ])
+    )
 
     expect(bobClient.contacts.consentState(alice.address)).toBe('denied')
     expect(bobClient.contacts.consentState(carol.address)).toBe('allowed')
     expect(bobClient.contacts.groupConsentState('foo')).toBe('allowed')
-    expect(bobClient.contacts.groupConsentState('bar')).toBe('allowed')
+    expect(bobClient.contacts.groupConsentState('bar')).toBe('denied')
     expect(bobClient.contacts.inboxConsentState('baz')).toBe('allowed')
     expect(bobClient.contacts.inboxConsentState('qux')).toBe('allowed')
   })

--- a/packages/js-sdk/test/keystore/privatePreferencesStore.test.ts
+++ b/packages/js-sdk/test/keystore/privatePreferencesStore.test.ts
@@ -1,0 +1,106 @@
+import type { PrivatePreferencesAction } from '@xmtp/proto/ts/dist/types/message_contents/private_preferences.pb'
+import crypto from '@/crypto/crypto'
+import InMemoryPersistence from '@/keystore/persistence/InMemoryPersistence'
+import { PrivatePreferencesStore } from '@/keystore/privatePreferencesStore'
+
+const generateActionsMap = (hashValue?: string) => {
+  const hash = hashValue ?? crypto.getRandomValues(new Uint8Array(8)).toString()
+  const action: PrivatePreferencesAction = {
+    allowAddress: {
+      walletAddresses: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+    denyAddress: {
+      walletAddresses: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+    allowGroup: {
+      groupIds: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+    denyGroup: {
+      groupIds: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+    allowInboxId: {
+      inboxIds: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+    denyInboxId: {
+      inboxIds: [crypto.getRandomValues(new Uint8Array(12)).toString()],
+    },
+  }
+  return {
+    hash,
+    map: new Map([[hash, action]]),
+  }
+}
+
+describe('PrivatePreferencesStore', () => {
+  it('can add and retrieve actions', async () => {
+    const store = await PrivatePreferencesStore.create(
+      InMemoryPersistence.create()
+    )
+    const { hash, map } = generateActionsMap()
+    await store.add(map)
+
+    const result = store.lookup(hash)
+    expect(result).toEqual(map.get(hash))
+  })
+
+  it('returns undefined when no match exists', async () => {
+    const store = await PrivatePreferencesStore.create(
+      InMemoryPersistence.create()
+    )
+    const result = store.lookup('foo')
+    expect(result).toBeUndefined()
+  })
+
+  it('persists data between instances', async () => {
+    const persistence = InMemoryPersistence.create()
+    const store = await PrivatePreferencesStore.create(persistence)
+    const { hash, map } = generateActionsMap()
+    await store.add(map)
+
+    const result = store.lookup(hash)
+    expect(result).toEqual(map.get(hash))
+
+    const store2 = await PrivatePreferencesStore.create(persistence)
+    const result2 = store2.lookup(hash)
+    expect(result2).toEqual(result)
+  })
+
+  it('handles concurrent access', async () => {
+    const persistence = InMemoryPersistence.create()
+    const store1 = await PrivatePreferencesStore.create(persistence)
+    const store2 = await PrivatePreferencesStore.create(persistence)
+    const { map } = generateActionsMap()
+    await store1.add(map)
+    expect(store1.actions).toHaveLength(1)
+    expect(store2.actions).toHaveLength(0)
+    const { map: map2 } = generateActionsMap()
+    await store2.add(map2)
+    expect(store2.actions).toHaveLength(2)
+    expect(await store2.getRevision()).toBe(2)
+  })
+
+  it('correctly handles revisions', async () => {
+    const persistence = InMemoryPersistence.create()
+    const store = await PrivatePreferencesStore.create(persistence)
+    for (let i = 0; i < 10; i++) {
+      const { map } = generateActionsMap()
+      await store.add(map)
+      expect(await store.getRevision()).toBe(i + 1)
+    }
+    const newStore = await PrivatePreferencesStore.create(persistence)
+    expect(await newStore.getRevision()).toBe(10)
+  })
+
+  it('ignores duplicate actions', async () => {
+    const store = await PrivatePreferencesStore.create(
+      InMemoryPersistence.create()
+    )
+    const { hash, map } = generateActionsMap()
+    await store.add(map)
+    const revision = await store.getRevision()
+    const { map: map2 } = generateActionsMap(hash)
+    await store.add(map2)
+    expect(await store.getRevision()).toBe(revision)
+    expect(store.actions).toHaveLength(1)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,6 +2997,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/proto@npm:^3.68.0":
+  version: 3.68.0
+  resolution: "@xmtp/proto@npm:3.68.0"
+  dependencies:
+    long: "npm:^5.2.0"
+    protobufjs: "npm:^7.0.0"
+    rxjs: "npm:^7.8.0"
+    undici: "npm:^5.8.1"
+  checksum: 10/2cadf9d212ac01dc6a1d3a83e59ca559debff65ee83c7381e29e1a5e9dc2f0caa021a4c6df696957d77da8b5c1133fe02cbc8a4c3c7c4d2e45993366e309da63
+  languageName: node
+  linkType: hard
+
 "@xmtp/rollup-plugin-resolve-extensions@npm:1.0.1":
   version: 1.0.1
   resolution: "@xmtp/rollup-plugin-resolve-extensions@npm:1.0.1"
@@ -3038,7 +3050,7 @@ __metadata:
     "@xmtp/consent-proof-signature": "npm:^0.1.3"
     "@xmtp/content-type-primitives": "npm:^1.0.1"
     "@xmtp/content-type-text": "npm:^1.0.0"
-    "@xmtp/proto": "npm:^3.62.1"
+    "@xmtp/proto": "npm:^3.68.0"
     "@xmtp/rollup-plugin-resolve-extensions": "npm:1.0.1"
     "@xmtp/user-preferences-bindings-wasm": "npm:^0.3.6"
     async-mutex: "npm:^0.5.0"


### PR DESCRIPTION
# Summary

This PR adds caching of private preferences to the JS SDK.

* Upgraded `@xmtp/proto` for encoding of a private preferences action map
* Added a private preferences store to manage persisting of actions
* Added new methods to `InMemoryKeystore` to interact with the private preferences store
* Refactored `Contacts` class to use the private preferences store
* Removed deprecated/unused `lastConsentListEntryTimestamp` method from `Contacts` class

### Notes

* The use of `for` loops rather than `for..of` is intentional as it's more performant with a large number of iterations.
* The persistence of private preferences relies on the existing `persistConversations` option. I think they should be tied together and having a separate option would create unnecessary complexity.
* The actions are key'd by their timestamp, which _should_ be unique. The use of their timestamp is necessary in order to process them in the proper order. While it's technically possible to have 2 separate actions published with the same timestamp, it's not something we should worry about under normal circumstances. In the case that there are 2 actions with the same timestamp, the first one returned by the network will be the one used. Any subsequent actions with a duplicate timestamp will be ignored.