### PR TITLE
Upgrade bindings, fix Node SDK build

### DIFF
--- a/.changeset/rude-papayas-design.md
+++ b/.changeset/rude-papayas-design.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Upgrade bindings, fix Node SDK build

--- a/content-types/content-type-group-updated/package.json
+++ b/content-types/content-type-group-updated/package.json
@@ -75,7 +75,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-primitives/package.json
+++ b/content-types/content-type-primitives/package.json
@@ -72,7 +72,7 @@
     "@types/node": "^22.10.6",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-reaction/package.json
+++ b/content-types/content-type-reaction/package.json
@@ -75,7 +75,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-read-receipt/package.json
+++ b/content-types/content-type-read-receipt/package.json
@@ -75,7 +75,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-remote-attachment/package.json
+++ b/content-types/content-type-remote-attachment/package.json
@@ -78,7 +78,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-reply/package.json
+++ b/content-types/content-type-reply/package.json
@@ -77,7 +77,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-text/package.json
+++ b/content-types/content-type-text/package.json
@@ -75,7 +75,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/content-types/content-type-transaction-reference/package.json
+++ b/content-types/content-type-transaction-reference/package.json
@@ -75,7 +75,7 @@
     "ethers": "^6.11.1",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "typescript": "^5.7.3",

--- a/packages/consent-proof-signature/package.json
+++ b/packages/consent-proof-signature/package.json
@@ -69,7 +69,7 @@
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^12.1.2",
     "ethers": "^6.13.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "tsconfig": "workspace:*",

--- a/packages/frames-client/package.json
+++ b/packages/frames-client/package.json
@@ -75,7 +75,7 @@
     "@xmtp/xmtp-js": "^12.0.0",
     "ethers": "^6.13.1",
     "fast-glob": "^3.3.3",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",

--- a/packages/frames-validator/package.json
+++ b/packages/frames-validator/package.json
@@ -51,7 +51,7 @@
     "@xmtp/xmtp-js": "^12.1.0",
     "ethers": "^6.10.0",
     "fast-glob": "^3.3.3",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "typescript": "^5.7.3",
     "vitest": "^2.1.3"

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -77,7 +77,7 @@
     "@vitest/coverage-v8": "^2.0.3",
     "@web/rollup-plugin-copy": "^0.5.1",
     "playwright": "^1.49.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
     "@xmtp/proto": "^3.72.3",
-    "@xmtp/wasm-bindings": "^0.0.19",
+    "@xmtp/wasm-bindings": "^0.0.21",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/sdks/js-sdk/package.json
+++ b/sdks/js-sdk/package.json
@@ -119,7 +119,7 @@
     "ethers": "^5.7.2",
     "happy-dom": "^16.6.0",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.0",
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
-    "@xmtp/node-bindings": "^0.0.39",
+    "@xmtp/node-bindings": "^0.0.41",
     "@xmtp/proto": "^3.72.3"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/xmtp-js": "workspace:^",
     "fast-glob": "^3.3.3",
     "rimraf": "^6.0.1",
-    "rollup": "^4.30.1",
+    "rollup": "^4.34.9",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-filesize": "^10.0.0",
     "rollup-plugin-tsconfig-paths": "^1.5.2",

