### PR TITLE
Remove support for CommonJS

### DIFF
--- a/.changeset/slow-peas-report.md
+++ b/.changeset/slow-peas-report.md
@@ -1,0 +1,17 @@
+---
+"@xmtp/content-type-transaction-reference": major
+"@xmtp/content-type-remote-attachment": major
+"@xmtp/content-type-group-updated": major
+"@xmtp/content-type-read-receipt": major
+"@xmtp/content-type-primitives": major
+"@xmtp/content-type-reaction": major
+"@xmtp/content-type-reply": major
+"@xmtp/consent-proof-signature": major
+"@xmtp/content-type-text": major
+"@xmtp/frames-validator": major
+"@xmtp/frames-client": patch
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Dropped support for CommonJS

--- a/content-types/content-type-group-updated/package.json
+++ b/content-types/content-type-group-updated/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-group-updated/rollup.config.js
+++ b/content-types/content-type-group-updated/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-primitives/package.json
+++ b/content-types/content-type-primitives/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-primitives/rollup.config.js
+++ b/content-types/content-type-primitives/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-reaction/package.json
+++ b/content-types/content-type-reaction/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-reaction/rollup.config.js
+++ b/content-types/content-type-reaction/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-read-receipt/package.json
+++ b/content-types/content-type-read-receipt/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-read-receipt/rollup.config.js
+++ b/content-types/content-type-read-receipt/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-remote-attachment/package.json
+++ b/content-types/content-type-remote-attachment/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-remote-attachment/rollup.config.js
+++ b/content-types/content-type-remote-attachment/rollup.config.js
@@ -50,16 +50,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-reply/package.json
+++ b/content-types/content-type-reply/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-reply/rollup.config.js
+++ b/content-types/content-type-reply/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-text/package.json
+++ b/content-types/content-type-text/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-text/rollup.config.js
+++ b/content-types/content-type-text/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/content-types/content-type-transaction-reference/package.json
+++ b/content-types/content-type-transaction-reference/package.json
@@ -29,13 +29,11 @@
     ".": {
       "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/content-types/content-type-transaction-reference/rollup.config.js
+++ b/content-types/content-type-transaction-reference/rollup.config.js
@@ -40,16 +40,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/packages/consent-proof-signature/package.json
+++ b/packages/consent-proof-signature/package.json
@@ -27,14 +27,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "browser": "./dist/browser/index.js",
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
-  "browser": "dist/index.js",
+  "main": "dist/index.js",
+  "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/consent-proof-signature/rollup.config.js
+++ b/packages/consent-proof-signature/rollup.config.js
@@ -30,16 +30,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    external,
-    plugins,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/browser/index.js",
       format: "es",
       sourcemap: true,

--- a/packages/frames-client/package.json
+++ b/packages/frames-client/package.json
@@ -27,12 +27,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": "./dist/browser/index.js",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "module": "dist/index.js",
-  "browser": "dist/index.js",
+  "main": "dist/index.js",
+  "browser": "dist/browser/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/frames-validator/package.json
+++ b/packages/frames-validator/package.json
@@ -17,13 +17,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/frames-validator/rollup.config.js
+++ b/packages/frames-validator/rollup.config.js
@@ -31,16 +31,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -32,8 +32,7 @@
     },
     "./package.json": "./package.json"
   },
-  "module": "dist/index.js",
-  "browser": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -26,13 +26,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/sdks/node-sdk/rollup.config.js
+++ b/sdks/node-sdk/rollup.config.js
@@ -44,16 +44,6 @@ export default defineConfig([
   {
     input: "src/index.ts",
     output: {
-      file: "dist/index.cjs",
-      format: "cjs",
-      sourcemap: true,
-    },
-    plugins,
-    external,
-  },
-  {
-    input: "src/index.ts",
-    output: {
       file: "dist/index.d.ts",
       format: "es",
     },


### PR DESCRIPTION
# Summary

This PR removes CommonJS exports from all packages (except the legacy JS SDK) and cleans up some `package.json` files.