### PR TITLE
Add 1:1 messages, consent state, and more identity updates

### DIFF
--- a/.changeset/small-singers-type.md
+++ b/.changeset/small-singers-type.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Add 1:1 messages, consent state, and more identity updates

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -1,4 +1,4 @@
-name: MLS Client
+name: Node SDK
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To learn more about the contents of this repository, see this README and the REA
 ### SDKs
 
 - [`js-sdk`](https://github.com/xmtp/xmtp-js/blob/main/sdks/js-sdk): XMTP JS client SDK for Node and the browser
+- [`node-sdk`](https://github.com/xmtp/xmtp-js/blob/main/sdks/node-sdk): XMTP client SDK for Node (V3 only)
+- [`browser-sdk`](https://github.com/xmtp/xmtp-js/blob/main/sdks/browser-sdk): XMTP client SDK for browsers (V3 only)
 
 ### Content types
 
@@ -22,8 +24,9 @@ To learn more about the contents of this repository, see this README and the REA
 
 ### Packages
 
-- [`frames-client`](https://github.com/xmtp/xmtp-js/blob/main/packages/frames-client): XMTP Open Frames client
 - [`consent-proof-signature`](https://github.com/xmtp/xmtp-js/blob/main/packages/consent-proof-signature): Lightweight package for creating consent proofs
+- [`frames-client`](https://github.com/xmtp/xmtp-js/blob/main/packages/frames-client): XMTP Open Frames client
+- [`frames-validator`](https://github.com/xmtp/xmtp-js/blob/main/packages/frames-validator): Tools for validating POST payloads from XMTP Open Frames
 
 ## Contributing
 

--- a/sdks/node-sdk/README.md
+++ b/sdks/node-sdk/README.md
@@ -1,4 +1,49 @@
-# XMTP MLS Client
+# XMTP client SDK for Node
 
-> **Important**  
-> This package is currently in **Alpha** status. Do not use in production as the API is not final and certain functionality may not work as intended. This package only works in Node.
+This package provides the XMTP client SDK for Node.
+
+To keep up with the latest SDK developments, see the [Issues tab](https://github.com/xmtp/xmtp-js/issues) in this repo.
+
+To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
+
+> [!CAUTION]
+> This SDK is currently in alpha. The API is subject to change and it is not yet recommended for production use.
+
+## Requirements
+
+- Node.js 20+
+
+## Install
+
+**NPM**
+
+```bash
+npm install @xmtp/node-sdk
+```
+
+**PNPM**
+
+```bash
+pnpm install @xmtp/node-sdk
+```
+
+**Yarn**
+
+```bash
+yarn add @xmtp/node-sdk
+```
+
+## XMTP network environments
+
+XMTP provides `production`, `dev`, and `local` network environments to support the development phases of your project. To learn more about these environments, see our [official documentation](https://xmtp.org/docs/build/authentication#environments).
+
+## Developing
+
+Run `yarn dev` to build the SDK and watch for changes, which will trigger a rebuild.
+
+### Useful commands
+
+- `yarn build`: Builds the SDK
+- `yarn clean`: Removes `node_modules`, `dist`, and `.turbo` folders
+- `yarn test`: Runs all tests
+- `yarn typecheck`: Runs `tsc`

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -67,6 +67,7 @@
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",
     "typescript": "^5.6.3",
+    "uuid": "^11.0.2",
     "viem": "^2.13.6",
     "vite": "^5.4.9",
     "vite-tsconfig-paths": "^5.0.1",

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -43,6 +43,7 @@
     "clean:deps": "rimraf node_modules",
     "clean:dist": "rimraf dist",
     "clean:tests": "rimraf test/*.db3* ||:",
+    "dev": "yarn build --watch",
     "test": "vitest run",
     "test:cov": "vitest run --coverage",
     "typecheck": "tsc"

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -51,7 +51,7 @@
     "@xmtp/content-type-group-updated": "^1.0.0",
     "@xmtp/content-type-primitives": "^1.0.2",
     "@xmtp/content-type-text": "^1.0.0",
-    "@xmtp/node-bindings": "^0.0.14",
+    "@xmtp/node-bindings": "^0.0.16",
     "@xmtp/proto": "^3.62.1"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -15,9 +15,9 @@ import {
   generateInboxId,
   getInboxIdForAddress,
   NapiGroupMessageKind,
-  NapiSignatureRequestType,
   type NapiClient,
   type NapiMessage,
+  type NapiSignatureRequestType,
 } from "@xmtp/node-bindings";
 import { Conversations } from "@/Conversations";
 
@@ -135,9 +135,44 @@ export class Client {
     return this.#innerClient.isRegistered();
   }
 
-  async signatureText() {
+  async createInboxSignatureText() {
     try {
       const signatureText = await this.#innerClient.createInboxSignatureText();
+      return signatureText;
+    } catch {
+      return null;
+    }
+  }
+
+  async addWalletSignatureText(
+    existingAccountAddress: string,
+    newAccountAddress: string,
+  ) {
+    try {
+      const signatureText = await this.#innerClient.addWalletSignatureText(
+        existingAccountAddress,
+        newAccountAddress,
+      );
+      return signatureText;
+    } catch {
+      return null;
+    }
+  }
+
+  async revokeWalletSignatureText(accountAddress: string) {
+    try {
+      const signatureText =
+        await this.#innerClient.revokeWalletSignatureText(accountAddress);
+      return signatureText;
+    } catch {
+      return null;
+    }
+  }
+
+  async revokeInstallationsSignatureText() {
+    try {
+      const signatureText =
+        await this.#innerClient.revokeInstallationsSignatureText();
       return signatureText;
     } catch {
       return null;
@@ -148,11 +183,15 @@ export class Client {
     return this.#innerClient.canMessage(accountAddresses);
   }
 
-  addSignature(signatureBytes: Uint8Array) {
-    void this.#innerClient.addSignature(
-      NapiSignatureRequestType.CreateInbox,
-      signatureBytes,
-    );
+  addSignature(
+    signatureType: NapiSignatureRequestType,
+    signatureBytes: Uint8Array,
+  ) {
+    void this.#innerClient.addSignature(signatureType, signatureBytes);
+  }
+
+  async applySignatures() {
+    return this.#innerClient.applySignatureRequests();
   }
 
   async registerIdentity() {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -251,6 +251,10 @@ export class Client {
     return this.#innerClient.inboxState(refreshFromNetwork);
   }
 
+  async getLatestInboxState(inboxId: string) {
+    return this.#innerClient.getLatestInboxState(inboxId);
+  }
+
   async inboxStateFromInboxIds(
     inboxIds: string[],
     refreshFromNetwork?: boolean,

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -16,6 +16,8 @@ import {
   getInboxIdForAddress,
   NapiGroupMessageKind,
   type NapiClient,
+  type NapiConsent,
+  type NapiConsentEntityType,
   type NapiMessage,
   type NapiSignatureRequestType,
 } from "@xmtp/node-bindings";
@@ -257,5 +259,13 @@ export class Client {
       refreshFromNetwork ?? false,
       inboxIds,
     );
+  }
+
+  async setConsentStates(consentStates: NapiConsent[]) {
+    return this.#innerClient.setConsentStates(consentStates);
+  }
+
+  async getConsentState(entityType: NapiConsentEntityType, entity: string) {
+    return this.#innerClient.getConsentState(entityType, entity);
   }
 }

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -197,4 +197,8 @@ export class Conversation {
         .filter((message) => message.content !== undefined)
     );
   }
+
+  get dmPeerInboxId() {
+    return this.#group.dmPeerInboxId();
+  }
 }

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -1,6 +1,10 @@
 import type { ContentTypeId } from "@xmtp/content-type-primitives";
 import { ContentTypeText } from "@xmtp/content-type-text";
-import type { NapiGroup, NapiListMessagesOptions } from "@xmtp/node-bindings";
+import type {
+  NapiConsentState,
+  NapiGroup,
+  NapiListMessagesOptions,
+} from "@xmtp/node-bindings";
 import { AsyncStream, type StreamCallback } from "@/AsyncStream";
 import type { Client } from "@/Client";
 import { DecodedMessage } from "@/DecodedMessage";
@@ -196,6 +200,14 @@ export class Conversation {
         // filter out messages without content
         .filter((message) => message.content !== undefined)
     );
+  }
+
+  get consentState() {
+    return this.#group.consentState();
+  }
+
+  updateConsentState(consentState: NapiConsentState) {
+    this.#group.updateConsentState(consentState);
   }
 
   get dmPeerInboxId() {

--- a/sdks/node-sdk/src/helpers/inboxId.ts
+++ b/sdks/node-sdk/src/helpers/inboxId.ts
@@ -1,0 +1,18 @@
+import {
+  generateInboxId as generateInboxIdBinding,
+  getInboxIdForAddress as getInboxIdForAddressBinding,
+} from "@xmtp/node-bindings";
+import { ApiUrls, type XmtpEnv } from "@/Client";
+
+export const generateInboxId = (accountAddress: string): string => {
+  return generateInboxIdBinding(accountAddress);
+};
+
+export const getInboxIdForAddress = async (
+  accountAddress: string,
+  env: XmtpEnv = "dev",
+) => {
+  const host = ApiUrls[env];
+  const isSecure = host.startsWith("https");
+  return getInboxIdForAddressBinding(host, isSecure, accountAddress);
+};

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -11,3 +11,4 @@ export { Conversations } from "./Conversations";
 export { DecodedMessage } from "./DecodedMessage";
 export type { StreamCallback } from "./AsyncStream";
 export type * from "@xmtp/node-bindings";
+export { generateInboxId, getInboxIdForAddress } from "./helpers/inboxId";

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -1,3 +1,10 @@
+import {
+  NapiConsentEntityType,
+  NapiConsentState,
+  NapiSignatureRequestType,
+} from "@xmtp/node-bindings";
+import { v4 } from "uuid";
+import { toBytes } from "viem";
 import { describe, expect, it } from "vitest";
 import {
   createClient,
@@ -11,7 +18,7 @@ describe("Client", () => {
     const client = await createClient(user);
     expect(client.accountAddress).toBe(user.account.address);
     expect(client.isRegistered).toBe(false);
-    expect(await client.signatureText()).not.toBe(null);
+    expect(await client.createInboxSignatureText()).not.toBe(null);
     expect(client.inboxId).toBeDefined();
     expect(client.installationId).toBeDefined();
   });
@@ -21,10 +28,17 @@ describe("Client", () => {
     await createRegisteredClient(user);
     const client2 = await createRegisteredClient(user);
     expect(client2.isRegistered).toBe(true);
-    expect(await client2.signatureText()).toBe(null);
+    expect(await client2.createInboxSignatureText()).toBe(null);
     expect(await client2.canMessage([user.account.address])).toEqual({
       [user.account.address.toLowerCase()]: true,
     });
+  });
+
+  it("should be able to message registered identity", async () => {
+    const user = createUser();
+    const client = await createRegisteredClient(user);
+    const canMessage = await client.canMessage([user.account.address]);
+    expect(canMessage).toEqual({ [user.account.address.toLowerCase()]: true });
   });
 
   it("should get an inbox ID from an address", async () => {
@@ -46,22 +60,196 @@ describe("Client", () => {
       user.account.address.toLowerCase(),
     ]);
     expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase());
+
+    const user2 = createUser();
+    const client2 = await createClient(user2);
+    const inboxState2 = await client2.getLatestInboxState(client.inboxId);
+    expect(inboxState2.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.length).toBe(1);
+    expect(inboxState.installations[0].id).toBe(client.installationId);
+    expect(inboxState2.accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ]);
+    expect(inboxState2.recoveryAddress).toBe(
+      user.account.address.toLowerCase(),
+    );
   });
 
   it("should get inbox states from inbox IDs", async () => {
     const user = createUser();
+    const user2 = createUser();
     const client = await createRegisteredClient(user);
+    const client2 = await createRegisteredClient(user2);
     const inboxStates = await client.inboxStateFromInboxIds([client.inboxId]);
     expect(inboxStates.length).toBe(1);
     expect(inboxStates[0].inboxId).toBe(client.inboxId);
-    expect(inboxStates[0].installations.map((install) => install.id)).toEqual([
-      client.installationId,
-    ]);
     expect(inboxStates[0].accountAddresses).toEqual([
       user.account.address.toLowerCase(),
     ]);
-    expect(inboxStates[0].recoveryAddress).toBe(
+
+    const inboxStates2 = await client2.inboxStateFromInboxIds(
+      [client2.inboxId],
+      true,
+    );
+    expect(inboxStates2.length).toBe(1);
+    expect(inboxStates2[0].inboxId).toBe(client2.inboxId);
+    expect(inboxStates2[0].accountAddresses).toEqual([
+      user2.account.address.toLowerCase(),
+    ]);
+  });
+
+  it("should add a wallet association to the client", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const client = await createRegisteredClient(user);
+    const signatureText = await client.addWalletSignatureText(
+      user.account.address,
+      user2.account.address,
+    );
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+    const signature2 = await user2.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    client.addSignature(NapiSignatureRequestType.AddWallet, toBytes(signature));
+    client.addSignature(
+      NapiSignatureRequestType.AddWallet,
+      toBytes(signature2),
+    );
+    await client.applySignatures();
+    const inboxState = await client.inboxState();
+    expect(inboxState.accountAddresses.length).toEqual(2);
+    expect(inboxState.accountAddresses).toContain(
       user.account.address.toLowerCase(),
     );
+    expect(inboxState.accountAddresses).toContain(
+      user2.account.address.toLowerCase(),
+    );
+  });
+
+  it("should revoke a wallet association from the client", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const client = await createRegisteredClient(user);
+    const signatureText = await client.addWalletSignatureText(
+      user.account.address,
+      user2.account.address,
+    );
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+    const signature2 = await user2.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    client.addSignature(NapiSignatureRequestType.AddWallet, toBytes(signature));
+    client.addSignature(
+      NapiSignatureRequestType.AddWallet,
+      toBytes(signature2),
+    );
+    await client.applySignatures();
+
+    const signatureText2 = await client.revokeWalletSignatureText(
+      user2.account.address,
+    );
+    expect(signatureText2).toBeDefined();
+
+    // sign message
+    const signature3 = await user.wallet.signMessage({
+      message: signatureText2!,
+    });
+
+    client.addSignature(
+      NapiSignatureRequestType.RevokeWallet,
+      toBytes(signature3),
+    );
+    await client.applySignatures();
+    const inboxState = await client.inboxState();
+    expect(inboxState.accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ]);
+  });
+
+  it("should revoke all installations", async () => {
+    const user = createUser();
+
+    const client = await createRegisteredClient(user);
+    user.uuid = v4();
+    const client2 = await createRegisteredClient(user);
+    user.uuid = v4();
+    const client3 = await createRegisteredClient(user);
+
+    const inboxState = await client3.inboxState(true);
+    expect(inboxState.installations.length).toBe(3);
+
+    const installationIds = inboxState.installations.map((i) => i.id);
+    expect(installationIds).toContain(client.installationId);
+    expect(installationIds).toContain(client2.installationId);
+    expect(installationIds).toContain(client3.installationId);
+
+    const signatureText = await client3.revokeInstallationsSignatureText();
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    client3.addSignature(
+      NapiSignatureRequestType.RevokeInstallations,
+      toBytes(signature),
+    );
+    await client3.applySignatures();
+    const inboxState2 = await client3.inboxState(true);
+
+    expect(inboxState2.installations.length).toBe(1);
+    expect(inboxState2.installations[0].id).toBe(client3.installationId);
+  });
+
+  it("should manage consent states", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const client1 = await createRegisteredClient(user1);
+    const client2 = await createRegisteredClient(user2);
+    const group = await client1.conversations.newConversation([
+      user2.account.address,
+    ]);
+
+    await client2.conversations.sync();
+    const group2 = client2.conversations.getConversationById(group.id);
+
+    expect(group2).not.toBeNull();
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2!.id),
+    ).toBe(NapiConsentState.Unknown);
+
+    await client2.setConsentStates([
+      {
+        entityType: NapiConsentEntityType.GroupId,
+        entity: group2!.id,
+        state: NapiConsentState.Allowed,
+      },
+    ]);
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2!.id),
+    ).toBe(NapiConsentState.Allowed);
+
+    expect(group2!.consentState).toBe(NapiConsentState.Allowed);
+
+    group2!.updateConsentState(NapiConsentState.Denied);
+
+    expect(
+      await client2.getConsentState(NapiConsentEntityType.GroupId, group2!.id),
+    ).toBe(NapiConsentState.Denied);
   });
 });

