### PR TITLE
Add support for HMAC keys in Node SDK

### DIFF
--- a/.changeset/blue-weeks-chew.md
+++ b/.changeset/blue-weeks-chew.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Add support for HMAC keys in Node SDK

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -51,7 +51,7 @@
     "@xmtp/content-type-group-updated": "^2.0.0",
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
-    "@xmtp/node-bindings": "^0.0.30",
+    "@xmtp/node-bindings": "^0.0.31",
     "@xmtp/proto": "^3.72.3"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -200,4 +200,8 @@ export class Conversations {
 
     return asyncStream;
   }
+
+  hmacKeys() {
+    return this.#conversations.getHmacKeys();
+  }
 }

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -23,6 +23,7 @@ export type {
   Message,
   PermissionPolicySet,
 } from "@xmtp/node-bindings";
+export type { HmacKey } from "@xmtp/node-bindings";
 export {
   ConsentEntityType,
   ConsentState,

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -505,4 +505,28 @@ describe("Conversations", () => {
       }
     }
   });
+
+  it("should get hmac keys", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const client1 = await createRegisteredClient(user1);
+    await createRegisteredClient(user2);
+    const group = await client1.conversations.newGroup([user2.account.address]);
+    const dm = await client1.conversations.newDm(user2.account.address);
+    const hmacKeys = client1.conversations.hmacKeys();
+    expect(hmacKeys).toBeDefined();
+    const keys = Object.keys(hmacKeys);
+    expect(keys.length).toBe(2);
+    expect(keys).toContain(group.id);
+    expect(keys).toContain(dm.id);
+    for (const values of Object.values(hmacKeys)) {
+      expect(values.length).toBe(3);
+      for (const value of values) {
+        expect(value.key).toBeDefined();
+        expect(value.key.length).toBe(42);
+        expect(value.epoch).toBeDefined();
+        expect(typeof value.epoch).toBe("bigint");
+      }
+    }
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5114,10 +5114,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^0.0.30":
-  version: 0.0.30
-  resolution: "@xmtp/node-bindings@npm:0.0.30"
-  checksum: 10/a7bf581c038f811b38ea53690b1500bd931b3fb8c32798fc96cf852ab5e0fc0b837fdfc2f354943be45095f096c23467e8de5a96235409b2013fc49c27cb2644
+"@xmtp/node-bindings@npm:^0.0.31":
+  version: 0.0.31
+  resolution: "@xmtp/node-bindings@npm:0.0.31"
+  checksum: 10/bcb754e23a8dd123789580d288336343e5bed12f2952ea24a0ee24961494c8765469f14b836815a33d54a7fe35afe2edc72c8113487013a690888eb190790a3f
   languageName: node
   linkType: hard
 
@@ -5145,7 +5145,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.0"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
-    "@xmtp/node-bindings": "npm:^0.0.30"
+    "@xmtp/node-bindings": "npm:^0.0.31"
     "@xmtp/proto": "npm:^3.72.3"
     "@xmtp/xmtp-js": "workspace:^"
     fast-glob: "npm:^3.3.2"


### PR DESCRIPTION
# Summary

- Upgraded node bindings
- Added `hmacKeys` method to `Conversations` for retrieving HMAC keys of all conversations
- Added `HmacKey` type export
- Added tests