### PR TITLE
Add 1:1 messaging to Browser SDK

### DIFF
--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -65,7 +65,7 @@
     "@xmtp/content-type-primitives": "^1.0.1",
     "@xmtp/content-type-text": "^1.0.0",
     "@xmtp/proto": "^3.70.0",
-    "@xmtp/wasm-bindings": "^0.0.1",
+    "@xmtp/wasm-bindings": "^0.0.2",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -99,8 +99,8 @@ export class Client extends ClientWorkerClass {
     return this.sendMessage("addSignature", { type, bytes });
   }
 
-  async applySignaturesRequests() {
-    return this.sendMessage("applySignaturesRequests", undefined);
+  async applySignatures() {
+    return this.sendMessage("applySignatures", undefined);
   }
 
   async registerIdentity() {

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -95,6 +95,10 @@ export class Client extends ClientWorkerClass {
     return this.sendMessage("getRevokeWalletSignatureText", { accountAddress });
   }
 
+  async getRevokeInstallationsSignatureText() {
+    return this.sendMessage("getRevokeInstallationsSignatureText", undefined);
+  }
+
   async addSignature(type: WasmSignatureRequestType, bytes: Uint8Array) {
     return this.sendMessage("addSignature", { type, bytes });
   }
@@ -119,8 +123,10 @@ export class Client extends ClientWorkerClass {
     return this.sendMessage("findInboxIdByAddress", { address });
   }
 
-  async inboxState(refreshFromNetwork: boolean) {
-    return this.sendMessage("inboxState", { refreshFromNetwork });
+  async inboxState(refreshFromNetwork?: boolean) {
+    return this.sendMessage("inboxState", {
+      refreshFromNetwork: refreshFromNetwork ?? false,
+    });
   }
 
   async getLatestInboxState(inboxId: string) {

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -282,4 +282,10 @@ export class Conversation {
       state,
     });
   }
+
+  async dmPeerInboxId() {
+    return this.#client.sendMessage("getDmPeerInboxId", {
+      id: this.#id,
+    });
+  }
 }

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -28,6 +28,12 @@ export class Conversations {
     });
   }
 
+  async getDmByInboxId(inboxId: string) {
+    return this.#client.sendMessage("getDmByInboxId", {
+      inboxId,
+    });
+  }
+
   async list(options?: SafeListConversationsOptions) {
     const conversations = await this.#client.sendMessage("getConversations", {
       options,
@@ -39,10 +45,34 @@ export class Conversations {
     );
   }
 
