### PR TITLE
Typo correct README.md

### DIFF
--- a/content-types/content-type-transaction-reference/README.md
+++ b/content-types/content-type-transaction-reference/README.md
@@ -39,7 +39,7 @@ const transactionReference: TransactionReference = {
    */
   namespace: "eip155";
   /**
-   * The networkId for the transaction, in decimal or hexidecimal format
+   * The networkId for the transaction, in decimal or hexadecimal format
    */
   networkId: 1;
   /**


### PR DESCRIPTION
<img width="668" alt="image" src="https://github.com/user-attachments/assets/3b48904c-bd51-49de-a227-6fdab88eaac6">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typographical error in the transaction reference content type documentation regarding the `networkId` key format for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->