### PR TITLE
Do not create DB on static canMessage

### DIFF
--- a/.changeset/hungry-dodos-own.md
+++ b/.changeset/hungry-dodos-own.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Do not create DB on static canMessage

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -313,10 +313,6 @@ export class Client {
     const accountAddress = "0x0000000000000000000000000000000000000000";
     const host = ApiUrls[env ?? "dev"];
     const isSecure = host.startsWith("https");
-    const dbPath = join(
-      process.cwd(),
-      `xmtp-${env ?? "dev"}-${accountAddress}.db3`,
-    );
     const inboxId =
       (await getInboxIdForAddress(host, isSecure, accountAddress)) ||
       generateInboxId(accountAddress);
@@ -325,7 +321,7 @@ export class Client {
       signMessage: () => new Uint8Array(),
     };
     const client = new Client(
-      await createClient(host, isSecure, dbPath, inboxId, accountAddress),
+      await createClient(host, isSecure, undefined, inboxId, accountAddress),
       signer,
       [],
     );


### PR DESCRIPTION
# Summary

This PR removes the creation of a local DB when statically checking if an address is on the network. It doesn't make sense to create a local DB for such an ephemeral client.