+  async listGroups(
+    options?: Omit<SafeListConversationsOptions, "conversation_type">,
+  ) {
+    return this.#client.sendMessage("getGroups", {
+      options,
+    });
+  }
+
+  async listDms(
+    options?: Omit<SafeListConversationsOptions, "conversation_type">,
+  ) {
+    return this.#client.sendMessage("getDms", {
+      options,
+    });
+  }
+
   async newGroup(accountAddresses: string[], options?: SafeCreateGroupOptions) {
     const conversation = await this.#client.sendMessage("newGroup", {
       accountAddresses,
       options,
+    });
+
+    return new Conversation(this.#client, conversation.id, conversation);
+  }
+
+  async newDm(accountAddress: string) {
+    const conversation = await this.#client.sendMessage("newDm", {
+      accountAddress,
     });
 
     return new Conversation(this.#client, conversation.id, conversation);

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -84,7 +84,7 @@ export class WorkerClient {
     return this.#client.addSignature(type, bytes);
   }
 
-  async applySignaturesRequests() {
+  async applySignatures() {
     return this.#client.applySignatureRequests();
   }
 

--- a/sdks/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/browser-sdk/src/WorkerConversation.ts
@@ -166,4 +166,8 @@ export class WorkerConversation {
   updateConsentState(state: WasmConsentState) {
     this.#group.update_consent_state(state);
   }
+
+  dmPeerInboxId() {
+    return this.#group.dm_peer_inbox_id();
+  }
 }

--- a/sdks/browser-sdk/src/WorkerConversations.ts
+++ b/sdks/browser-sdk/src/WorkerConversations.ts
@@ -43,8 +43,35 @@ export class WorkerConversations {
     }
   }
 
+  getDmByInboxId(inboxId: string) {
+    try {
+      const group = this.#conversations.find_dm_by_target_inbox_id(inboxId);
+      return new WorkerConversation(this.#client, group);
+    } catch {
+      return undefined;
+    }
+  }
+
   async list(options?: SafeListConversationsOptions) {
     const groups = (await this.#conversations.list(
+      options ? fromSafeListConversationsOptions(options) : undefined,
+    )) as WasmGroup[];
+    return groups.map((group) => new WorkerConversation(this.#client, group));
+  }
+
+  async listGroups(
+    options?: Omit<SafeListConversationsOptions, "conversation_type">,
+  ) {
+    const groups = (await this.#conversations.list_groups(
+      options ? fromSafeListConversationsOptions(options) : undefined,
+    )) as WasmGroup[];
+    return groups.map((group) => new WorkerConversation(this.#client, group));
+  }
+
+  async listDms(
+    options?: Omit<SafeListConversationsOptions, "conversation_type">,
+  ) {
+    const groups = (await this.#conversations.list_dms(
       options ? fromSafeListConversationsOptions(options) : undefined,
     )) as WasmGroup[];
     return groups.map((group) => new WorkerConversation(this.#client, group));
@@ -55,6 +82,11 @@ export class WorkerConversations {
       accountAddresses,
       options ? fromSafeCreateGroupOptions(options) : undefined,
     );
+    return new WorkerConversation(this.#client, group);
+  }
+
+  async newDm(accountAddress: string) {
+    const group = await this.#conversations.create_dm(accountAddress);
     return new WorkerConversation(this.#client, group);
   }
 }

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -79,7 +79,7 @@ export type ClientEvents =
       };
     }
   | {
-      action: "applySignaturesRequests";
+      action: "applySignatures";
       id: string;
       result: undefined;
       data: undefined;

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -165,11 +165,35 @@ export type ClientEvents =
       };
     }
   | {
+      action: "getDmByInboxId";
+      id: string;
+      result: SafeConversation | undefined;
+      data: {
+        inboxId: string;
+      };
+    }
+  | {
       action: "getConversations";
       id: string;
       result: SafeConversation[];
       data: {
         options?: SafeListConversationsOptions;
+      };
+    }
+  | {
+      action: "getGroups";
+      id: string;
+      result: SafeConversation[];
+      data: {
+        options?: Omit<SafeListConversationsOptions, "conversation_type">;
+      };
+    }
+  | {
+      action: "getDms";
+      id: string;
+      result: SafeConversation[];
+      data: {
+        options?: Omit<SafeListConversationsOptions, "conversation_type">;
       };
     }
   | {
@@ -179,6 +203,14 @@ export type ClientEvents =
       data: {
         accountAddresses: string[];
         options?: SafeCreateGroupOptions;
+      };
+    }
+  | {
+      action: "newDm";
+      id: string;
+      result: SafeConversation;
+      data: {
+        accountAddress: string;
       };
     }
   | {
@@ -398,6 +430,14 @@ export type ClientEvents =
       data: {
         id: string;
         state: WasmConsentState;
+      };
+    }
+  | {
+      action: "getDmPeerInboxId";
+      id: string;
+      result: string;
+      data: {
+        id: string;
       };
     };
 

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -12,7 +12,10 @@ import {
   WasmListMessagesOptions,
   type WasmConsentEntityType,
   type WasmConsentState,
+  type WasmConversationType,
   type WasmDeliveryStatus,
+  type WasmDirection,
+  type WasmGroupMembershipState,
   type WasmGroupMessageKind,
   type WasmGroupPermissionsOptions,
   type WasmInboxState,
@@ -141,6 +144,7 @@ export const toSafeMessage = (message: WasmMessage): SafeMessage => ({
 
 export type SafeListMessagesOptions = {
   delivery_status?: WasmDeliveryStatus;
+  direction?: WasmDirection;
   limit?: bigint;
   sent_after_ns?: bigint;
   sent_before_ns?: bigint;
@@ -150,6 +154,7 @@ export const toSafeListMessagesOptions = (
   options: WasmListMessagesOptions,
 ): SafeListMessagesOptions => ({
   delivery_status: options.delivery_status,
+  direction: options.direction,
   limit: options.limit,
   sent_after_ns: options.sent_after_ns,
   sent_before_ns: options.sent_before_ns,
@@ -163,9 +168,12 @@ export const fromSafeListMessagesOptions = (
     options.sent_after_ns,
     options.limit,
     options.delivery_status,
+    options.direction,
   );
 
 export type SafeListConversationsOptions = {
+  allowed_states?: WasmGroupMembershipState[];
+  conversation_type?: WasmConversationType;
   created_after_ns?: bigint;
   created_before_ns?: bigint;
   limit?: bigint;
@@ -183,6 +191,8 @@ export const fromSafeListConversationsOptions = (
   options: SafeListConversationsOptions,
 ): WasmListConversationsOptions =>
   new WasmListConversationsOptions(
+    options.allowed_states,
+    options.conversation_type,
     options.created_after_ns,
     options.created_before_ns,
     options.limit,

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -182,6 +182,8 @@ export type SafeListConversationsOptions = {
 export const toSafeListConversationsOptions = (
   options: WasmListConversationsOptions,
 ): SafeListConversationsOptions => ({
+  allowed_states: options.allowed_states,
+  conversation_type: options.conversation_type,
   created_after_ns: options.created_after_ns,
   created_before_ns: options.created_before_ns,
   limit: options.limit,

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -14,7 +14,8 @@ export const createClient = async (
   await init();
 
   const host = options?.apiUrl ?? ApiUrls[options?.env ?? "dev"];
-  const dbPath = `xmtp-${options?.env ?? "dev"}-${accountAddress}.db3`;
+  const dbPath =
+    options?.dbPath ?? `xmtp-${options?.env ?? "dev"}-${accountAddress}.db3`;
 
   const inboxId =
     (await getInboxIdForAddress(host, accountAddress)) ||

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -14,6 +14,10 @@ export const createClient = async (
   await init();
 
   const host = options?.apiUrl ?? ApiUrls[options?.env ?? "dev"];
+  // TODO: add db path validation
+  //       - must end with .db3
+  //       - must not contain invalid characters
+  //       - must not start with a dot
   const dbPath =
     options?.dbPath ?? `xmtp-${options?.env ?? "dev"}-${accountAddress}.db3`;
 

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -203,10 +203,45 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
         });
         break;
       }
+      case "getGroups": {
+        const conversations = await client.conversations.listGroups(
+          data.options,
+        );
+        postMessage({
+          id,
+          action,
+          result: conversations.map((conversation) =>
+            toSafeConversation(conversation),
+          ),
+        });
+        break;
+      }
+      case "getDms": {
+        const conversations = await client.conversations.listDms(data.options);
+        postMessage({
+          id,
+          action,
+          result: conversations.map((conversation) =>
+            toSafeConversation(conversation),
+          ),
+        });
+        break;
+      }
       case "newGroup": {
         const conversation = await client.conversations.newGroup(
           data.accountAddresses,
           data.options,
+        );
+        postMessage({
+          id,
+          action,
+          result: toSafeConversation(conversation),
+        });
+        break;
+      }
+      case "newDm": {
+        const conversation = await client.conversations.newDm(
+          data.accountAddress,
         );
         postMessage({
           id,
@@ -239,6 +274,15 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
           id,
           action,
           result: message,
+        });
+        break;
+      }
+      case "getDmByInboxId": {
+        const conversation = client.conversations.getDmByInboxId(data.inboxId);
+        postMessage({
+          id,
+          action,
+          result: conversation ? toSafeConversation(conversation) : undefined,
         });
         break;
       }
@@ -677,6 +721,23 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
           });
         }
         break;
+      }
+      case "getDmPeerInboxId": {
+        const group = client.conversations.getConversationById(data.id);
+        if (group) {
+          const result = group.dmPeerInboxId();
+          postMessage({
+            id,
+            action,
+            result,
+          });
+        } else {
+          postMessageError({
+            id,
+            action,
+            error: "Group not found",
+          });
+        }
       }
     }
   } catch (e) {

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -747,6 +747,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             error: "Group not found",
           });
         }
+        break;
       }
     }
   } catch (e) {

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -107,8 +107,8 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
           result: undefined,
         });
         break;
-      case "applySignaturesRequests":
-        await client.applySignaturesRequests();
+      case "applySignatures":
+        await client.applySignatures();
         postMessage({
           id,
           action,

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -99,6 +99,15 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
         });
         break;
       }
