### PR TITLE
Update Node + Browser SDKs

### DIFF
--- a/apps/xmtp.chat/vite.config.ts
+++ b/apps/xmtp.chat/vite.config.ts
@@ -8,10 +8,4 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ["@xmtp/wasm-bindings"],
   },
-  server: {
-    headers: {
-      "Cross-Origin-Embedder-Policy": "require-corp",
-      "Cross-Origin-Opener-Policy": "same-origin",
-    },
-  },
 });

--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -9,62 +9,11 @@ To learn more about XMTP and get answers to frequently asked questions, see theÂ
 > [!CAUTION]
 > This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
 
-## Requirements
+## Limitations
 
-### Response headers
+This SDK uses the [origin private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) (OPFS) to persist a SQLite database and the [SyncAccessHandle Pool VFS](https://sqlite.org/wasm/doc/trunk/persistence.md#vfs-opfs-sahpool) to access it. This VFS does not support multiple simultaneous connections.
 
-Server response headers must be set to the following values:
-
-- `Cross-Origin-Embedder-Policy: require-corp`
-- `Cross-Origin-Opener-Policy: same-origin`
-
-#### Vite
-
-Add the following to `vite.config.ts`:
-
-```typescript
-import { defineConfig } from "vite";
-
-export default defineConfig({
-  server: {
-    headers: {
-      "Cross-Origin-Embedder-Policy": "require-corp",
-      "Cross-Origin-Opener-Policy": "same-origin",
-    },
-  },
-});
-```
-
-#### Next.js
-
-Add the following to `next.config.ts`:
-
-```typescript
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  async headers() {
-    return [
-      {
-        // adjust ":path*" as needed
-        source: "/:path*",
-        headers: [
-          {
-            key: "Cross-Origin-Embedder-Policy",
-            value: "require-corp",
-          },
-          {
-            key: "Cross-Origin-Opener-Policy",
-            value: "same-origin",
-          },
-        ],
-      },
-    ];
-  },
-};
-
-export default nextConfig;
-```
+This means that when using this SDK in your application, you must prevent multiple browser tabs or windows from accessing your application at the same time.
 
 ### Bundlers
 

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
     "@xmtp/proto": "^3.72.3",
-    "@xmtp/wasm-bindings": "^0.0.16",
+    "@xmtp/wasm-bindings": "^0.0.19",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/src/WorkerConversations.ts
+++ b/sdks/browser-sdk/src/WorkerConversations.ts
@@ -1,10 +1,12 @@
 import {
   ConversationType,
+  type Consent,
   type ConsentState,
   type Conversation,
   type ConversationListItem,
   type Conversations,
   type Message,
+  type UserPreference,
 } from "@xmtp/wasm-bindings";
 import type { StreamCallback } from "@/AsyncStream";
 import {
@@ -171,5 +173,28 @@ export class WorkerConversations {
       { on_message, on_error },
       conversationType,
     );
+  }
+
+  streamConsent(callback?: StreamCallback<Consent[]>) {
+    const on_consent_update = (consent: Consent[]) => {
+      void callback?.(null, consent);
+    };
+    const on_error = (error: Error | null) => {
+      void callback?.(error, undefined);
+    };
+    return this.#conversations.streamConsent({ on_consent_update, on_error });
+  }
+
+  streamPreferences(callback?: StreamCallback<UserPreference[]>) {
+    const on_user_preference_update = (preferences: UserPreference[]) => {
+      void callback?.(null, preferences);
+    };
+    const on_error = (error: Error | null) => {
+      void callback?.(error, undefined);
+    };
+    return this.#conversations.streamPreferences({
+      on_user_preference_update,
+      on_error,
+    });
   }
 }

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -7,24 +7,33 @@ export { Utils } from "./Utils";
 export { ApiUrls, HistorySyncUrls } from "./constants";
 export type * from "./types";
 export * from "./utils/conversions";
