### PR TITLE
Refactor AsyncStream

### DIFF
--- a/.changeset/tidy-planes-pay.md
+++ b/.changeset/tidy-planes-pay.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Refactor AsyncStream

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -119,7 +119,7 @@ export class Conversation {
       callback?.(err, decodedMessage);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -106,7 +106,7 @@ export class Conversations {
       callback?.(err, conversation);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }
@@ -120,7 +120,7 @@ export class Conversations {
       callback?.(err, conversation);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }
@@ -134,7 +134,7 @@ export class Conversations {
       callback?.(err, conversation);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }
@@ -151,7 +151,7 @@ export class Conversations {
       callback?.(err, decodedMessage);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }
@@ -170,7 +170,7 @@ export class Conversations {
       },
     );
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }
@@ -187,7 +187,7 @@ export class Conversations {
       callback?.(err, decodedMessage);
     });
 
-    asyncStream.stopCallback = stream.end.bind(stream);
+    asyncStream.onReturn = stream.end.bind(stream);
 
     return asyncStream;
   }

--- a/sdks/node-sdk/test/AsyncStream.test.ts
+++ b/sdks/node-sdk/test/AsyncStream.test.ts
@@ -6,6 +6,10 @@ const testError = new Error("test");
 describe("AsyncStream", () => {
   it("should return values from callbacks", async () => {
     const stream = new AsyncStream<number>();
+    let onReturnCalled = false;
+    stream.onReturn = () => {
+      onReturnCalled = true;
+    };
     stream.callback(null, 1);
     stream.callback(null, 2);
     stream.callback(null, 3);
@@ -25,10 +29,15 @@ describe("AsyncStream", () => {
       }
       count++;
     }
+    expect(onReturnCalled).toBe(true);
   });
 
   it("should catch an error thrown in the for..await loop", async () => {
     const stream = new AsyncStream<number>();
+    let onReturnCalled = false;
+    stream.onReturn = () => {
+      onReturnCalled = true;
+    };
     stream.callback(null, 1);
 
     try {
@@ -40,11 +49,16 @@ describe("AsyncStream", () => {
       expect(error).toBe(testError);
       expect((error as Error).message).toBe("test");
     }
+    expect(onReturnCalled).toBe(true);
   });
 
   it("should catch an error passed to callback", async () => {
     const runTest = async () => {
       const stream = new AsyncStream<number>();
+      let onReturnCalled = false;
+      stream.onReturn = () => {
+        onReturnCalled = true;
+      };
       stream.callback(testError, 1);
       try {
         for await (const _value of stream) {
@@ -54,6 +68,7 @@ describe("AsyncStream", () => {
         expect(error).toBe(testError);
         expect((error as Error).message).toBe("test");
       }
+      expect(onReturnCalled).toBe(true);
     };
 
     await expect(runTest()).rejects.toThrow(testError);

--- a/sdks/node-sdk/test/AsyncStream.test.ts
+++ b/sdks/node-sdk/test/AsyncStream.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { AsyncStream } from "@/AsyncStream";
+
+const testError = new Error("test");
+
+describe("AsyncStream", () => {
+  it("should return values from callbacks", async () => {
+    const stream = new AsyncStream<number>();
+    stream.callback(null, 1);
+    stream.callback(null, 2);
+    stream.callback(null, 3);
+
+    let count = 0;
+
+    for await (const value of stream) {
+      if (count === 0) {
+        expect(value).toBe(1);
+      }
+      if (count === 1) {
+        expect(value).toBe(2);
+      }
+      if (count === 2) {
+        expect(value).toBe(3);
+        break;
+      }
+      count++;
+    }
+  });
+
+  it("should catch an error thrown in the for..await loop", async () => {
+    const stream = new AsyncStream<number>();
+    stream.callback(null, 1);
+
+    try {
+      for await (const value of stream) {
+        expect(value).toBe(1);
+        throw testError;
+      }
+    } catch (error) {
+      expect(error).toBe(testError);
+      expect((error as Error).message).toBe("test");
+    }
+  });
+
+  it("should catch an error passed to callback", async () => {
+    const runTest = async () => {
+      const stream = new AsyncStream<number>();
+      stream.callback(testError, 1);
+      try {
+        for await (const _value of stream) {
+          // this block should never be reached
+        }
+      } catch (error) {
+        expect(error).toBe(testError);
+        expect((error as Error).message).toBe("test");
+      }
+    };
+
+    await expect(runTest()).rejects.toThrow(testError);
+  });
+});

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -337,7 +337,6 @@ describe("Conversation", () => {
         break;
       }
     }
-    stream.stop();
   });
 
   it("should add and remove admins", async () => {

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -3,8 +3,6 @@ import {
   NapiGroupPermissionsOptions,
 } from "@xmtp/node-bindings";
 import { describe, expect, it } from "vitest";
-import { AsyncStream } from "@/AsyncStream";
-import type { Conversation } from "@/Conversation";
 import { createRegisteredClient, createUser } from "@test/helpers";
 
 describe("Conversations", () => {
@@ -287,7 +285,6 @@ describe("Conversations", () => {
         break;
       }
     }
-    stream.stop();
     expect(
       client3.conversations.getConversationById(conversation1.id)?.id,
     ).toBe(conversation1.id);
@@ -305,8 +302,7 @@ describe("Conversations", () => {
     const client2 = await createRegisteredClient(user2);
     const client3 = await createRegisteredClient(user3);
     const client4 = await createRegisteredClient(user4);
-    const asyncStream = new AsyncStream<Conversation>();
-    const stream = client3.conversations.streamGroups(asyncStream.callback);
+    const stream = client3.conversations.streamGroups();
     await client4.conversations.newDm(user3.account.address);
     const group1 = await client1.conversations.newConversation([
       user3.account.address,
@@ -315,7 +311,7 @@ describe("Conversations", () => {
       user3.account.address,
     ]);
     let count = 0;
-    for await (const convo of asyncStream) {
+    for await (const convo of stream) {
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
@@ -326,7 +322,6 @@ describe("Conversations", () => {
         break;
       }
     }
-    stream.stop();
   });
 
   it("should only stream dm conversations", async () => {
@@ -338,13 +333,12 @@ describe("Conversations", () => {
     const client2 = await createRegisteredClient(user2);
     const client3 = await createRegisteredClient(user3);
     const client4 = await createRegisteredClient(user4);
-    const asyncStream = new AsyncStream<Conversation>();
-    const stream = client3.conversations.streamDms(asyncStream.callback);
+    const stream = client3.conversations.streamDms();
     await client1.conversations.newConversation([user3.account.address]);
     await client2.conversations.newConversation([user3.account.address]);
     const group3 = await client4.conversations.newDm(user3.account.address);
     let count = 0;
-    for await (const convo of asyncStream) {
+    for await (const convo of stream) {
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
@@ -353,7 +347,6 @@ describe("Conversations", () => {
       }
     }
     expect(count).toBe(1);
-    stream.stop();
   });
 
   it("should stream all messages", async () => {
@@ -390,7 +383,6 @@ describe("Conversations", () => {
         break;
       }
     }
-    stream.stop();
   });
 
   it("should only stream group conversation messages", async () => {
@@ -437,7 +429,6 @@ describe("Conversations", () => {
         break;
       }
     }
-    stream.stop();
   });
 
   it("should only stream dm messages", async () => {
@@ -481,6 +472,5 @@ describe("Conversations", () => {
         break;
       }
     }
-    stream.stop();
   });
 });


### PR DESCRIPTION
# Summary

This PR refactors `AsyncStream` to be more compliant with the async iterator pattern.

- Replaced `stop()` with `return()`
- Renamed `stopCallback` property to `onReturn`
- Added throw of error passed to stream callback

The `return()` method of an async iterator will always be called when the iteration is complete. This allows shutting down streams without manually calling `stop()`.

With these changes, `for..await const..of` loops will properly throw errors passed into the stream callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method `return` in the `AsyncStream` class for improved stream completion handling.
	- Updated `stopCallback` to `onReturn` for clearer callback functionality in the `AsyncStream` class.
	- Added unit tests for `AsyncStream` and enhanced test coverage for the `Conversation` class, including member management and message handling.

- **Bug Fixes**
	- Improved error handling in the `AsyncStream` class, allowing errors to propagate to the caller.

- **Tests**
	- Added tests for various functionalities in the `Conversation` class, including message sending and updating conversation properties.
	- Streamlined tests for conversations to align with updated streaming methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->