### PR TITLE
Include installation ID bytes in inbox state

### DIFF
--- a/.changeset/orange-wombats-thank.md
+++ b/.changeset/orange-wombats-thank.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": patch
+---
+
+Include installation ID bytes in inbox state

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -339,15 +339,17 @@ export const toSafeConversation = async (
 });
 
 export type SafeInstallation = {
-  id: string;
+  bytes: Uint8Array;
   clientTimestampNs?: bigint;
+  id: string;
 };
 
 export const toSafeInstallation = (
   installation: Installation,
 ): SafeInstallation => ({
-  id: installation.id,
+  bytes: installation.bytes,
   clientTimestampNs: installation.clientTimestampNs,
+  id: installation.id,
 });
 
 export type SafeInboxState = {

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -70,6 +70,9 @@ describe.concurrent("Client", () => {
     expect(inboxState2.inboxId).toBe(client.inboxId);
     expect(inboxState.installations.length).toBe(1);
     expect(inboxState.installations[0].id).toBe(client.installationId);
+    expect(inboxState.installations[0].bytes).toEqual(
+      client.installationIdBytes,
+    );
     expect(inboxState2.accountAddresses).toEqual([
       user.account.address.toLowerCase(),
     ]);


### PR DESCRIPTION
# Summary

- Added `bytes` field to `SafeInstallation` type
- Included `bytes` field when converting from `Installation` to `SafeInstallation`