+export type { UserPreference } from "@xmtp/wasm-bindings";
 export {
+  Consent,
   ConsentEntityType,
   ConsentState,
+  ContentType,
+  ContentTypeId,
+  ConversationListItem,
   ConversationType,
+  CreateDMOptions,
   CreateGroupOptions,
   DeliveryStatus,
-  GroupMembershipState,
   EncodedContent,
   GroupMember,
+  GroupMembershipState,
+  GroupMessageKind,
   GroupMetadata,
   GroupPermissions,
-  GroupMessageKind,
   GroupPermissionsOptions,
+  HmacKey,
   InboxState,
   Installation,
   ListConversationsOptions,
   ListMessagesOptions,
+  LogOptions,
   Message,
+  MessageDisappearingSettings,
   MetadataField,
   PermissionLevel,
   PermissionPolicy,
@@ -32,8 +41,5 @@ export {
   PermissionUpdateType,
   SignatureRequestType,
   SortDirection,
-  Consent,
-  ContentTypeId,
-  HmacKey,
 } from "@xmtp/wasm-bindings";
 export type { Signer } from "./utils/signer";

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -336,6 +336,22 @@ export type ClientEvents =
         conversationType?: ConversationType;
       };
     }
+  | {
+      action: "streamConsent";
+      id: string;
+      result: undefined;
+      data: {
+        streamId: string;
+      };
+    }
+  | {
+      action: "streamPreferences";
+      id: string;
+      result: undefined;
+      data: {
+        streamId: string;
+      };
+    }
   /**
    * Group actions
    */

--- a/sdks/browser-sdk/src/types/clientStreamEvents.ts
+++ b/sdks/browser-sdk/src/types/clientStreamEvents.ts
@@ -1,9 +1,14 @@
+import type { UserPreference } from "@xmtp/wasm-bindings";
 import type {
   StreamEventsClientPostMessageData,
   StreamEventsErrorData,
   StreamEventsResult,
 } from "@/types";
