### PR TITLE
Upgrade WASM bindings, add new methods

### DIFF
--- a/.changeset/khaki-files-call.md
+++ b/.changeset/khaki-files-call.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": patch
+---
+
+Upgrade WASM bindings, add new methods

--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -7,7 +7,7 @@ To keep up with the latest SDK developments, see the [Issues tab](https://githu
 To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
 
 > [!CAUTION]
-> This SDK is currently in alpha. The API is subject to change and it is not yet recommended for production use.
+> This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
 
 ## Requirements
 
@@ -79,8 +79,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   optimizeDeps: {
-    exclude: ["@xmtp/browser-sdk"],
-    include: ["@xmtp/proto"],
+    exclude: ["@xmtp/wasm-bindings"],
   },
 });
 ```

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
     "@xmtp/proto": "^3.72.3",
-    "@xmtp/wasm-bindings": "^0.0.14",
+    "@xmtp/wasm-bindings": "^0.0.16",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -310,6 +310,32 @@ export class Conversation {
     });
   }
 
+  async messageDisappearingSettings() {
+    return this.#client.sendMessage("getGroupMessageDisappearingSettings", {
+      id: this.#id,
+    });
+  }
+
+  async updateMessageDisappearingSettings(fromNs: bigint, inNs: bigint) {
+    return this.#client.sendMessage("updateGroupMessageDisappearingSettings", {
+      id: this.#id,
+      fromNs,
+      inNs,
+    });
+  }
+
+  async removeMessageDisappearingSettings() {
+    return this.#client.sendMessage("removeGroupMessageDisappearingSettings", {
+      id: this.#id,
+    });
+  }
+
+  async isMessageDisappearingEnabled() {
+    return this.#client.sendMessage("isGroupMessageDisappearingEnabled", {
+      id: this.#id,
+    });
+  }
+
   async stream(callback?: StreamCallback<DecodedMessage>) {
     const streamId = v4();
     const asyncStream = new AsyncStream<DecodedMessage>();

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -1,4 +1,4 @@
-import { ConversationType } from "@xmtp/wasm-bindings";
+import { ConversationType, type ConsentState } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
 import { AsyncStream, type StreamCallback } from "@/AsyncStream";
 import type { Client } from "@/Client";
@@ -6,6 +6,7 @@ import { Conversation } from "@/Conversation";
 import { DecodedMessage } from "@/DecodedMessage";
 import type {
   SafeConversation,
+  SafeCreateDmOptions,
   SafeCreateGroupOptions,
   SafeListConversationsOptions,
   SafeMessage,
@@ -22,8 +23,10 @@ export class Conversations {
     return this.#client.sendMessage("syncConversations", undefined);
   }
 
-  async syncAll() {
-    return this.#client.sendMessage("syncAllConversations", undefined);
+  async syncAll(consentStates?: ConsentState[]) {
+    return this.#client.sendMessage("syncAllConversations", {
+      consentStates,
+    });
   }
 
   async getConversationById(id: string) {
@@ -93,9 +96,31 @@ export class Conversations {
     return new Conversation(this.#client, conversation.id, conversation);
   }
 
-  async newDm(accountAddress: string) {
+  async newGroupByInboxIds(
+    inboxIds: string[],
+    options?: SafeCreateGroupOptions,
+  ) {
+    const conversation = await this.#client.sendMessage("newGroupByInboxIds", {
+      inboxIds,
+      options,
+    });
+
+    return new Conversation(this.#client, conversation.id, conversation);
+  }
+
+  async newDm(accountAddress: string, options?: SafeCreateDmOptions) {
     const conversation = await this.#client.sendMessage("newDm", {
       accountAddress,
+      options,
+    });
+
+    return new Conversation(this.#client, conversation.id, conversation);
+  }
+
+  async newDmByInboxId(inboxId: string, options?: SafeCreateDmOptions) {
+    const conversation = await this.#client.sendMessage("newDmByInboxId", {
+      inboxId,
+      options,
     });
 
     return new Conversation(this.#client, conversation.id, conversation);

--- a/sdks/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/browser-sdk/src/WorkerConversation.ts
@@ -1,12 +1,13 @@
-import type {
-  ConsentState,
-  Conversation,
-  EncodedContent,
-  GroupMember,
-  Message,
-  MetadataField,
-  PermissionPolicy,
-  PermissionUpdateType,
+import {
+  MessageDisappearingSettings,
+  type ConsentState,
+  type Conversation,
+  type EncodedContent,
+  type GroupMember,
+  type Message,
+  type MetadataField,
+  type PermissionPolicy,
+  type PermissionUpdateType,
 } from "@xmtp/wasm-bindings";
 import { type StreamCallback } from "@/AsyncStream";
 import {
@@ -180,6 +181,23 @@ export class WorkerConversation {
 
   dmPeerInboxId() {
     return this.#group.dmPeerInboxId();
+  }
+
+  messageDisappearingSettings() {
+    return this.#group.messageDisappearingSettings();
+  }
+
+  async updateMessageDisappearingSettings(fromNs: bigint, inNs: bigint) {
+    const settings = new MessageDisappearingSettings(fromNs, inNs);
+    return this.#group.updateMessageDisappearingSettings(settings);
+  }
+
+  async removeMessageDisappearingSettings() {
+    return this.#group.removeMessageDisappearingSettings();
+  }
+
+  isMessageDisappearingEnabled() {
+    return this.#group.isMessageDisappearingEnabled();
   }
 
   stream(callback?: StreamCallback<Message>) {

--- a/sdks/browser-sdk/src/WorkerConversations.ts
+++ b/sdks/browser-sdk/src/WorkerConversations.ts
@@ -1,14 +1,18 @@
 import {
   ConversationType,
+  type ConsentState,
   type Conversation,
+  type ConversationListItem,
   type Conversations,
   type Message,
 } from "@xmtp/wasm-bindings";
 import type { StreamCallback } from "@/AsyncStream";
 import {
+  fromSafeCreateDmOptions,
   fromSafeCreateGroupOptions,
   fromSafeListConversationsOptions,
   type HmacKeys,
+  type SafeCreateDmOptions,
   type SafeCreateGroupOptions,
   type SafeListConversationsOptions,
 } from "@/utils/conversions";
@@ -29,8 +33,8 @@ export class WorkerConversations {
     return this.#conversations.sync();
   }
 
-  async syncAll() {
-    return this.#conversations.syncAllConversations();
+  async syncAll(consentStates?: ConsentState[]) {
+    return this.#conversations.syncAllConversations(consentStates);
   }
 
   getConversationById(id: string) {
@@ -64,8 +68,10 @@ export class WorkerConversations {
   list(options?: SafeListConversationsOptions) {
     const groups = this.#conversations.list(
       options ? fromSafeListConversationsOptions(options) : undefined,
-    ) as Conversation[];
-    return groups.map((group) => new WorkerConversation(this.#client, group));
+    ) as ConversationListItem[];
+    return groups.map(
+      (item) => new WorkerConversation(this.#client, item.conversation),
+    );
   }
 
   listGroups(
@@ -73,15 +79,19 @@ export class WorkerConversations {
   ) {
     const groups = this.#conversations.listGroups(
       options ? fromSafeListConversationsOptions(options) : undefined,
-    ) as Conversation[];
-    return groups.map((group) => new WorkerConversation(this.#client, group));
+    ) as ConversationListItem[];
+    return groups.map(
+      (item) => new WorkerConversation(this.#client, item.conversation),
+    );
   }
 
   listDms(options?: Omit<SafeListConversationsOptions, "conversation_type">) {
     const groups = this.#conversations.listDms(
       options ? fromSafeListConversationsOptions(options) : undefined,
-    ) as Conversation[];
-    return groups.map((group) => new WorkerConversation(this.#client, group));
+    ) as ConversationListItem[];
+    return groups.map(
+      (item) => new WorkerConversation(this.#client, item.conversation),
+    );
   }
 
   async newGroup(accountAddresses: string[], options?: SafeCreateGroupOptions) {
@@ -92,8 +102,30 @@ export class WorkerConversations {
     return new WorkerConversation(this.#client, group);
   }
 
-  async newDm(accountAddress: string) {
-    const group = await this.#conversations.createDm(accountAddress);
+  async newGroupByInboxIds(
+    inboxIds: string[],
+    options?: SafeCreateGroupOptions,
+  ) {
+    const group = await this.#conversations.createGroupByInboxIds(
+      inboxIds,
+      options ? fromSafeCreateGroupOptions(options) : undefined,
+    );
+    return new WorkerConversation(this.#client, group);
+  }
+
+  async newDm(accountAddress: string, options?: SafeCreateDmOptions) {
+    const group = await this.#conversations.createDm(
+      accountAddress,
+      options ? fromSafeCreateDmOptions(options) : undefined,
+    );
+    return new WorkerConversation(this.#client, group);
+  }
+
+  async newDmByInboxId(inboxId: string, options?: SafeCreateDmOptions) {
+    const group = await this.#conversations.createDmByInboxId(
+      inboxId,
+      options ? fromSafeCreateDmOptions(options) : undefined,
+    );
     return new WorkerConversation(this.#client, group);
   }
 

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   SafeConsent,
   SafeConversation,
+  SafeCreateDmOptions,
   SafeCreateGroupOptions,
   SafeEncodedContent,
   SafeGroupMember,
@@ -28,6 +29,7 @@ import type {
   SafeListConversationsOptions,
   SafeListMessagesOptions,
   SafeMessage,
+  SafeMessageDisappearingSettings,
 } from "@/utils/conversions";
 
 export type ClientEvents =
@@ -270,11 +272,30 @@ export type ClientEvents =
       };
     }
   | {
+      action: "newGroupByInboxIds";
+      id: string;
+      result: SafeConversation;
+      data: {
+        inboxIds: string[];
+        options?: SafeCreateGroupOptions;
+      };
+    }
+  | {
       action: "newDm";
       id: string;
       result: SafeConversation;
       data: {
         accountAddress: string;
+        options?: SafeCreateDmOptions;
+      };
+    }
+  | {
+      action: "newDmByInboxId";
+      id: string;
+      result: SafeConversation;
+      data: {
+        inboxId: string;
+        options?: SafeCreateDmOptions;
       };
     }
   | {
@@ -287,7 +308,9 @@ export type ClientEvents =
       action: "syncAllConversations";
       id: string;
       result: undefined;
-      data: undefined;
+      data: {
+        consentStates?: ConsentState[];
+      };
     }
   | {
       action: "getHmacKeys";
@@ -540,6 +563,38 @@ export type ClientEvents =
       action: "getGroupPermissions";
       id: string;
       result: SafeConversation["permissions"];
+      data: {
+        id: string;
+      };
+    }
+  | {
+      action: "getGroupMessageDisappearingSettings";
+      id: string;
+      result: SafeMessageDisappearingSettings | undefined;
+      data: {
+        id: string;
+      };
+    }
+  | {
+      action: "updateGroupMessageDisappearingSettings";
+      id: string;
+      result: undefined;
+      data: SafeMessageDisappearingSettings & {
+        id: string;
+      };
+    }
+  | {
+      action: "removeGroupMessageDisappearingSettings";
+      id: string;
+      result: undefined;
+      data: {
+        id: string;
+      };
+    }
+  | {
+      action: "isGroupMessageDisappearingEnabled";
+      id: string;
+      result: boolean;
       data: {
         id: string;
       };

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -4,11 +4,13 @@ import {
 } from "@xmtp/content-type-primitives";
 import {
   Consent,
+  CreateDMOptions,
   CreateGroupOptions,
   GroupMember,
   GroupPermissionsOptions,
   ListConversationsOptions,
   ListMessagesOptions,
+  MessageDisappearingSettings,
   PermissionPolicySet,
   ContentTypeId as WasmContentTypeId,
   EncodedContent as WasmEncodedContent,
@@ -175,9 +177,12 @@ export const fromSafeListMessagesOptions = (
 
 export type SafeListConversationsOptions = {
   allowedStates?: GroupMembershipState[];
+  consentStates?: ConsentState[];
   conversationType?: ConversationType;
   createdAfterNs?: bigint;
   createdBeforeNs?: bigint;
+  includeDuplicateDms?: boolean;
+  includeSyncGroups?: boolean;
   limit?: bigint;
 };
 
@@ -185,9 +190,12 @@ export const toSafeListConversationsOptions = (
   options: ListConversationsOptions,
 ): SafeListConversationsOptions => ({
   allowedStates: options.allowedStates,
+  consentStates: options.consentStates,
   conversationType: options.conversationType,
   createdAfterNs: options.createdAfterNs,
   createdBeforeNs: options.createdBeforeNs,
+  includeDuplicateDms: options.includeDuplicateDms,
+  includeSyncGroups: options.includeSyncGroups,
   limit: options.limit,
 });
 
@@ -196,9 +204,12 @@ export const fromSafeListConversationsOptions = (
 ): ListConversationsOptions =>
   new ListConversationsOptions(
     options.allowedStates,
+    options.consentStates,
     options.conversationType,
     options.createdAfterNs,
     options.createdBeforeNs,
+    options.includeDuplicateDms ?? false,
+    options.includeSyncGroups ?? false,
     options.limit,
   );
 
@@ -244,6 +255,7 @@ export type SafeCreateGroupOptions = {
   customPermissionPolicySet?: SafePermissionPolicySet;
   description?: string;
   imageUrlSquare?: string;
+  messageDisappearingSettings?: SafeMessageDisappearingSettings;
   name?: string;
   permissions?: GroupPermissionsOptions;
 };
@@ -251,11 +263,14 @@ export type SafeCreateGroupOptions = {
 export const toSafeCreateGroupOptions = (
   options: CreateGroupOptions,
 ): SafeCreateGroupOptions => ({
+  customPermissionPolicySet: options.customPermissionPolicySet,
   description: options.groupDescription,
   imageUrlSquare: options.groupImageUrlSquare,
+  messageDisappearingSettings: options.messageDisappearingSettings
+    ? toSafeMessageDisappearingSettings(options.messageDisappearingSettings)
+    : undefined,
   name: options.groupName,
   permissions: options.permissions,
-  customPermissionPolicySet: options.customPermissionPolicySet,
 });
 
 export const fromSafeCreateGroupOptions = (
@@ -270,6 +285,30 @@ export const fromSafeCreateGroupOptions = (
     options.customPermissionPolicySet &&
     options.permissions === GroupPermissionsOptions.CustomPolicy
       ? fromSafePermissionPolicySet(options.customPermissionPolicySet)
+      : undefined,
+    options.messageDisappearingSettings
+      ? fromSafeMessageDisappearingSettings(options.messageDisappearingSettings)
+      : undefined,
+  );
+
+export type SafeCreateDmOptions = {
+  messageDisappearingSettings?: SafeMessageDisappearingSettings;
+};
+
+export const toSafeCreateDmOptions = (
+  options: CreateDMOptions,
+): SafeCreateDmOptions => ({
+  messageDisappearingSettings: options.messageDisappearingSettings
+    ? toSafeMessageDisappearingSettings(options.messageDisappearingSettings)
+    : undefined,
+});
+
+export const fromSafeCreateDmOptions = (
+  options: SafeCreateDmOptions,
+): CreateDMOptions =>
+  new CreateDMOptions(
+    options.messageDisappearingSettings
+      ? fromSafeMessageDisappearingSettings(options.messageDisappearingSettings)
       : undefined,
   );
 
@@ -427,3 +466,20 @@ export const toSafeHmacKey = (hmacKey: HmacKey): SafeHmacKey => ({
 
 export type HmacKeys = Map<string, HmacKey[]>;
 export type SafeHmacKeys = Record<string, SafeHmacKey[]>;
+
+export type SafeMessageDisappearingSettings = {
+  fromNs: bigint;
+  inNs: bigint;
+};
+
+export const toSafeMessageDisappearingSettings = (
+  settings: MessageDisappearingSettings,
+): SafeMessageDisappearingSettings => ({
+  fromNs: settings.fromNs,
+  inNs: settings.inNs,
+});
+
+export const fromSafeMessageDisappearingSettings = (
+  settings: SafeMessageDisappearingSettings,
+): MessageDisappearingSettings =>
+  new MessageDisappearingSettings(settings.fromNs, settings.inNs);

--- a/sdks/browser-sdk/test/Conversation.test.ts
+++ b/sdks/browser-sdk/test/Conversation.test.ts
@@ -15,7 +15,7 @@ import {
   TestCodec,
 } from "@test/helpers";
 
-describe.concurrent("Conversation", () => {
+describe("Conversation", () => {
   it("should update conversation name", async () => {
     const user1 = createUser();
     const user2 = createUser();
@@ -504,8 +504,8 @@ describe.concurrent("Conversation", () => {
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: SafeMessageDisappearingSettings = {
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     };
 
     // create a group with message disappearing settings
@@ -518,8 +518,8 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(await conversation.messageDisappearingSettings()).toEqual({
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     });
     expect(await conversation.isMessageDisappearingEnabled()).toBe(true);
 
@@ -539,13 +539,13 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(await conversation2!.messageDisappearingSettings()).toEqual({
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     });
     expect(await conversation2!.isMessageDisappearingEnabled()).toBe(true);
 
     // wait for the messages to be deleted
-    await sleep(2000);
+    await sleep(5000);
 
     // verify that the messages are deleted
     expect((await conversation.messages()).length).toBe(1);
@@ -596,8 +596,8 @@ describe.concurrent("Conversation", () => {
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: SafeMessageDisappearingSettings = {
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     };
 
     // create a group with message disappearing settings
@@ -610,8 +610,8 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(await conversation.messageDisappearingSettings()).toEqual({
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     });
     expect(await conversation.isMessageDisappearingEnabled()).toBe(true);
 
@@ -631,13 +631,13 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(await conversation2!.messageDisappearingSettings()).toEqual({
-      fromNs: 1_000_000n,
-      inNs: 1_000_000n,
+      fromNs: 5_000_000n,
+      inNs: 5_000_000n,
     });
     expect(await conversation2!.isMessageDisappearingEnabled()).toBe(true);
 
     // wait for the messages to be deleted
-    await sleep(2000);
+    await sleep(5000);
 
     // verify that the messages are deleted
     expect((await conversation.messages()).length).toBe(1);

--- a/sdks/browser-sdk/test/helpers.ts
+++ b/sdks/browser-sdk/test/helpers.ts
@@ -13,6 +13,9 @@ import type { Signer } from "@/utils/signer";
 
 const testEncryptionKey = window.crypto.getRandomValues(new Uint8Array(32));
 
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export const createUser = () => {
   const key = generatePrivateKey();
   const account = privateKeyToAccount(key);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4878,7 +4878,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
     "@xmtp/proto": "npm:^3.72.3"
-    "@xmtp/wasm-bindings": "npm:^0.0.14"
+    "@xmtp/wasm-bindings": "npm:^0.0.16"
     playwright: "npm:^1.49.1"
     rollup: "npm:^4.30.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -5309,10 +5309,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^0.0.14":
-  version: 0.0.14
-  resolution: "@xmtp/wasm-bindings@npm:0.0.14"
-  checksum: 10/dbc8b691e211d635a6d8cb6983ee3e08397ef9b3673a4c8b83cb1ebe1f500c4c14afc5661e6c1b71b4d412a5d50703028691c52a11d640d006a60c46b5763411
+"@xmtp/wasm-bindings@npm:^0.0.16":
+  version: 0.0.16
+  resolution: "@xmtp/wasm-bindings@npm:0.0.16"
+  checksum: 10/46138b8a58a3bf41a40fdfa61be0698afa5cf77e39a267accadf9353d80caaf1a5773d6ddc3d33c5c66122d2781b14763634f9d1bdb8a81b4225fb57246eacaa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Added `allowedStates`, `consentStates`, `includeSyncGroups`, and `includeDuplicateDms` options to `Conversations.list` method
- Added `consentStates` option to `Conversations.syncAll` method
- Added `newGroupByInboxIds` method to `Conversations`
- Added `newDmByInboxId` method to `Conversations`
- Added `messageDisappearingSettings` option for creating groups and DMs
- Added `updateMessageDisappearingSettings` method to `Conversation`
- Added `removeMessageDisappearingSettings` method to `Conversation`
- Added `isMessageDisappearingEnabled` method to `Conversation`
- Fixed invalid key package issues
- Fixed rate limiting issues
- Updated README