--- a/sdks/node-sdk/rollup.config.js
+++ b/sdks/node-sdk/rollup.config.js
@@ -12,8 +12,8 @@ const external = [
   "@xmtp/content-type-primitives",
   "@xmtp/content-type-text",
   "@xmtp/node-bindings",
+  "@xmtp/node-bindings/version.json",
   "@xmtp/proto",
-  "@xmtp/xmtp-js",
 ];
 
 const plugins = [
@@ -37,6 +37,7 @@ export default defineConfig([
       file: "dist/index.js",
       format: "es",
       sourcemap: true,
+      importAttributesKey: "with",
     },
     plugins,
     external,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3071,9 +3071,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.30.1"
+"@rollup/rollup-android-arm-eabi@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.34.9"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
@@ -3092,9 +3092,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.30.1"
+"@rollup/rollup-android-arm64@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-android-arm64@npm:4.34.9"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -3113,9 +3113,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.30.1"
+"@rollup/rollup-darwin-arm64@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.34.9"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -3134,9 +3134,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.30.1"
+"@rollup/rollup-darwin-x64@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-darwin-x64@npm:4.34.9"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3148,9 +3148,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.30.1"
+"@rollup/rollup-freebsd-arm64@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.34.9"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -3162,9 +3162,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.30.1"
+"@rollup/rollup-freebsd-x64@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.34.9"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -3183,9 +3183,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.30.1"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.34.9"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
@@ -3204,9 +3204,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.30.1"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.34.9"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
@@ -3225,9 +3225,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.30.1"
+"@rollup/rollup-linux-arm64-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.34.9"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3246,16 +3246,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.30.1"
+"@rollup/rollup-linux-arm64-musl@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.34.9"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.30.1"
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.34.9"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3274,9 +3274,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.30.1"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.34.9"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3295,9 +3295,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.30.1"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.34.9"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3316,9 +3316,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.30.1"
+"@rollup/rollup-linux-s390x-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.34.9"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -3337,9 +3337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.30.1"
+"@rollup/rollup-linux-x64-gnu@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.34.9"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -3358,9 +3358,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.30.1"
+"@rollup/rollup-linux-x64-musl@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.34.9"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -3379,9 +3379,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.30.1"
+"@rollup/rollup-win32-arm64-msvc@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.34.9"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -3400,9 +3400,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.30.1"
+"@rollup/rollup-win32-ia32-msvc@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.34.9"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -3421,9 +3421,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.30.1":
-  version: 4.30.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.30.1"
+"@rollup/rollup-win32-x64-msvc@npm:4.34.9":
+  version: 4.34.9
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.34.9"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -4866,7 +4866,7 @@ __metadata:
     "@xmtp/proto": "npm:^3.72.3"
     "@xmtp/wasm-bindings": "npm:^0.0.19"
     playwright: "npm:^1.49.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     rollup-plugin-tsconfig-paths: "npm:^1.5.2"
@@ -4900,7 +4900,7 @@ __metadata:
     "@xmtp/proto": "npm:^3.72.0"
     ethers: "npm:^6.13.1"
     long: "npm:^5.2.3"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     tsconfig: "workspace:*"
@@ -4924,7 +4924,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -4952,7 +4952,7 @@ __metadata:
     "@xmtp/proto": "npm:^3.72.0"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -4974,7 +4974,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -4996,7 +4996,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -5021,7 +5021,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -5045,7 +5045,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -5076,7 +5076,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -5098,7 +5098,7 @@ __metadata:
     ethers: "npm:^6.11.1"
     happy-dom: "npm:^16.6.0"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     typescript: "npm:^5.7.3"
@@ -5122,7 +5122,7 @@ __metadata:
     ethers: "npm:^6.13.1"
     fast-glob: "npm:^3.3.3"
     long: "npm:^5.2.3"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     rollup-plugin-tsconfig-paths: "npm:^1.5.2"
@@ -5153,7 +5153,7 @@ __metadata:
     "@xmtp/xmtp-js": "npm:^12.1.0"
     ethers: "npm:^6.10.0"
     fast-glob: "npm:^3.3.3"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     typescript: "npm:^5.7.3"
     uint8array-extras: "npm:^1.4.0"
@@ -5205,7 +5205,7 @@ __metadata:
     "@xmtp/xmtp-js": "workspace:^"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     rollup-plugin-tsconfig-paths: "npm:^1.5.2"
@@ -5357,7 +5357,7 @@ __metadata:
     happy-dom: "npm:^16.6.0"
     long: "npm:^5.2.3"
     rimraf: "npm:^6.0.1"
-    rollup: "npm:^4.30.1"
+    rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
     rollup-plugin-filesize: "npm:^10.0.0"
     rollup-plugin-tsconfig-paths: "npm:^1.5.2"
@@ -11414,29 +11414,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.30.1":
-  version: 4.30.1
-  resolution: "rollup@npm:4.30.1"
+"rollup@npm:^4.34.9":
+  version: 4.34.9
+  resolution: "rollup@npm:4.34.9"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.30.1"
-    "@rollup/rollup-android-arm64": "npm:4.30.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.30.1"
-    "@rollup/rollup-darwin-x64": "npm:4.30.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.30.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.30.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.30.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.30.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.30.1"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.30.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.30.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.30.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.30.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.30.1"
+    "@rollup/rollup-android-arm-eabi": "npm:4.34.9"
+    "@rollup/rollup-android-arm64": "npm:4.34.9"
+    "@rollup/rollup-darwin-arm64": "npm:4.34.9"
+    "@rollup/rollup-darwin-x64": "npm:4.34.9"
+    "@rollup/rollup-freebsd-arm64": "npm:4.34.9"
+    "@rollup/rollup-freebsd-x64": "npm:4.34.9"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.34.9"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.34.9"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.34.9"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.34.9"
+    "@rollup/rollup-linux-x64-musl": "npm:4.34.9"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.34.9"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.34.9"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.34.9"
     "@types/estree": "npm:1.0.6"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -11482,7 +11482,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10/f5d240a76a8c3cd7918f7dc97b7eaec5d97d27b3901e3843f74e18b4e9195c77abe8aa61575cd64ad7897f6a6dea6c68a7ad1a8073e3cf3139529e9fa7d06c2b
+  checksum: 10/856560db066fe6f4313e7907ece7cb100a3499e6baed4ee5df76e98f9d618bf2d4e33f6bd5a2fa70c00742d04dee2fea34b00547c77cc27df2e6cbed852ae12c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,7 +4864,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
     "@xmtp/proto": "npm:^3.72.3"
-    "@xmtp/wasm-bindings": "npm:^0.0.19"
+    "@xmtp/wasm-bindings": "npm:^0.0.21"
     playwright: "npm:^1.49.1"
     rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -5169,10 +5169,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:^0.0.39":
-  version: 0.0.39
-  resolution: "@xmtp/node-bindings@npm:0.0.39"
-  checksum: 10/d3125a10a2116c5a194b3999837ca805e6f7702167df8fdbf2d5461319eb8ccf07113f34826dadbb2681278c5193fda14eaeaf55fa1c93fb1adfce754bbe688d
+"@xmtp/node-bindings@npm:^0.0.41":
+  version: 0.0.41
+  resolution: "@xmtp/node-bindings@npm:0.0.41"
+  checksum: 10/809347d36de2b4f205fe46cc3869b1eab7595107fd14b0535457732745d14851121d1e7b0f22a0845deb32e48dfca29a7ad36a12bf9fc5c46b445a308a589c10
   languageName: node
   linkType: hard
 
@@ -5200,7 +5200,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.0"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
-    "@xmtp/node-bindings": "npm:^0.0.39"
+    "@xmtp/node-bindings": "npm:^0.0.41"
     "@xmtp/proto": "npm:^3.72.3"
     "@xmtp/xmtp-js": "workspace:^"
     fast-glob: "npm:^3.3.3"
@@ -5288,10 +5288,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^0.0.19":
-  version: 0.0.19
-  resolution: "@xmtp/wasm-bindings@npm:0.0.19"
-  checksum: 10/ebb2717a557c522c1026207651e8ffa84e756c78076042e0b6f48b0eb4c4ad86f6117bad194576dee6187fa2fddd611de04ad1e8c9f604d1e6dde6b9974e2f27
+"@xmtp/wasm-bindings@npm:^0.0.21":
+  version: 0.0.21
+  resolution: "@xmtp/wasm-bindings@npm:0.0.21"
+  checksum: 10/fa51d41c7381cd19774f72fd501cf9c2dcee72e3a750d4411edc55f27dd7059c4bd1ca9727a4dbbf8be61bea61e285c8801e769a88647d770494d1d75b0d6930
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Upgraded bindings for WASM and Node
- Upgraded `rollup`
- Fixed Node SDK build

Resolves #856 