### PR TITLE
Add identifiers to Browser SDK

### DIFF
--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -28,7 +28,8 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   optimizeDeps: {
-    exclude: ["@xmtp/wasm-bindings"],
+    exclude: ["@xmtp/wasm-bindings", "@xmtp/browser-sdk"],
+    include: ["@xmtp/proto"],
   },
 });
 ```

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -44,6 +44,7 @@
     "clean:dist": "rm -rf dist",
     "dev": "yarn clean:dist && yarn rollup -c --watch",
     "test": "vitest run",
+    "test:debug": "vitest run --inspect-brk --no-file-parallelism",
     "typecheck": "tsc",
     "typedoc": "typedoc"
   },

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-text": "^2.0.0",
     "@xmtp/proto": "^3.72.3",
-    "@xmtp/wasm-bindings": "^0.0.21",
+    "@xmtp/wasm-bindings": "^1.0.0-rc4",
     "uuid": "^11.0.3"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -199,4 +199,10 @@ export class Conversation {
     };
     return asyncStream;
   }
+
+  async pausedForVersion() {
+    return this.#client.sendMessage("getGroupPausedForVersion", {
+      id: this.#id,
+    });
+  }
 }

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -1,6 +1,7 @@
 import {
   ConversationType,
   type ConsentState,
+  type Identifier,
   type UserPreference,
 } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
@@ -97,38 +98,47 @@ export class Conversations {
     );
   }
 
-  async newGroup(accountAddresses: string[], options?: SafeCreateGroupOptions) {
-    const conversation = await this.#client.sendMessage("newGroup", {
-      accountAddresses,
-      options,
-    });
-
-    return new Group(this.#client, conversation.id, conversation);
-  }
-
-  async newGroupByInboxIds(
-    inboxIds: string[],
+  async newGroupWithIdentifiers(
+    identifiers: Identifier[],
     options?: SafeCreateGroupOptions,
   ) {
-    const conversation = await this.#client.sendMessage("newGroupByInboxIds", {
-      inboxIds,
-      options,
-    });
+    const conversation = await this.#client.sendMessage(
+      "newGroupWithIdentifiers",
+      {
+        identifiers,
+        options,
+      },
+    );
 
     return new Group(this.#client, conversation.id, conversation);
   }
 
-  async newDm(accountAddress: string, options?: SafeCreateDmOptions) {
-    const conversation = await this.#client.sendMessage("newDm", {
-      accountAddress,
+  async newGroup(inboxIds: string[], options?: SafeCreateGroupOptions) {
+    const conversation = await this.#client.sendMessage(
+      "newGroupWithInboxIds",
+      {
+        inboxIds,
+        options,
+      },
+    );
+
+    return new Group(this.#client, conversation.id, conversation);
+  }
+
+  async newDmWithIdentifier(
+    identifier: Identifier,
+    options?: SafeCreateDmOptions,
+  ) {
+    const conversation = await this.#client.sendMessage("newDmWithIdentifier", {
+      identifier,
       options,
     });
 
     return new Dm(this.#client, conversation.id, conversation);
   }
 
-  async newDmByInboxId(inboxId: string, options?: SafeCreateDmOptions) {
-    const conversation = await this.#client.sendMessage("newDmByInboxId", {
+  async newDm(inboxId: string, options?: SafeCreateDmOptions) {
+    const conversation = await this.#client.sendMessage("newDmWithInboxId", {
       inboxId,
       options,
     });

--- a/sdks/browser-sdk/src/Group.ts
+++ b/sdks/browser-sdk/src/Group.ts
@@ -1,4 +1,5 @@
 import type {
+  Identifier,
   MetadataField,
   PermissionPolicy,
   PermissionUpdateType,
@@ -132,28 +133,28 @@ export class Group extends Conversation {
     return superAdmins.includes(inboxId);
   }
 
-  async addMembers(accountAddresses: string[]) {
+  async addMembersByIdentifiers(identifiers: Identifier[]) {
     return this.#client.sendMessage("addGroupMembers", {
       id: this.#id,
-      accountAddresses,
+      identifiers,
     });
   }
 
-  async addMembersByInboxId(inboxIds: string[]) {
+  async addMembers(inboxIds: string[]) {
     return this.#client.sendMessage("addGroupMembersByInboxId", {
       id: this.#id,
       inboxIds,
     });
   }
 
-  async removeMembers(accountAddresses: string[]) {
+  async removeMembersByIdentifiers(identifiers: Identifier[]) {
     return this.#client.sendMessage("removeGroupMembers", {
       id: this.#id,
-      accountAddresses,
+      identifiers,
     });
   }
 
-  async removeMembersByInboxId(inboxIds: string[]) {
+  async removeMembers(inboxIds: string[]) {
     return this.#client.sendMessage("removeGroupMembersByInboxId", {
       id: this.#id,
       inboxIds,

--- a/sdks/browser-sdk/src/Utils.ts
+++ b/sdks/browser-sdk/src/Utils.ts
@@ -1,3 +1,4 @@
+import type { Identifier } from "@xmtp/wasm-bindings";
 import type { XmtpEnv } from "@/types/options";
 import { UtilsWorkerClass } from "@/UtilsWorkerClass";
 
@@ -11,16 +12,16 @@ export class Utils extends UtilsWorkerClass {
     this.#enableLogging = enableLogging ?? false;
   }
 
-  async generateInboxId(address: string) {
+  async generateInboxId(identifier: Identifier) {
     return this.sendMessage("generateInboxId", {
-      address,
+      identifier,
       enableLogging: this.#enableLogging,
     });
   }
 
-  async getInboxIdForAddress(address: string, env?: XmtpEnv) {
-    return this.sendMessage("getInboxIdForAddress", {
-      address,
+  async getInboxIdForIdentifier(identifier: Identifier, env?: XmtpEnv) {
+    return this.sendMessage("getInboxIdForIdentifier", {
+      identifier,
       env,
       enableLogging: this.#enableLogging,
     });

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -2,6 +2,7 @@ import {
   verifySignedWithPublicKey,
   type Client,
   type ConsentEntityType,
+  type Identifier,
   type SignatureRequestType,
 } from "@xmtp/wasm-bindings";
 import type { ClientOptions } from "@/types";
@@ -14,25 +15,22 @@ export class WorkerClient {
 
   #conversations: WorkerConversations;
 
-  #accountAddress: string;
-
   constructor(client: Client) {
     this.#client = client;
-    this.#accountAddress = client.accountAddress;
     this.#conversations = new WorkerConversations(this, client.conversations());
   }
 
   static async create(
-    accountAddress: string,
+    identifier: Identifier,
     encryptionKey: Uint8Array,
     options?: Omit<ClientOptions, "codecs">,
   ) {
-    const client = await createClient(accountAddress, encryptionKey, options);
+    const client = await createClient(identifier, encryptionKey, options);
     return new WorkerClient(client);
   }
 
-  get accountAddress() {
-    return this.#accountAddress;
+  get accountIdentifier() {
+    return this.#client.accountIdentifier;
   }
 
   get inboxId() {
@@ -59,17 +57,17 @@ export class WorkerClient {
     }
   }
 
-  async addAccountSignatureText(accountAddress: string) {
+  async addAccountSignatureText(identifier: Identifier) {
     try {
-      return await this.#client.addWalletSignatureText(accountAddress);
+      return await this.#client.addWalletSignatureText(identifier);
     } catch {
       return undefined;
     }
   }
 
-  async removeAccountSignatureText(accountAddress: string) {
+  async removeAccountSignatureText(identifier: Identifier) {
     try {
-      return await this.#client.revokeWalletSignatureText(accountAddress);
+      return await this.#client.revokeWalletSignatureText(identifier);
     } catch {
       return undefined;
     }
@@ -93,8 +91,8 @@ export class WorkerClient {
     }
   }
 
-  async addSignature(type: SignatureRequestType, bytes: Uint8Array) {
-    return this.#client.addSignature(type, bytes);
+  async addEcdsaSignature(type: SignatureRequestType, bytes: Uint8Array) {
+    return this.#client.addEcdsaSignature(type, bytes);
   }
 
   async addScwSignature(
@@ -110,8 +108,8 @@ export class WorkerClient {
     return this.#client.applySignatureRequests();
   }
 
-  async canMessage(accountAddresses: string[]) {
-    return this.#client.canMessage(accountAddresses) as Promise<
+  async canMessage(identifiers: Identifier[]) {
+    return this.#client.canMessage(identifiers) as Promise<
       Map<string, boolean>
     >;
   }
@@ -120,8 +118,8 @@ export class WorkerClient {
     return this.#client.registerIdentity();
   }
 
-  async findInboxIdByAddress(address: string) {
-    return this.#client.findInboxIdByAddress(address);
+  async findInboxIdByIdentifier(identifier: Identifier) {
+    return this.#client.findInboxIdByIdentifier(identifier);
   }
 
   async inboxState(refreshFromNetwork: boolean) {

--- a/sdks/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/browser-sdk/src/WorkerConversation.ts
@@ -4,6 +4,7 @@ import {
   type Conversation,
   type EncodedContent,
   type GroupMember,
+  type Identifier,
   type Message,
   type MetadataField,
   type PermissionPolicy,
@@ -121,19 +122,19 @@ export class WorkerConversation {
     return this.#group.sync();
   }
 
-  async addMembers(accountAddresses: string[]) {
-    return this.#group.addMembers(accountAddresses);
+  async addMembersByIdentifiers(identifiers: Identifier[]) {
+    return this.#group.addMembers(identifiers);
   }
 
-  async addMembersByInboxId(inboxIds: string[]) {
+  async addMembers(inboxIds: string[]) {
     return this.#group.addMembersByInboxId(inboxIds);
   }
 
-  async removeMembers(accountAddresses: string[]) {
-    return this.#group.removeMembers(accountAddresses);
+  async removeMembersByIdentifiers(identifiers: Identifier[]) {
+    return this.#group.removeMembers(identifiers);
   }
 
-  async removeMembersByInboxId(inboxIds: string[]) {
+  async removeMembers(inboxIds: string[]) {
     return this.#group.removeMembersByInboxId(inboxIds);
   }
 
@@ -208,5 +209,9 @@ export class WorkerConversation {
       void callback?.(error, undefined);
     };
     return this.#group.stream({ on_message, on_error });
+  }
+
+  pausedForVersion() {
+    return this.#group.pausedForVersion();
   }
 }

--- a/sdks/browser-sdk/src/WorkerConversations.ts
+++ b/sdks/browser-sdk/src/WorkerConversations.ts
@@ -5,6 +5,7 @@ import {
   type Conversation,
   type ConversationListItem,
   type Conversations,
+  type Identifier,
   type Message,
   type UserPreference,
 } from "@xmtp/wasm-bindings";
@@ -96,18 +97,18 @@ export class WorkerConversations {
     );
   }
 
-  async newGroup(accountAddresses: string[], options?: SafeCreateGroupOptions) {
+  async newGroupWithIdentifiers(
+    identifiers: Identifier[],
+    options?: SafeCreateGroupOptions,
+  ) {
     const group = await this.#conversations.createGroup(
-      accountAddresses,
+      identifiers,
       options ? fromSafeCreateGroupOptions(options) : undefined,
     );
     return new WorkerConversation(this.#client, group);
   }
 
-  async newGroupByInboxIds(
-    inboxIds: string[],
-    options?: SafeCreateGroupOptions,
-  ) {
+  async newGroup(inboxIds: string[], options?: SafeCreateGroupOptions) {
     const group = await this.#conversations.createGroupByInboxIds(
       inboxIds,
       options ? fromSafeCreateGroupOptions(options) : undefined,
@@ -115,15 +116,18 @@ export class WorkerConversations {
     return new WorkerConversation(this.#client, group);
   }
 
-  async newDm(accountAddress: string, options?: SafeCreateDmOptions) {
+  async newDmWithIdentifier(
+    identifier: Identifier,
+    options?: SafeCreateDmOptions,
+  ) {
     const group = await this.#conversations.createDm(
-      accountAddress,
+      identifier,
       options ? fromSafeCreateDmOptions(options) : undefined,
     );
     return new WorkerConversation(this.#client, group);
   }
 
-  async newDmByInboxId(inboxId: string, options?: SafeCreateDmOptions) {
+  async newDm(inboxId: string, options?: SafeCreateDmOptions) {
     const group = await this.#conversations.createDmByInboxId(
       inboxId,
       options ? fromSafeCreateDmOptions(options) : undefined,

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -9,7 +9,11 @@ export { Utils } from "./Utils";
 export { ApiUrls, HistorySyncUrls } from "./constants";
 export type * from "./types";
 export * from "./utils/conversions";
-export type { LogOptions, UserPreference } from "@xmtp/wasm-bindings";
+export type {
+  Identifier,
+  IdentifierKind,
+  UserPreference,
+} from "@xmtp/wasm-bindings";
 export {
   Consent,
   ConsentEntityType,
@@ -33,6 +37,7 @@ export {
   Installation,
   ListConversationsOptions,
   ListMessagesOptions,
+  LogOptions,
   Message,
   MessageDisappearingSettings,
   MetadataField,

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -9,7 +9,7 @@ export { Utils } from "./Utils";
 export { ApiUrls, HistorySyncUrls } from "./constants";
 export type * from "./types";
 export * from "./utils/conversions";
-export type { UserPreference } from "@xmtp/wasm-bindings";
+export type { LogOptions, UserPreference } from "@xmtp/wasm-bindings";
 export {
   Consent,
   ConsentEntityType,
@@ -33,7 +33,6 @@ export {
   Installation,
   ListConversationsOptions,
   ListMessagesOptions,
-  LogOptions,
   Message,
   MessageDisappearingSettings,
   MetadataField,

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -2,6 +2,7 @@ import type {
   ConsentEntityType,
   ConsentState,
   ConversationType,
+  Identifier,
   MetadataField,
   PermissionPolicy,
   PermissionUpdateType,
@@ -56,7 +57,7 @@ export type ClientEvents =
         installationIdBytes: Uint8Array;
       };
       data: {
-        address: string;
+        identifier: Identifier;
         encryptionKey: Uint8Array;
         options?: ClientOptions;
       };
@@ -72,7 +73,7 @@ export type ClientEvents =
       id: string;
       result: string | undefined;
       data: {
-        newAccountAddress: string;
+        newIdentifier: Identifier;
       };
     }
   | {
@@ -80,7 +81,7 @@ export type ClientEvents =
       id: string;
       result: string | undefined;
       data: {
-        accountAddress: string;
+        identifier: Identifier;
       };
     }
   | {
@@ -98,7 +99,7 @@ export type ClientEvents =
       };
     }
   | {
-      action: "addSignature";
+      action: "addEcdsaSignature";
       id: string;
       result: undefined;
       data: {
@@ -140,7 +141,7 @@ export type ClientEvents =
       id: string;
       result: Map<string, boolean>;
       data: {
-        accountAddresses: string[];
+        identifiers: Identifier[];
       };
     }
   | {
@@ -177,11 +178,11 @@ export type ClientEvents =
       };
     }
   | {
-      action: "findInboxIdByAddress";
+      action: "findInboxIdByIdentifier";
       id: string;
       result: string | undefined;
       data: {
-        address: string;
+        identifier: Identifier;
       };
     }
   | {
@@ -263,16 +264,16 @@ export type ClientEvents =
       };
     }
   | {
-      action: "newGroup";
+      action: "newGroupWithIdentifiers";
       id: string;
       result: SafeConversation;
       data: {
-        accountAddresses: string[];
+        identifiers: Identifier[];
         options?: SafeCreateGroupOptions;
       };
     }
   | {
-      action: "newGroupByInboxIds";
+      action: "newGroupWithInboxIds";
       id: string;
       result: SafeConversation;
       data: {
@@ -281,16 +282,16 @@ export type ClientEvents =
       };
     }
   | {
-      action: "newDm";
+      action: "newDmWithIdentifier";
       id: string;
       result: SafeConversation;
       data: {
-        accountAddress: string;
+        identifier: Identifier;
         options?: SafeCreateDmOptions;
       };
     }
   | {
-      action: "newDmByInboxId";
+      action: "newDmWithInboxId";
       id: string;
       result: SafeConversation;
       data: {
@@ -446,7 +447,7 @@ export type ClientEvents =
       result: undefined;
       data: {
         id: string;
-        accountAddresses: string[];
+        identifiers: Identifier[];
       };
     }
   | {
@@ -455,7 +456,7 @@ export type ClientEvents =
       result: undefined;
       data: {
         id: string;
-        accountAddresses: string[];
+        identifiers: Identifier[];
       };
     }
   | {
@@ -622,6 +623,14 @@ export type ClientEvents =
       data: {
         groupId: string;
         streamId: string;
+      };
+    }
+  | {
+      action: "getGroupPausedForVersion";
+      id: string;
+      result: string | undefined;
+      data: {
+        id: string;
       };
     };
 

--- a/sdks/browser-sdk/src/types/utilsEvents.ts
+++ b/sdks/browser-sdk/src/types/utilsEvents.ts
@@ -1,3 +1,4 @@
+import type { Identifier } from "@xmtp/wasm-bindings";
 import type {
   EventsClientMessageData,
   EventsClientPostMessageData,
@@ -15,16 +16,16 @@ export type UtilsEvents =
       id: string;
       result: string;
       data: {
-        address: string;
+        identifier: Identifier;
         enableLogging: boolean;
       };
     }
   | {
-      action: "getInboxIdForAddress";
+      action: "getInboxIdForIdentifier";
       id: string;
       result: string | undefined;
       data: {
-        address: string;
+        identifier: Identifier;
         env?: XmtpEnv;
         enableLogging: boolean;
       };

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -20,6 +20,7 @@ import {
   type DeliveryStatus,
   type GroupMessageKind,
   type HmacKey,
+  type Identifier,
   type InboxState,
   type Installation,
   type Message,
@@ -394,17 +395,17 @@ export const toSafeInstallation = (
 });
 
 export type SafeInboxState = {
-  accountAddresses: string[];
+  accountIdentifiers: Identifier[];
   inboxId: string;
   installations: SafeInstallation[];
-  recoveryAddress: string;
+  recoveryIdentifier: Identifier;
 };
 
 export const toSafeInboxState = (inboxState: InboxState): SafeInboxState => ({
-  accountAddresses: inboxState.accountAddresses,
+  accountIdentifiers: inboxState.accountIdentifiers,
   inboxId: inboxState.inboxId,
   installations: inboxState.installations.map(toSafeInstallation),
-  recoveryAddress: inboxState.recoveryAddress,
+  recoveryIdentifier: inboxState.recoveryIdentifier,
 });
 
 export type SafeConsent = {
@@ -423,7 +424,7 @@ export const fromSafeConsent = (consent: SafeConsent): Consent =>
   new Consent(consent.entityType, consent.state, consent.entity);
 
 export type SafeGroupMember = {
-  accountAddresses: string[];
+  accountIdentifiers: Identifier[];
   consentState: ConsentState;
   inboxId: string;
   installationIds: string[];
@@ -431,7 +432,7 @@ export type SafeGroupMember = {
 };
 
 export const toSafeGroupMember = (member: GroupMember): SafeGroupMember => ({
-  accountAddresses: member.accountAddresses,
+  accountIdentifiers: member.accountIdentifiers,
   consentState: member.consentState,
   inboxId: member.inboxId,
   installationIds: member.installationIds,
@@ -441,7 +442,7 @@ export const toSafeGroupMember = (member: GroupMember): SafeGroupMember => ({
 export const fromSafeGroupMember = (member: SafeGroupMember): GroupMember =>
   new GroupMember(
     member.inboxId,
-    member.accountAddresses,
+    member.accountIdentifiers,
     member.installationIds,
     member.permissionLevel,
     member.consentState,

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -2,6 +2,7 @@ import {
   createClient as createWasmClient,
   generateInboxId,
   getInboxIdForIdentifier,
+  LogOptions,
   type Identifier,
 } from "@xmtp/wasm-bindings";
 import { ApiUrls, HistorySyncUrls } from "@/constants";
@@ -35,11 +36,11 @@ export const createClient = async (
     encryptionKey,
     historySyncUrl,
     isLogging
-      ? {
-          structured: options.structuredLogging ?? false,
-          performance: options.performanceLogging ?? false,
-          level: options.loggingLevel,
-        }
+      ? new LogOptions(
+          options.structuredLogging ?? false,
+          options.performanceLogging ?? false,
+          options.loggingLevel,
+        )
       : undefined,
   );
 };

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -1,28 +1,23 @@
-import init, {
+import {
   createClient as createWasmClient,
   generateInboxId,
-  getInboxIdForAddress,
-  LogOptions,
+  getInboxIdForIdentifier,
+  type Identifier,
 } from "@xmtp/wasm-bindings";
 import { ApiUrls, HistorySyncUrls } from "@/constants";
 import type { ClientOptions } from "@/types";
 
 export const createClient = async (
-  accountAddress: string,
+  identifier: Identifier,
   encryptionKey: Uint8Array,
   options?: Omit<ClientOptions, "codecs">,
 ) => {
-  // initialize WASM module
-  await init();
-
   const host = options?.apiUrl || ApiUrls[options?.env || "dev"];
-  const dbPath =
-    options?.dbPath || `xmtp-${options?.env || "dev"}-${accountAddress}.db3`;
-
   const inboxId =
-    (await getInboxIdForAddress(host, accountAddress)) ||
-    generateInboxId(accountAddress);
-
+    (await getInboxIdForIdentifier(host, identifier)) ||
+    generateInboxId(identifier);
+  const dbPath =
+    options?.dbPath || `xmtp-${options?.env || "dev"}-${inboxId}.db3`;
   const isLogging =
     options &&
     (options.loggingLevel !== undefined ||
@@ -35,16 +30,16 @@ export const createClient = async (
   return createWasmClient(
     host,
     inboxId,
-    accountAddress,
+    identifier,
     dbPath,
     encryptionKey,
     historySyncUrl,
     isLogging
-      ? new LogOptions(
-          options.structuredLogging ?? false,
-          options.performanceLogging ?? false,
-          options.loggingLevel,
-        )
+      ? {
+          structured: options.structuredLogging ?? false,
+          performance: options.performanceLogging ?? false,
+          level: options.loggingLevel,
+        }
       : undefined,
   );
 };

--- a/sdks/browser-sdk/src/utils/signer.ts
+++ b/sdks/browser-sdk/src/utils/signer.ts
@@ -1,18 +1,23 @@
+import type { Identifier } from "@xmtp/wasm-bindings";
+
 export type SignMessage = (message: string) => Promise<Uint8Array> | Uint8Array;
-export type GetAddress = () => Promise<string> | string;
+export type GetIdentifier = () => Promise<Identifier> | Identifier;
 export type GetChainId = () => bigint;
 export type GetBlockNumber = () => bigint;
 
 export type Signer =
   | {
-      walletType: "EOA";
-      getAddress: GetAddress;
+      type: "EOA";
+      getIdentifier: GetIdentifier;
       signMessage: SignMessage;
     }
   | {
-      walletType: "SCW";
-      getAddress: GetAddress;
+      type: "SCW";
+      getIdentifier: GetIdentifier;
       signMessage: SignMessage;
       getBlockNumber?: GetBlockNumber;
       getChainId: GetChainId;
     };
+
+export type EOASigner = Extract<Signer, { type: "EOA" }>;
+export type SCWSigner = Extract<Signer, { type: "SCW" }>;

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -1,4 +1,4 @@
-import init, { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
+import { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import { Client } from "@/Client";
@@ -11,7 +11,6 @@ import {
 
 describe.concurrent("Client", () => {
   it("should create a client", async () => {
-    await init();
     const user = createUser();
     const signer = createSigner(user);
     const client = await createClient(signer);

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -1,4 +1,4 @@
-import { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
+import init, { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import { Client } from "@/Client";
@@ -11,9 +11,14 @@ import {
 
 describe.concurrent("Client", () => {
   it("should create a client", async () => {
+    await init();
     const user = createUser();
-    const client = await createClient(user);
-    expect(client.accountAddress).toBe(user.account.address);
+    const signer = createSigner(user);
+    const client = await createClient(signer);
+    expect(await client.accountIdentifier()).toEqual({
+      identifier: user.account.address.toLowerCase(),
+      identifierKind: "Ethereum",
+    });
     expect(await client.isRegistered()).toBe(false);
     expect(client.inboxId).toBeDefined();
     expect(client.installationId).toBeDefined();
@@ -21,15 +26,17 @@ describe.concurrent("Client", () => {
 
   it("should register an identity", async () => {
     const user = createUser();
-    await createRegisteredClient(user);
-    const client2 = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer);
     expect(await client2.isRegistered()).toBe(true);
   });
 
   it("should be able to message registered identity", async () => {
     const user = createUser();
-    const client = await createRegisteredClient(user);
-    const canMessage = await client.canMessage([user.account.address]);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const canMessage = await client.canMessage([await signer.getIdentifier()]);
     expect(Object.fromEntries(canMessage)).toEqual({
       [user.account.address.toLowerCase()]: true,
     });
@@ -37,8 +44,12 @@ describe.concurrent("Client", () => {
 
   it("should be able to check if can message without client instance", async () => {
     const user = createUser();
-    await createRegisteredClient(user);
-    const canMessage = await Client.canMessage([user.account.address], "local");
+    const signer = createSigner(user);
+    await createRegisteredClient(signer);
+    const canMessage = await Client.canMessage(
+      [await signer.getIdentifier()],
+      "local",
+    );
     expect(Object.fromEntries(canMessage)).toEqual({
       [user.account.address.toLowerCase()]: true,
     });
@@ -46,26 +57,31 @@ describe.concurrent("Client", () => {
 
   it("should get an inbox ID from an address", async () => {
     const user = createUser();
-    const client = await createRegisteredClient(user);
-    const inboxId = await client.findInboxIdByAddress(user.account.address);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const inboxId = await client.findInboxIdByIdentifier(
+      await signer.getIdentifier(),
+    );
     expect(inboxId).toBe(client.inboxId);
   });
 
   it("should return the correct inbox state", async () => {
     const user = createUser();
-    const client = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
     const inboxState = await client.inboxState(false);
     expect(inboxState.inboxId).toBe(client.inboxId);
     expect(inboxState.installations.map((install) => install.id)).toEqual([
       client.installationId,
     ]);
-    expect(inboxState.accountAddresses).toEqual([
-      user.account.address.toLowerCase(),
+    expect(inboxState.accountIdentifiers).toEqual([
+      await signer.getIdentifier(),
     ]);
-    expect(inboxState.recoveryAddress).toBe(user.account.address.toLowerCase());
+    expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
     const user2 = createUser();
-    const client2 = await createClient(user2);
+    const signer2 = createSigner(user2);
+    const client2 = await createClient(signer2);
     const inboxState2 = await client2.getLatestInboxState(client.inboxId!);
     expect(inboxState2.inboxId).toBe(client.inboxId);
     expect(inboxState.installations.length).toBe(1);
@@ -73,53 +89,62 @@ describe.concurrent("Client", () => {
     expect(inboxState.installations[0].bytes).toEqual(
       client.installationIdBytes,
     );
-    expect(inboxState2.accountAddresses).toEqual([
-      user.account.address.toLowerCase(),
+    expect(inboxState2.accountIdentifiers).toEqual([
+      await signer.getIdentifier(),
     ]);
-    expect(inboxState2.recoveryAddress).toBe(
-      user.account.address.toLowerCase(),
+    expect(inboxState2.recoveryIdentifier).toEqual(
+      await signer.getIdentifier(),
     );
   });
 
   it("should add a wallet association to the client", async () => {
     const user = createUser();
-    const user2 = createUser();
-    const client = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
 
-    await client.unsafe_addAccount(createSigner(user2));
+    const user2 = createUser();
+    const signer2 = createSigner(user2);
+
+    await client.unsafe_addAccount(signer2);
 
     const inboxState = await client.inboxState();
-    expect(inboxState.accountAddresses.length).toEqual(2);
-    expect(inboxState.accountAddresses).toContain(
-      user.account.address.toLowerCase(),
+    expect(inboxState.accountIdentifiers.length).toEqual(2);
+    expect(inboxState.accountIdentifiers).toContainEqual(
+      await signer.getIdentifier(),
     );
-    expect(inboxState.accountAddresses).toContain(
-      user2.account.address.toLowerCase(),
+    expect(inboxState.accountIdentifiers).toContainEqual(
+      await signer2.getIdentifier(),
     );
   });
 
   it("should revoke a wallet association from the client", async () => {
     const user = createUser();
-    const user2 = createUser();
-    const client = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
 
-    await client.unsafe_addAccount(createSigner(user2));
-    await client.removeAccount(user2.account.address);
+    const user2 = createUser();
+    const signer2 = createSigner(user2);
+
+    await client.unsafe_addAccount(signer2);
+    await client.removeAccount(await signer2.getIdentifier());
 
     const inboxState = await client.inboxState();
-    expect(inboxState.accountAddresses).toEqual([
-      user.account.address.toLowerCase(),
+    expect(inboxState.accountIdentifiers).toEqual([
+      await signer.getIdentifier(),
     ]);
   });
 
   it("should revoke all other installations", async () => {
     const user = createUser();
+    const signer = createSigner(user);
 
-    const client = await createRegisteredClient(user);
-    user.uuid = v4();
-    const client2 = await createRegisteredClient(user);
-    user.uuid = v4();
-    const client3 = await createRegisteredClient(user);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+    const client3 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
 
     const inboxState = await client3.inboxState(true);
     expect(inboxState.installations.length).toBe(3);
@@ -139,12 +164,14 @@ describe.concurrent("Client", () => {
 
   it("should revoke specific installations", async () => {
     const user = createUser();
-
-    const client = await createRegisteredClient(user);
-    user.uuid = v4();
-    const client2 = await createRegisteredClient(user);
-    user.uuid = v4();
-    const client3 = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+    const client3 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
 
     const inboxState = await client3.inboxState(true);
     expect(inboxState.installations.length).toBe(3);
@@ -169,9 +196,11 @@ describe.concurrent("Client", () => {
   it("should manage consent states", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
-    const group = await client1.conversations.newGroup([user2.account.address]);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client1.conversations.newGroup([client2.inboxId!]);
 
     await client2.conversations.sync();
     const group2 = await client2.conversations.getConversationById(group.id);

--- a/sdks/browser-sdk/test/Conversation.test.ts
+++ b/sdks/browser-sdk/test/Conversation.test.ts
@@ -10,6 +10,7 @@ import type { SafeMessageDisappearingSettings } from "@/utils/conversions";
 import {
   ContentTypeTest,
   createRegisteredClient,
+  createSigner,
   createUser,
   sleep,
   TestCodec,
@@ -19,10 +20,12 @@ describe("Conversation", () => {
   it("should update conversation name", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
     const newName = "foo";
     await conversation.updateName(newName);
@@ -46,10 +49,12 @@ describe("Conversation", () => {
   it("should update conversation image URL", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
     const imageUrl = "https://foo/bar.jpg";
     await conversation.updateImageUrl(imageUrl);
@@ -73,10 +78,12 @@ describe("Conversation", () => {
   it("should update conversation description", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
     const newDescription = "foo";
     await conversation.updateDescription(newDescription);
@@ -101,11 +108,14 @@ describe("Conversation", () => {
     const user1 = createUser();
     const user2 = createUser();
     const user3 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
-    const client3 = await createRegisteredClient(user3);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const signer3 = createSigner(user3);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const client3 = await createRegisteredClient(signer3);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     const members = await conversation.members();
@@ -115,7 +125,7 @@ describe("Conversation", () => {
     expect(memberInboxIds).toContain(client2.inboxId);
     expect(memberInboxIds).not.toContain(client3.inboxId);
 
-    await conversation.addMembers([user3.account.address]);
+    await conversation.addMembers([client3.inboxId!]);
 
     const members2 = await conversation.members();
     expect(members2.length).toBe(3);
@@ -125,7 +135,7 @@ describe("Conversation", () => {
     expect(memberInboxIds2).toContain(client2.inboxId);
     expect(memberInboxIds2).toContain(client3.inboxId);
 
-    await conversation.removeMembers([user2.account.address]);
+    await conversation.removeMembers([client2.inboxId!]);
 
     const members3 = await conversation.members();
     expect(members3.length).toBe(2);
@@ -140,11 +150,14 @@ describe("Conversation", () => {
     const user1 = createUser();
     const user2 = createUser();
     const user3 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
-    const client3 = await createRegisteredClient(user3);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const signer3 = createSigner(user3);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const client3 = await createRegisteredClient(signer3);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     const members = await conversation.members();
@@ -153,7 +166,7 @@ describe("Conversation", () => {
     expect(memberInboxIds).toContain(client2.inboxId);
     expect(memberInboxIds).not.toContain(client3.inboxId);
 
-    await conversation.addMembersByInboxId([client3.inboxId!]);
+    await conversation.addMembers([client3.inboxId!]);
 
     const members2 = await conversation.members();
     expect(members2.length).toBe(3);
@@ -163,7 +176,7 @@ describe("Conversation", () => {
     expect(memberInboxIds2).toContain(client2.inboxId);
     expect(memberInboxIds2).toContain(client3.inboxId);
 
-    await conversation.removeMembersByInboxId([client2.inboxId!]);
+    await conversation.removeMembers([client2.inboxId!]);
 
     const members3 = await conversation.members();
     expect(members3.length).toBe(2);
@@ -177,10 +190,12 @@ describe("Conversation", () => {
   it("should send and list messages", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     const text = "gm";
@@ -207,12 +222,14 @@ describe("Conversation", () => {
   it("should require content type when sending non-string content", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1, {
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1, {
       codecs: [new TestCodec()],
     });
-    await createRegisteredClient(user2);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     await expect(() => conversation.send(1)).rejects.toThrow();
@@ -225,10 +242,12 @@ describe("Conversation", () => {
   it("should optimistically send and list messages", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     const text = "gm";
@@ -262,12 +281,14 @@ describe("Conversation", () => {
   it("should require content type when optimistically sending non-string content", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1, {
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1, {
       codecs: [new TestCodec()],
     });
-    await createRegisteredClient(user2);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     await expect(() => conversation.sendOptimistic(1)).rejects.toThrow();
@@ -282,10 +303,12 @@ describe("Conversation", () => {
   it("should throw when sending content without a codec", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     await expect(
@@ -296,10 +319,12 @@ describe("Conversation", () => {
   it("should add and remove admins", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     expect(await conversation.isSuperAdmin(client1.inboxId!)).toBe(true);
@@ -326,10 +351,12 @@ describe("Conversation", () => {
   it("should add and remove super admins", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     expect(await conversation.isSuperAdmin(client1.inboxId!)).toBe(true);
@@ -359,12 +386,15 @@ describe("Conversation", () => {
     const user1 = createUser();
     const user2 = createUser();
     const user3 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
-    const client3 = await createRegisteredClient(user3);
-    const group = await client1.conversations.newGroup([user2.account.address]);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const signer3 = createSigner(user3);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const client3 = await createRegisteredClient(signer3);
+    const group = await client1.conversations.newGroup([client2.inboxId!]);
     expect(group).toBeDefined();
-    const dmGroup = await client1.conversations.newDm(user3.account.address);
+    const dmGroup = await client1.conversations.newDm(client3.inboxId!);
     expect(dmGroup).toBeDefined();
 
     await client2.conversations.sync();
@@ -389,12 +419,12 @@ describe("Conversation", () => {
   it("should update group permission policy", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const user3 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    await createRegisteredClient(user2);
-    await createRegisteredClient(user3);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     const permissions = await conversation.permissions();
@@ -499,8 +529,10 @@ describe("Conversation", () => {
   it("should handle disappearing messages in a group", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: SafeMessageDisappearingSettings = {
@@ -510,7 +542,7 @@ describe("Conversation", () => {
 
     // create a group with message disappearing settings
     const conversation = await client1.conversations.newGroup(
-      [user2.account.address],
+      [client2.inboxId!],
       {
         messageDisappearingSettings,
       },
@@ -591,8 +623,10 @@ describe("Conversation", () => {
   it("should handle disappearing messages in a DM group", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
 
     // create message disappearing settings so that messages are deleted after 1 second
     const messageDisappearingSettings: SafeMessageDisappearingSettings = {
@@ -601,12 +635,9 @@ describe("Conversation", () => {
     };
 
     // create a group with message disappearing settings
-    const conversation = await client1.conversations.newDm(
-      user2.account.address,
-      {
-        messageDisappearingSettings,
-      },
-    );
+    const conversation = await client1.conversations.newDm(client2.inboxId!, {
+      messageDisappearingSettings,
+    });
 
     // verify that the message disappearing settings are set and enabled
     expect(await conversation.messageDisappearingSettings()).toEqual({
@@ -683,10 +714,12 @@ describe("Conversation", () => {
   it("should stream messages", async () => {
     const user1 = createUser();
     const user2 = createUser();
-    const client1 = await createRegisteredClient(user1);
-    const client2 = await createRegisteredClient(user2);
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
     const conversation = await client1.conversations.newGroup([
-      user2.account.address,
+      client2.inboxId!,
     ]);
 
     await client2.conversations.sync();

--- a/sdks/browser-sdk/test/Utils.test.ts
+++ b/sdks/browser-sdk/test/Utils.test.ts
@@ -1,21 +1,27 @@
 import { describe, expect, it } from "vitest";
 import { Utils } from "@/Utils";
-import { createRegisteredClient, createUser } from "@test/helpers";
+import {
+  createRegisteredClient,
+  createSigner,
+  createUser,
+} from "@test/helpers";
 
 describe.concurrent("Utils", () => {
   it("should generate inbox id", async () => {
     const user = createUser();
+    const signer = createSigner(user);
     const utils = new Utils();
-    const inboxId = await utils.generateInboxId(user.account.address);
+    const inboxId = await utils.generateInboxId(await signer.getIdentifier());
     expect(inboxId).toBeDefined();
   });
 
   it("should get inbox id for address", async () => {
     const user = createUser();
-    const client = await createRegisteredClient(user);
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
     const utils = new Utils();
-    const inboxId = await utils.getInboxIdForAddress(
-      client.accountAddress,
+    const inboxId = await utils.getInboxIdForIdentifier(
+      await signer.getIdentifier(),
       "local",
     );
     expect(inboxId).toBe(client.inboxId);

--- a/sdks/browser-sdk/test/helpers.ts
+++ b/sdks/browser-sdk/test/helpers.ts
@@ -33,8 +33,11 @@ export const createUser = () => {
 
 export const createSigner = (user: User): Signer => {
   return {
-    walletType: "EOA",
-    getAddress: () => user.account.address,
+    type: "EOA",
+    getIdentifier: () => ({
+      identifier: user.account.address.toLowerCase(),
+      identifierKind: "Ethereum",
+    }),
     signMessage: async (message: string) => {
       const signature = await user.wallet.signMessage({
         message,
@@ -46,29 +49,31 @@ export const createSigner = (user: User): Signer => {
 
 export type User = ReturnType<typeof createUser>;
 
-export const createClient = async (user: User, options?: ClientOptions) => {
+export const createClient = async (signer: Signer, options?: ClientOptions) => {
   const opts = {
     ...options,
     env: options?.env ?? "local",
   };
-  return Client.create(createSigner(user), testEncryptionKey, {
+  const identifier = await signer.getIdentifier();
+  return Client.create(signer, testEncryptionKey, {
     ...opts,
     disableAutoRegister: true,
-    dbPath: `./test-${user.uuid}.db3`,
+    dbPath: opts.dbPath ?? `./test-${identifier.identifier}.db3`,
   });
 };
 
 export const createRegisteredClient = async (
-  user: User,
+  signer: Signer,
   options?: ClientOptions,
 ) => {
   const opts = {
     ...options,
     env: options?.env ?? "local",
   };
-  return Client.create(createSigner(user), testEncryptionKey, {
+  const identifier = await signer.getIdentifier();
+  return Client.create(signer, testEncryptionKey, {
     ...opts,
-    dbPath: `./test-${user.uuid}.db3`,
+    dbPath: opts.dbPath ?? `./test-${identifier.identifier}.db3`,
   });
 };
 

--- a/sdks/browser-sdk/vite.config.ts
+++ b/sdks/browser-sdk/vite.config.ts
@@ -21,12 +21,6 @@ const vitestConfig = defineVitestConfig({
     },
     testTimeout: 120000,
   },
-  server: {
-    headers: {
-      "Cross-Origin-Embedder-Policy": "require-corp",
-      "Cross-Origin-Opener-Policy": "same-origin",
-    },
-  },
 });
 
 export default mergeConfig(viteConfig, vitestConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,7 +4864,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-text": "npm:^2.0.0"
     "@xmtp/proto": "npm:^3.72.3"
-    "@xmtp/wasm-bindings": "npm:^0.0.21"
+    "@xmtp/wasm-bindings": "npm:^1.0.0-rc4"
     playwright: "npm:^1.49.1"
     rollup: "npm:^4.34.9"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -5288,10 +5288,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^0.0.21":
-  version: 0.0.21
-  resolution: "@xmtp/wasm-bindings@npm:0.0.21"
-  checksum: 10/fa51d41c7381cd19774f72fd501cf9c2dcee72e3a750d4411edc55f27dd7059c4bd1ca9727a4dbbf8be61bea61e285c8801e769a88647d770494d1d75b0d6930
+"@xmtp/wasm-bindings@npm:^1.0.0-rc4":
+  version: 1.0.0-rc4
+  resolution: "@xmtp/wasm-bindings@npm:1.0.0-rc4"
+  checksum: 10/ffcda1ac256ab77d185381f85e3ec81cb5ea32e9556758c5243e30d9e889dad201a729d4f06feb48eede45d3bdca2e9359d344b643e3ddff59fb6dabb86a20f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Upgraded to latest WASM bindings
- Updated `Signer` type
- Replaced address parameters with inbox IDs or identifiers
- Added new methods to use with identifiers
- Added `pausedForVersion` to `Conversation`
- Updated exports