### PR TITLE
Refactor Signer (Browser SDK)

### DIFF
--- a/.changeset/little-pumas-wave.md
+++ b/.changeset/little-pumas-wave.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": patch
+---
+
+Refactor Signer

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -21,7 +21,7 @@ import {
   type SafeConsent,
   type SafeMessage,
 } from "@/utils/conversions";
-import { isSmartContractSigner, type Signer } from "@/utils/signer";
+import { type Signer } from "@/utils/signer";
 
 export class Client extends ClientWorkerClass {
   #accountAddress: string;
@@ -146,12 +146,12 @@ export class Client extends ClientWorkerClass {
   ) {
     const signature = await signer.signMessage(signatureText);
 
-    if (isSmartContractSigner(signer)) {
+    if (signer.walletType === "SCW") {
       await this.sendMessage("addScwSignature", {
         type: signatureType,
         bytes: signature,
         chainId: signer.getChainId(),
-        blockNumber: signer.getBlockNumber(),
+        blockNumber: signer.getBlockNumber?.(),
       });
     } else {
       await this.sendMessage("addSignature", {
@@ -264,6 +264,7 @@ export class Client extends ClientWorkerClass {
   static async canMessage(accountAddresses: string[], env?: XmtpEnv) {
     const accountAddress = "0x0000000000000000000000000000000000000000";
     const signer: Signer = {
+      walletType: "EOA",
       getAddress: () => accountAddress,
       signMessage: () => new Uint8Array(),
     };

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -36,8 +36,4 @@ export {
   ContentTypeId,
   HmacKey,
 } from "@xmtp/wasm-bindings";
-export {
-  isSmartContractSigner,
-  type Signer,
-  type SmartContractSigner,
-} from "./utils/signer";
+export type { Signer } from "./utils/signer";

--- a/sdks/browser-sdk/src/utils/signer.ts
+++ b/sdks/browser-sdk/src/utils/signer.ts
@@ -2,18 +2,17 @@ export type SignMessage = (message: string) => Promise<Uint8Array> | Uint8Array;
 export type GetAddress = () => Promise<string> | string;
 export type GetChainId = () => bigint;
 export type GetBlockNumber = () => bigint;
-export type WalletType = () => "EOA" | "SCW";
 
-export type Signer = {
-  getAddress: GetAddress;
-  signMessage: SignMessage;
-  walletType?: WalletType;
-  getBlockNumber?: GetBlockNumber;
-  getChainId?: GetChainId;
-};
-
-export type SmartContractSigner = Required<Signer>;
-
-export const isSmartContractSigner = (
-  signer: Signer,
-): signer is SmartContractSigner => signer.walletType?.() === "SCW";
+export type Signer =
+  | {
+      walletType: "EOA";
+      getAddress: GetAddress;
+      signMessage: SignMessage;
+    }
+  | {
+      walletType: "SCW";
+      getAddress: GetAddress;
+      signMessage: SignMessage;
+      getBlockNumber?: GetBlockNumber;
+      getChainId: GetChainId;
+    };

--- a/sdks/browser-sdk/test/helpers.ts
+++ b/sdks/browser-sdk/test/helpers.ts
@@ -33,6 +33,7 @@ export const createUser = () => {
 
 export const createSigner = (user: User): Signer => {
   return {
+    walletType: "EOA",
     getAddress: () => user.account.address,
     signMessage: async (message: string) => {
       const signature = await user.wallet.signMessage({


### PR DESCRIPTION
# Summary

- Refactored `Signer`
  - Changed `walletType` type to `string`
  - Made `getBlockNumber` optional for `SCW` wallet type