-import type { SafeConversation, SafeMessage } from "@/utils/conversions";
+import type {
+  SafeConsent,
+  SafeConversation,
+  SafeMessage,
+} from "@/utils/conversions";
 
 export type ClientStreamEvents =
   | {
@@ -15,6 +20,16 @@ export type ClientStreamEvents =
       type: "group";
       streamId: string;
       result: SafeConversation | undefined;
+    }
+  | {
+      type: "consent";
+      streamId: string;
+      result: SafeConsent[] | undefined;
+    }
+  | {
+      type: "preferences";
+      streamId: string;
+      result: UserPreference[] | undefined;
     };
 
 export type ClientStreamEventsTypes = ClientStreamEvents["type"];

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -16,9 +16,7 @@ import {
   EncodedContent as WasmEncodedContent,
   type ConsentEntityType,
   type ConsentState,
-  type ConversationType,
   type DeliveryStatus,
-  type GroupMembershipState,
   type GroupMessageKind,
   type HmacKey,
   type InboxState,
@@ -176,26 +174,20 @@ export const fromSafeListMessagesOptions = (
   );
 
 export type SafeListConversationsOptions = {
-  allowedStates?: GroupMembershipState[];
   consentStates?: ConsentState[];
-  conversationType?: ConversationType;
   createdAfterNs?: bigint;
   createdBeforeNs?: bigint;
   includeDuplicateDms?: boolean;
-  includeSyncGroups?: boolean;
   limit?: bigint;
 };
 
 export const toSafeListConversationsOptions = (
   options: ListConversationsOptions,
 ): SafeListConversationsOptions => ({
-  allowedStates: options.allowedStates,
   consentStates: options.consentStates,
-  conversationType: options.conversationType,
   createdAfterNs: options.createdAfterNs,
   createdBeforeNs: options.createdBeforeNs,
   includeDuplicateDms: options.includeDuplicateDms,
-  includeSyncGroups: options.includeSyncGroups,
   limit: options.limit,
 });
 
@@ -203,13 +195,10 @@ export const fromSafeListConversationsOptions = (
   options: SafeListConversationsOptions,
 ): ListConversationsOptions =>
   new ListConversationsOptions(
-    options.allowedStates,
     options.consentStates,
-    options.conversationType,
     options.createdAfterNs,
     options.createdBeforeNs,
     options.includeDuplicateDms ?? false,
-    options.includeSyncGroups ?? false,
     options.limit,
   );
 

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -16,6 +16,7 @@ import {
   EncodedContent as WasmEncodedContent,
   type ConsentEntityType,
   type ConsentState,
+  type ContentType,
   type DeliveryStatus,
   type GroupMessageKind,
   type HmacKey,
@@ -145,6 +146,7 @@ export const toSafeMessage = (message: Message): SafeMessage => ({
 });
 
 export type SafeListMessagesOptions = {
+  contentTypes?: ContentType[];
   deliveryStatus?: DeliveryStatus;
   direction?: SortDirection;
   limit?: bigint;
@@ -155,6 +157,7 @@ export type SafeListMessagesOptions = {
 export const toSafeListMessagesOptions = (
   options: ListMessagesOptions,
 ): SafeListMessagesOptions => ({
+  contentTypes: options.contentTypes,
   deliveryStatus: options.deliveryStatus,
   direction: options.direction,
   limit: options.limit,
@@ -171,6 +174,7 @@ export const fromSafeListMessagesOptions = (
     options.limit,
     options.deliveryStatus,
     options.direction,
+    options.contentTypes,
   );
 
 export type SafeListConversationsOptions = {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.0",
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
-    "@xmtp/node-bindings": "^0.0.38",
+    "@xmtp/node-bindings": "^0.0.39",
     "@xmtp/proto": "^3.72.3"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -13,18 +13,22 @@ export { DecodedMessage } from "./DecodedMessage";
 export type { StreamCallback } from "./AsyncStream";
 export type {
   Consent,
+  ContentType,
   ContentTypeId,
+  ConversationListItem,
+  CreateDmOptions,
   CreateGroupOptions,
   EncodedContent,
+  HmacKey,
   InboxState,
   Installation,
   ListConversationsOptions,
   ListMessagesOptions,
   LogOptions,
   Message,
+  MessageDisappearingSettings,
   PermissionPolicySet,
 } from "@xmtp/node-bindings";
-export type { HmacKey } from "@xmtp/node-bindings";
 export {
   ConsentEntityType,
   ConsentState,

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -486,8 +486,8 @@ describe.concurrent("Conversation", () => {
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: MessageDisappearingSettings = {
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     };
 
     // create a group with message disappearing settings
@@ -500,8 +500,8 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(conversation.messageDisappearingSettings()).toEqual({
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     });
     expect(conversation.isMessageDisappearingEnabled()).toBe(true);
 
@@ -521,13 +521,13 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(conversation2!.messageDisappearingSettings()).toEqual({
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     });
     expect(conversation2!.isMessageDisappearingEnabled()).toBe(true);
 
     // wait for the messages to be deleted
-    await sleep(3000);
+    await sleep(10000);
 
     // verify that the messages are deleted
     expect((await conversation.messages()).length).toBe(1);
@@ -578,8 +578,8 @@ describe.concurrent("Conversation", () => {
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: MessageDisappearingSettings = {
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     };
 
     // create a group with message disappearing settings
@@ -592,8 +592,8 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(conversation.messageDisappearingSettings()).toEqual({
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     });
     expect(conversation.isMessageDisappearingEnabled()).toBe(true);
 
@@ -613,13 +613,13 @@ describe.concurrent("Conversation", () => {
 
     // verify that the message disappearing settings are set and enabled
     expect(conversation2!.messageDisappearingSettings()).toEqual({
-      fromNs: 2_000_000,
-      inNs: 2_000_000,
+      fromNs: 10_000_000,
+      inNs: 10_000_000,
     });
     expect(conversation2!.isMessageDisappearingEnabled()).toBe(true);
 
     // wait for the messages to be deleted
-    await sleep(3000);
+    await sleep(10000);
 
     // verify that the messages are deleted
     expect((await conversation.messages()).length).toBe(1);

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -385,18 +385,26 @@ describe.concurrent("Conversations", () => {
     const conversation2 = await client2.conversations.newGroup([
       user3.account.address,
     ]);
+
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
     let count = 0;
     for await (const convo of stream) {
+      if (convo === undefined) {
+        break;
+      }
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
-        expect(convo!.id).toBe(conversation1.id);
+        expect(convo.id).toBe(conversation1.id);
       }
       if (count === 2) {
-        expect(convo!.id).toBe(conversation2.id);
-        break;
+        expect(convo.id).toBe(conversation2.id);
       }
     }
+    expect(count).toBe(2);
     expect(
       client3.conversations.getConversationById(conversation1.id)?.id,
     ).toBe(conversation1.id);
@@ -422,18 +430,26 @@ describe.concurrent("Conversations", () => {
     const group2 = await client2.conversations.newGroup([
       user3.account.address,
     ]);
+
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
     let count = 0;
     for await (const convo of stream) {
+      if (convo === undefined) {
+        break;
+      }
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
-        expect(convo!.id).toBe(group1.id);
+        expect(convo.id).toBe(group1.id);
       }
       if (count === 2) {
-        expect(convo!.id).toBe(group2.id);
-        break;
+        expect(convo.id).toBe(group2.id);
       }
     }
+    expect(count).toBe(2);
   });
 
   it("should only stream dm conversations", async () => {
@@ -449,13 +465,20 @@ describe.concurrent("Conversations", () => {
     await client1.conversations.newGroup([user3.account.address]);
     await client2.conversations.newGroup([user3.account.address]);
     const group3 = await client4.conversations.newDm(user3.account.address);
+
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
     let count = 0;
     for await (const convo of stream) {
+      if (convo === undefined) {
+        break;
+      }
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
-        expect(convo!.id).toBe(group3.id);
-        break;
+        expect(convo.id).toBe(group3.id);
       }
     }
     expect(count).toBe(1);
@@ -482,19 +505,25 @@ describe.concurrent("Conversations", () => {
     await groups2[0].send("gm!");
     await groups3[0].send("gm2!");
 
-    let count = 0;
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
 
+    let count = 0;
     for await (const message of stream) {
+      if (message === undefined) {
+        break;
+      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
-        expect(message!.senderInboxId).toBe(client2.inboxId);
+        expect(message.senderInboxId).toBe(client2.inboxId);
       }
       if (count === 2) {
-        expect(message!.senderInboxId).toBe(client3.inboxId);
-        break;
+        expect(message.senderInboxId).toBe(client3.inboxId);
       }
     }
+    expect(count).toBe(2);
   });
 
   it("should only stream group conversation messages", async () => {
@@ -528,19 +557,25 @@ describe.concurrent("Conversations", () => {
     await groupsList2[0].send("gm!");
     await groupsList3[0].send("gm2!");
 
-    let count = 0;
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
 
+    let count = 0;
     for await (const message of stream) {
+      if (message === undefined) {
+        break;
+      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
-        expect(message!.senderInboxId).toBe(client2.inboxId);
+        expect(message.senderInboxId).toBe(client2.inboxId);
       }
       if (count === 2) {
-        expect(message!.senderInboxId).toBe(client3.inboxId);
-        break;
+        expect(message.senderInboxId).toBe(client3.inboxId);
       }
     }
+    expect(count).toBe(2);
   });
 
   it("should only stream dm messages", async () => {
@@ -574,15 +609,21 @@ describe.concurrent("Conversations", () => {
     await groupsList3[0].send("gm2!");
     await groupsList4[0].send("gm3!");
 
-    let count = 0;
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
 
+    let count = 0;
     for await (const message of stream) {
+      if (message === undefined) {
+        break;
+      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
-        expect(message!.senderInboxId).toBe(client4.inboxId);
-        break;
+        expect(message.senderInboxId).toBe(client4.inboxId);
       }
+      expect(count).toBe(1);
     }
   });
 
@@ -667,33 +708,40 @@ describe.concurrent("Conversations", () => {
       },
     ]);
 
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
     let count = 0;
     for await (const updates of stream) {
-      count++;
-      expect(updates).toBeDefined();
-      if (count === 1) {
-        expect(updates!.length).toBe(1);
-        expect(updates![0].state).toBe(ConsentState.Denied);
-        expect(updates![0].entity).toBe(group.id);
-        expect(updates![0].entityType).toBe(ConsentEntityType.GroupId);
-        break;
-      } else if (count === 2) {
-        expect(updates!.length).toBe(1);
-        expect(updates![0].state).toBe(ConsentState.Allowed);
-        expect(updates![0].entity).toBe(group.id);
-        expect(updates![0].entityType).toBe(ConsentEntityType.GroupId);
-        break;
-      } else if (count === 3) {
-        expect(updates!.length).toBe(2);
-        expect(updates![0].state).toBe(ConsentState.Denied);
-        expect(updates![0].entity).toBe(user2.account.address);
-        expect(updates![0].entityType).toBe(ConsentEntityType.Address);
-        expect(updates![1].state).toBe(ConsentState.Allowed);
-        expect(updates![1].entity).toBe(client2.inboxId);
-        expect(updates![1].entityType).toBe(ConsentEntityType.InboxId);
+      if (updates === undefined) {
         break;
       }
+      count++;
+      if (count === 1) {
+        expect(updates.length).toBe(1);
+        expect(updates[0].state).toBe(ConsentState.Denied);
+        expect(updates[0].entity).toBe(group.id);
+        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+      } else if (count === 2) {
+        expect(updates.length).toBe(1);
+        expect(updates[0].state).toBe(ConsentState.Allowed);
+        expect(updates[0].entity).toBe(group.id);
+        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+      } else if (count === 3) {
+        expect(updates.length).toBe(3);
+        expect(updates[0].state).toBe(ConsentState.Denied);
+        expect(updates[0].entity).toBe(client2.inboxId);
+        expect(updates[0].entityType).toBe(ConsentEntityType.InboxId);
+        expect(updates[1].state).toBe(ConsentState.Denied);
+        expect(updates[1].entity).toBe(user2.account.address);
+        expect(updates[1].entityType).toBe(ConsentEntityType.Address);
+        expect(updates[2].state).toBe(ConsentState.Allowed);
+        expect(updates[2].entity).toBe(client2.inboxId);
+        expect(updates[2].entityType).toBe(ConsentEntityType.InboxId);
+      }
     }
+    expect(count).toBe(3);
   });
 
   it("should stream preferences", async () => {
@@ -716,18 +764,21 @@ describe.concurrent("Conversations", () => {
     await client2.conversations.syncAll();
     await sleep(2000);
 
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
     let count = 0;
     for await (const preferences of stream) {
-      count++;
-      expect(preferences).toBeDefined();
-      expect(preferences?.type).toBeDefined();
-      expect(preferences?.HmacKeyUpdate).toBeDefined();
-      expect(preferences?.HmacKeyUpdate?.key).toBeDefined();
-
-      if (count === 2) {
+      if (preferences === undefined) {
         break;
       }
+      count++;
+      expect(preferences).toBeDefined();
+      expect(preferences.type).toBeDefined();
+      expect(preferences.HmacKeyUpdate).toBeDefined();
+      expect(preferences.HmacKeyUpdate?.key).toBeDefined();
     }
-    expect(count).toBe(2);
+    expect(count).toBe(3);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,7 +4864,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
     "@xmtp/proto": "npm:^3.72.3"
-    "@xmtp/wasm-bindings": "npm:^0.0.16"
+    "@xmtp/wasm-bindings": "npm:^0.0.19"
     playwright: "npm:^1.49.1"
     rollup: "npm:^4.30.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -5288,10 +5288,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^0.0.16":
-  version: 0.0.16
-  resolution: "@xmtp/wasm-bindings@npm:0.0.16"
-  checksum: 10/46138b8a58a3bf41a40fdfa61be0698afa5cf77e39a267accadf9353d80caaf1a5773d6ddc3d33c5c66122d2781b14763634f9d1bdb8a81b4225fb57246eacaa
+"@xmtp/wasm-bindings@npm:^0.0.19":
+  version: 0.0.19
+  resolution: "@xmtp/wasm-bindings@npm:0.0.19"
+  checksum: 10/ebb2717a557c522c1026207651e8ffa84e756c78076042e0b6f48b0eb4c4ad86f6117bad194576dee6187fa2fddd611de04ad1e8c9f604d1e6dde6b9974e2f27
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5169,10 +5169,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^0.0.38":
-  version: 0.0.38
-  resolution: "@xmtp/node-bindings@npm:0.0.38"
-  checksum: 10/a9452a913cdda5cd050b91ed34358b8975524d1c5e6434db51b1d60f13a29069b531ee566811ab4ed339713ad0e041e83f24fc916684c968c322ba63f21319f3
+"@xmtp/node-bindings@npm:^0.0.39":
+  version: 0.0.39
+  resolution: "@xmtp/node-bindings@npm:0.0.39"
+  checksum: 10/d3125a10a2116c5a194b3999837ca805e6f7702167df8fdbf2d5461319eb8ccf07113f34826dadbb2681278c5193fda14eaeaf55fa1c93fb1adfce754bbe688d
   languageName: node
   linkType: hard
 
@@ -5200,7 +5200,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.0"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
-    "@xmtp/node-bindings": "npm:^0.0.38"
+    "@xmtp/node-bindings": "npm:^0.0.39"
     "@xmtp/proto": "npm:^3.72.3"
     "@xmtp/xmtp-js": "workspace:^"
     fast-glob: "npm:^3.3.3"


### PR DESCRIPTION
# Summary

### Browser SDK

- Added consent and preference streaming
- Removed `allowed_states`, `conversation_type`, and `include_sync_groups` from `ListConversationsOptions`
- Added `contentTypes` option to `ListMessagesOptions`
- Changed OPFS VFS to `SyncAccessHandle Pool`
- Added more exports from the bindings

### Node SDK

- Removed `allowed_states`, `conversation_type`, and `include_sync_groups` from `ListConversationsOptions`
- Added `contentTypes` option to `ListMessagesOptions`
- Added more exports from the bindings

Once again, there's no release at this time, but will soon follow.