### PR TITLE
Make getBlockNumber optional for SCWs

### DIFF
--- a/.changeset/sharp-boxes-brush.md
+++ b/.changeset/sharp-boxes-brush.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Make getBlockNumber optional for SCWs

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -247,7 +247,7 @@ export class Client {
         signatureType,
         signature,
         signer.getChainId(),
-        signer.getBlockNumber(),
+        signer.getBlockNumber?.(),
       );
     } else {
       await this.#innerClient.addSignature(signatureType, signature);

--- a/sdks/node-sdk/src/helpers/signer.ts
+++ b/sdks/node-sdk/src/helpers/signer.ts
@@ -13,6 +13,6 @@ export type Signer =
       walletType: "SCW";
       getAddress: GetAddress;
       signMessage: SignMessage;
-      getBlockNumber: GetBlockNumber;
+      getBlockNumber?: GetBlockNumber;
       getChainId: GetChainId;
     };


### PR DESCRIPTION
# Summary

- Removed `getBlockNumber` requirement for smart contract wallet signers

Closes #843 