### PR TITLE
Enable MLS in Docker container, run MLS client tests in CI

### DIFF
--- a/.github/workflows/js-sdk.yml
+++ b/.github/workflows/js-sdk.yml
@@ -81,8 +81,7 @@ jobs:
 
   test:
     name: Test
-    # TODO: Investigate why fetch is failing for some of these tests on warp build runners
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -95,8 +94,12 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: yarn
-      - run: ./dev/up
-      - run: |
+      - name: Start dev environment
+        run: ./dev/up
+      - name: Sleep for 5 seconds
+        run: sleep 5s
+      - name: Run node tests
+        run: |
           cd packages/js-sdk
           yarn test:node
         env:
@@ -105,7 +108,8 @@ jobs:
           DD_SERVICE: xmtp-js
           DD_CIVISIBILITY_AGENTLESS_ENABLED: 'true'
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      - run: |
+      - name: Run browser tests
+        run: |
           cd packages/js-sdk
           yarn test:browser
 

--- a/.github/workflows/mls-client.yml
+++ b/.github/workflows/mls-client.yml
@@ -81,9 +81,27 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - run: echo "No tests for MLS Client yet."
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+        env:
+          SKIP_YARN_COREPACK_CHECK: '1'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn
+      - name: Start dev environment
+        run: ./dev/up
+      - name: Sleep for 5 seconds
+        run: sleep 5s
+      - name: Run tests
+        run: |
+          cd packages/mls-client
+          yarn test
 
   build:
     name: Build

--- a/dev/compose
+++ b/dev/compose
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -eou pipefail
+
+docker compose -f dev/docker-compose.yml -p "xmtp-js" "$@"

--- a/dev/docker-compose
+++ b/dev/docker-compose
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-docker compose -p xmtp-js -f dev/docker-compose.yml "$@"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  waku-node:
+  node:
     image: xmtp/node-go:latest
     platform: linux/amd64
     environment:
@@ -8,14 +8,29 @@ services:
       - --store.enable
       - --store.db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --store.reader-db-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
+      - --mls-store.db-connection-string=postgres://postgres:xmtp@mlsdb:5432/postgres?sslmode=disable
+      - --mls-validation.grpc-address=validation:50051
+      - --api.enable-mls
       - --wait-for-db=30s
       - --api.authn.enable
     ports:
-      - 9001:9001
       - 5555:5555
+      - 5556:5556
     depends_on:
       - db
+      - mlsdb
+      - validation
+
+  validation:
+    image: ghcr.io/xmtp/mls-validation-service:main
+    platform: linux/amd64
+
   db:
+    image: postgres:13
+    environment:
+      POSTGRES_PASSWORD: xmtp
+
+  mlsdb:
     image: postgres:13
     environment:
       POSTGRES_PASSWORD: xmtp

--- a/dev/down
+++ b/dev/down
@@ -1,4 +1,5 @@
 #!/bin/bash
-set -e
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-dev/docker-compose down
+"${script_dir}"/compose down

--- a/dev/up
+++ b/dev/up
@@ -1,9 +1,6 @@
 #!/bin/bash
-set -e
+set -eou pipefail
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-if ! which docker &>/dev/null; then
-    echo "Docker required to run dev/up. Install it and run this again."
-    exit 1
-fi
-
-dev/docker-compose up -d
+"${script_dir}"/compose pull
+"${script_dir}"/compose up -d --wait


### PR DESCRIPTION
# Summary

* Updated `docker-compose.yml` to enable MLS
* Updated docker scripts to match `libxmtp`
* Enabled MLS client testing in CI
* Replaced GitHub runner with warp build runner for JS SDK tests