+      case "getRevokeInstallationsSignatureText": {
+        const result = await client.getRevokeInstallationsSignatureText();
+        postMessage({
+          id,
+          action,
+          result,
+        });
+        break;
+      }
       case "addSignature":
         await client.addSignature(data.type, data.bytes);
         postMessage({

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -1,11 +1,19 @@
+import {
+  WasmConsentEntityType,
+  WasmConsentState,
+  WasmSignatureRequestType,
+} from "@xmtp/wasm-bindings";
+import { v4 } from "uuid";
+import { toBytes } from "viem";
 import { describe, expect, it } from "vitest";
+import { Conversation } from "@/Conversation";
 import {
   createClient,
   createRegisteredClient,
   createUser,
 } from "@test/helpers";
 
-describe("Client", () => {
+describe.concurrent("Client", () => {
   it("should create a client", async () => {
     const user = createUser();
     const client = await createClient(user);
@@ -22,9 +30,13 @@ describe("Client", () => {
     const client2 = await createRegisteredClient(user);
     expect(await client2.isRegistered()).toBe(true);
     expect(await client2.getCreateInboxSignatureText()).toBeUndefined();
-    expect(
-      Object.fromEntries(await client2.canMessage([user.account.address])),
-    ).toEqual({
+  });
+
+  it("should be able to message registered identity", async () => {
+    const user = createUser();
+    const client = await createRegisteredClient(user);
+    const canMessage = await client.canMessage([user.account.address]);
+    expect(Object.fromEntries(canMessage)).toEqual({
       [user.account.address.toLowerCase()]: true,
     });
   });
@@ -48,19 +60,178 @@ describe("Client", () => {
       user.account.address.toLowerCase(),
     ]);
     expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase());
+
+    const user2 = createUser();
+    const client2 = await createClient(user2);
+    const inboxState2 = await client2.getLatestInboxState(client.inboxId!);
+    expect(inboxState2.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.length).toBe(1);
+    expect(inboxState.installations[0].id).toBe(client.installationId);
+    expect(inboxState2.accountAddresses).toEqual([
+      user.account.address.toLowerCase(),
+    ]);
+    expect(inboxState2.recoveryAddress).toBe(
+      user.account.address.toLowerCase(),
+    );
   });
 
-  it("should get latest inbox state from inbox ID", async () => {
+  it("should add a wallet association to the client", async () => {
     const user = createUser();
+    const user2 = createUser();
     const client = await createRegisteredClient(user);
-    const inboxState = await client.getLatestInboxState(client.inboxId!);
-    expect(inboxState.inboxId).toBe(client.inboxId);
-    expect(inboxState.installations.map((install) => install.id)).toEqual([
-      client.installationId,
-    ]);
+    const signatureText = await client.getAddWalletSignatureText(
+      user2.account.address,
+    );
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+    const signature2 = await user2.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    await client.addSignature(
+      WasmSignatureRequestType.AddWallet,
+      toBytes(signature),
+    );
+    await client.addSignature(
+      WasmSignatureRequestType.AddWallet,
+      toBytes(signature2),
+    );
+    await client.applySignatures();
+
+    const inboxState = await client.inboxState();
+    expect(inboxState.accountAddresses.length).toEqual(2);
+    expect(inboxState.accountAddresses).toContain(
+      user.account.address.toLowerCase(),
+    );
+    expect(inboxState.accountAddresses).toContain(
+      user2.account.address.toLowerCase(),
+    );
+  });
+
+  it("should revoke a wallet association from the client", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const client = await createRegisteredClient(user);
+    const signatureText = await client.getAddWalletSignatureText(
+      user2.account.address,
+    );
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+    const signature2 = await user2.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    await client.addSignature(
+      WasmSignatureRequestType.AddWallet,
+      toBytes(signature),
+    );
+    await client.addSignature(
+      WasmSignatureRequestType.AddWallet,
+      toBytes(signature2),
+    );
+    await client.applySignatures();
+
+    const signatureText2 = await client.getRevokeWalletSignatureText(
+      user2.account.address,
+    );
+    expect(signatureText2).toBeDefined();
+
+    // sign message
+    const signature3 = await user.wallet.signMessage({
+      message: signatureText2!,
+    });
+
+    await client.addSignature(
+      WasmSignatureRequestType.RevokeWallet,
+      toBytes(signature3),
+    );
+    await client.applySignatures();
+    const inboxState = await client.inboxState();
     expect(inboxState.accountAddresses).toEqual([
       user.account.address.toLowerCase(),
     ]);
-    expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase());
+  });
+
+  it("should revoke all installations", async () => {
+    const user = createUser();
+
+    const client = await createRegisteredClient(user);
+    user.uuid = v4();
+    const client2 = await createRegisteredClient(user);
+    user.uuid = v4();
+    const client3 = await createRegisteredClient(user);
+
+    const inboxState = await client3.inboxState(true);
+    expect(inboxState.installations.length).toBe(3);
+
+    const installationIds = inboxState.installations.map((i) => i.id);
+    expect(installationIds).toContain(client.installationId);
+    expect(installationIds).toContain(client2.installationId);
+    expect(installationIds).toContain(client3.installationId);
+
+    const signatureText = await client3.getRevokeInstallationsSignatureText();
+    expect(signatureText).toBeDefined();
+
+    // sign message
+    const signature = await user.wallet.signMessage({
+      message: signatureText!,
+    });
+
+    await client3.addSignature(
+      WasmSignatureRequestType.RevokeInstallations,
+      toBytes(signature),
+    );
+    await client3.applySignatures();
+    const inboxState2 = await client3.inboxState(true);
+
+    expect(inboxState2.installations.length).toBe(1);
+    expect(inboxState2.installations[0].id).toBe(client3.installationId);
+  });
+
+  it("should manage consent states", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const client1 = await createRegisteredClient(user1);
+    const client2 = await createRegisteredClient(user2);
+    const group = await client1.conversations.newGroup([user2.account.address]);
+
+    await client2.conversations.sync();
+    const group2 = await client2.conversations.getConversationById(group.id);
+
+    expect(group2).not.toBeNull();
+
+    expect(
+      await client2.getConsentState(WasmConsentEntityType.GroupId, group2!.id),
+    ).toBe(WasmConsentState.Unknown);
+
+    await client2.setConsentStates([
+      {
+        entityType: WasmConsentEntityType.GroupId,
+        entity: group2!.id,
+        state: WasmConsentState.Allowed,
+      },
+    ]);
+
+    expect(
+      await client2.getConsentState(WasmConsentEntityType.GroupId, group2!.id),
+    ).toBe(WasmConsentState.Allowed);
+
+    const convo = new Conversation(client2, group2!.id, group2);
+
+    expect(await convo.consentState()).toBe(WasmConsentState.Allowed);
+
+    await convo.updateConsentState(WasmConsentState.Denied);
+
+    expect(
+      await client2.getConsentState(WasmConsentEntityType.GroupId, group2!.id),
+    ).toBe(WasmConsentState.Denied);
   });
 });

--- a/sdks/browser-sdk/test/Utils.test.ts
+++ b/sdks/browser-sdk/test/Utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { Utils } from "@/Utils";
 import { createRegisteredClient, createUser } from "@test/helpers";
 
-describe("Utils", () => {
+describe.concurrent("Utils", () => {
   it("should generate inbox id", async () => {
     const utils = new Utils();
     const inboxId = await utils.generateInboxId("0x1234");

--- a/sdks/browser-sdk/test/helpers.ts
+++ b/sdks/browser-sdk/test/helpers.ts
@@ -4,6 +4,7 @@ import {
   type EncodedContent,
 } from "@xmtp/content-type-primitives";
 import { WasmSignatureRequestType } from "@xmtp/wasm-bindings";
+import { v4 } from "uuid";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
@@ -21,6 +22,7 @@ export const createUser = () => {
       chain: sepolia,
       transport: http(),
     }),
+    uuid: v4(),
   };
 };
 
@@ -44,7 +46,7 @@ export const createClient = async (user: User, options?: ClientOptions) => {
   };
   return Client.create(user.account.address, {
     ...opts,
-    dbPath: `./test-${user.account.address}.db3`,
+    dbPath: `./test-${user.uuid}.db3`,
   });
 };
 

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -84,7 +84,8 @@ describe("Conversations", () => {
     const group = await client1.conversations.newDm(user2.account.address);
     expect(group).toBeDefined();
     expect(group.id).toBeDefined();
-    expect(group.createdAtNs).toBeTypeOf("number");
+    expect(group.createdAtNs).toBeDefined();
+    expect(group.createdAt).toBeDefined();
     expect(group.isActive).toBe(true);
     expect(group.name).toBe("");
     expect(group.permissions.policyType).toBe(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4569,7 +4569,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^1.0.1"
     "@xmtp/content-type-text": "npm:^1.0.0"
     "@xmtp/proto": "npm:^3.70.0"
-    "@xmtp/wasm-bindings": "npm:^0.0.1"
+    "@xmtp/wasm-bindings": "npm:^0.0.2"
     playwright: "npm:^1.48.1"
     rollup: "npm:^4.18.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -4960,10 +4960,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@xmtp/wasm-bindings@npm:0.0.1"
-  checksum: 10/0af5824306d9499376e5a0e0a33d4372239d7b5d7e91ad6ac131749cf4461c3a8171fe7756a1da6902871d43241b1c68202f85c887ca7ae4e480616ad968d8a4
+"@xmtp/wasm-bindings@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@xmtp/wasm-bindings@npm:0.0.2"
+  checksum: 10/7aea7984776e4928185d76310c98a3c93ebc2288771ef7f385437064ce972ab9afced95a875c71d98f2389d3275b8a805d5da6cbd33aee87cd7922a13eebd5bd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Added missing `getRevokeInstallationsSignatureText` method to client
- Renamed `applySignaturesRequests` to `applySignatures`
- Added `newDm`, `listGroups`, `listDms`, and `getDmByInboxId` methods to `Conversations`
- Added `dmPeerInboxId` to `Conversation`
- Added `direction` to list messages options
- Added `allowed_states` and `conversation_type` to list conversations options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new methods for handling direct messages and group conversations, including `getDmByInboxId`, `listGroups`, `listDms`, and `newDm`.
	- Added asynchronous methods for signature management, inbox ID retrieval, and revoking installations.
	- Enhanced client creation flexibility with optional database path specification.

- **Bug Fixes**
	- Improved message handling for group and direct message operations.

- **Tests**
	- Expanded test coverage for client and conversation functionalities, including new tests for consent management and messaging capabilities.
	- Updated test suites to run concurrently for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->