### PR TITLE
docs: fix minor typo TransactionReference.ts

### DIFF
--- a/content-types/content-type-transaction-reference/src/TransactionReference.ts
+++ b/content-types/content-type-transaction-reference/src/TransactionReference.ts
@@ -17,7 +17,7 @@ export type TransactionReference = {
    */
   namespace?: string;
   /**
-   * The networkId for the transaction, in decimal or hexidecimal format
+   * The networkId for the transaction, in decimal or hexadecimal format
    */
   networkId: number | string;
   /**


### PR DESCRIPTION
"hexidecimal" -> "hexadecimal"

The correct spelling is "hexadecimal" because it combines "hex" (six) and "decimal" (ten). The "i" in "hexidecimal" is incorrect.