--- a/sdks/node-sdk/test/inboxId.test.ts
+++ b/sdks/node-sdk/test/inboxId.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { generateInboxId, getInboxIdForAddress } from "@/helpers/inboxId";
+import { createRegisteredClient, createUser } from "@test/helpers";
+
+describe("generateInboxId", () => {
+  it("should generate an inbox id", () => {
+    const user = createUser();
+    const inboxId = generateInboxId(user.account.address);
+    expect(inboxId).toBeDefined();
+  });
+});
+
+describe("getInboxIdForAddress", () => {
+  it("should return `null` inbox ID for unregistered address", async () => {
+    const user = createUser();
+    const inboxId = await getInboxIdForAddress(user.account.address, "local");
+    expect(inboxId).toBe(null);
+  });
+
+  it("should return inbox ID for registered address", async () => {
+    const user = createUser();
+    const client = await createRegisteredClient(user);
+    const inboxId = await getInboxIdForAddress(user.account.address, "local");
+    expect(inboxId).toBe(client.inboxId);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4860,6 +4860,7 @@ __metadata:
     rollup-plugin-filesize: "npm:^10.0.0"
     rollup-plugin-tsconfig-paths: "npm:^1.5.2"
     typescript: "npm:^5.6.3"
+    uuid: "npm:^11.0.2"
     viem: "npm:^2.13.6"
     vite: "npm:^5.4.9"
     vite-tsconfig-paths: "npm:^5.0.1"
@@ -12562,6 +12563,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10/35aa60614811a201ff90f8ca5e9ecb7076a75c3821e17f0f5ff72d44e36c2d35fcbc2ceee9c4ac7317f4cc41895da30e74f3885e30313bee48fda6338f250538
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "uuid@npm:11.0.2"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 10/b98082f398fa2ece8cacc2264402f739256ca70def4bb82e3a14ec70777d189c01ce1054764c3b59b8fc098b62b135a15d1b24914712904c988822e2ac9b4f44
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,10 +4832,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^0.0.14":
-  version: 0.0.14
-  resolution: "@xmtp/node-bindings@npm:0.0.14"
-  checksum: 10/1c2186418fc3c3066f3a63f91b547b23a0165b2b7ca162e9032a19e575fe9f1fc4922ca4ee4af332d898d98c03ecdec7d954aec3dbed065f8893cf06689a7475
+"@xmtp/node-bindings@npm:^0.0.16":
+  version: 0.0.16
+  resolution: "@xmtp/node-bindings@npm:0.0.16"
+  checksum: 10/d6bf406c0e2802061a1d5808dac17fc7c0bcf01b1d3917805832e38fa5a69ccfdb0b0283fe47da2e9c302214cf693271207c466d061f8a7096b86edf7fa12c8e
   languageName: node
   linkType: hard
 
@@ -4850,7 +4850,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^1.0.0"
     "@xmtp/content-type-primitives": "npm:^1.0.2"
     "@xmtp/content-type-text": "npm:^1.0.0"
-    "@xmtp/node-bindings": "npm:^0.0.14"
+    "@xmtp/node-bindings": "npm:^0.0.16"
     "@xmtp/proto": "npm:^3.62.1"
     "@xmtp/xmtp-js": "workspace:^"
     fast-glob: "npm:^3.3.2"


### PR DESCRIPTION
# Summary

- Added 1:1 messages
- Added stream errors to the stream's async iterator values
- Added consent state methods to client and conversation
- Added signature methods for adding/revoke wallets and revoking installations
- Added `getLatestInboxState` to client
- Added inbox ID helpers