### PR TITLE
Add history sync URL to clients (browser + node)

### DIFF
--- a/.changeset/sharp-jars-sin.md
+++ b/.changeset/sharp-jars-sin.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Add history sync URL to client

--- a/sdks/browser-sdk/src/constants.ts
+++ b/sdks/browser-sdk/src/constants.ts
@@ -3,3 +3,9 @@ export const ApiUrls = {
   dev: "https://dev.xmtp.network",
   production: "https://production.xmtp.network",
 } as const;
+
+export const HistorySyncUrls = {
+  local: "http://localhost:5558",
+  dev: "https://message-history.dev.ephemera.network",
+  production: "https://message-history.production.ephemera.network",
+} as const;

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -4,7 +4,7 @@ export { Conversation } from "./Conversation";
 export type { MessageDeliveryStatus, MessageKind } from "./DecodedMessage";
 export { DecodedMessage } from "./DecodedMessage";
 export { Utils } from "./Utils";
-export { ApiUrls } from "./constants";
+export { ApiUrls, HistorySyncUrls } from "./constants";
 export type * from "./types";
 export * from "./utils/conversions";
 export {

--- a/sdks/browser-sdk/src/types/options.ts
+++ b/sdks/browser-sdk/src/types/options.ts
@@ -16,6 +16,18 @@ export type NetworkOptions = {
    * specific endpoint
    */
   apiUrl?: string;
+  /**
+   * historySyncUrl can be used to override the `env` flag and connect to a
+   * specific endpoint for syncing history
+   */
+  historySyncUrl?: string;
+};
+
+export type ContentOptions = {
+  /**
+   * Allow configuring codecs for additional content types
+   */
+  codecs?: ContentCodec[];
 };
 
 /**
@@ -26,13 +38,6 @@ export type StorageOptions = {
    * Path to the local DB
    */
   dbPath?: string;
-};
-
-export type ContentOptions = {
-  /**
-   * Allow configuring codecs for additional content types
-   */
-  codecs?: ContentCodec[];
 };
 
 export type OtherOptions = {
@@ -55,6 +60,6 @@ export type OtherOptions = {
 };
 
 export type ClientOptions = NetworkOptions &
-  StorageOptions &
   ContentOptions &
+  StorageOptions &
   OtherOptions;

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -4,7 +4,7 @@ import init, {
   getInboxIdForAddress,
   LogOptions,
 } from "@xmtp/wasm-bindings";
-import { ApiUrls } from "@/constants";
+import { ApiUrls, HistorySyncUrls } from "@/constants";
 import type { ClientOptions } from "@/types";
 
 export const createClient = async (
@@ -16,10 +16,6 @@ export const createClient = async (
   await init();
 
   const host = options?.apiUrl ?? ApiUrls[options?.env ?? "dev"];
-  // TODO: add db path validation
-  //       - must end with .db3
-  //       - must not contain invalid characters
-  //       - must not start with a dot
   const dbPath =
     options?.dbPath ?? `xmtp-${options?.env ?? "dev"}-${accountAddress}.db3`;
 
@@ -33,13 +29,16 @@ export const createClient = async (
       options.structuredLogging ||
       options.performanceLogging);
 
+  const historySyncUrl =
+    options?.historySyncUrl ?? HistorySyncUrls[options?.env ?? "dev"];
+
   return createWasmClient(
     host,
     inboxId,
     accountAddress,
     dbPath,
     encryptionKey,
-    undefined,
+    historySyncUrl,
     isLogging
       ? new LogOptions(
           options.structuredLogging ?? false,

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -35,6 +35,12 @@ export const ApiUrls = {
   production: "https://grpc.production.xmtp.network:443",
 } as const;
 
+export const HistorySyncUrls = {
+  local: "http://localhost:5558",
+  dev: "https://message-history.dev.ephemera.network",
+  production: "https://message-history.production.ephemera.network",
+} as const;
+
 export type XmtpEnv = keyof typeof ApiUrls;
 
 /**
@@ -50,6 +56,11 @@ export type NetworkOptions = {
    * specific endpoint
    */
   apiUrl?: string;
+  /**
+   * historySyncUrl can be used to override the `env` flag and connect to a
+   * specific endpoint for syncing history
+   */
+  historySyncUrl?: string;
 };
 
 /**
@@ -70,10 +81,6 @@ export type ContentOptions = {
 };
 
 export type OtherOptions = {
-  /**
-   * Optionally set the request history sync URL
-   */
-  requestHistorySync?: string;
   /**
    * Enable structured JSON logging
    */
@@ -132,6 +139,9 @@ export class Client {
       level: options?.loggingLevel ?? LogLevel.off,
     };
 
+    const historySyncUrl =
+      options?.historySyncUrl ?? HistorySyncUrls[options?.env ?? "dev"];
+
     const client = new Client(
       await createClient(
         host,
@@ -140,7 +150,7 @@ export class Client {
         inboxId,
         accountAddress,
         encryptionKey,
-        options?.requestHistorySync,
+        historySyncUrl,
         logOptions,
       ),
       signer,

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -5,7 +5,7 @@ export type {
   StorageOptions,
   XmtpEnv,
 } from "./Client";
-export { Client, ApiUrls } from "./Client";
+export { Client, ApiUrls, HistorySyncUrls } from "./Client";
 export { Conversation } from "./Conversation";
 export { Conversations } from "./Conversations";
 export { DecodedMessage } from "./DecodedMessage";


### PR DESCRIPTION
# Summary

- Automatically included history sync URLs when initializing clients 
- Exported history sync URLs for each environment
- Added `historySyncUrl` client option to override history sync URL