### PR TITLE
Create separate Preferences class

### DIFF
--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -10,16 +10,15 @@ import { TextCodec } from "@xmtp/content-type-text";
 import {
   GroupMessageKind,
   SignatureRequestType,
-  type ConsentEntityType,
   type Identifier,
 } from "@xmtp/wasm-bindings";
 import { ClientWorkerClass } from "@/ClientWorkerClass";
 import { Conversations } from "@/Conversations";
+import { Preferences } from "@/Preferences";
 import type { ClientOptions, XmtpEnv } from "@/types";
 import {
   fromSafeEncodedContent,
   toSafeEncodedContent,
-  type SafeConsent,
   type SafeMessage,
 } from "@/utils/conversions";
 import { type Signer } from "@/utils/signer";
@@ -32,6 +31,7 @@ export class Client extends ClientWorkerClass {
   #installationId: string | undefined;
   #installationIdBytes: Uint8Array | undefined;
   #isReady = false;
+  #preferences: Preferences;
   #signer: Signer;
   options?: ClientOptions;
 
@@ -51,6 +51,7 @@ export class Client extends ClientWorkerClass {
     this.#encryptionKey = encryptionKey;
     this.#signer = signer;
     this.#conversations = new Conversations(this);
+    this.#preferences = new Preferences(this);
     const codecs = [
       new GroupUpdatedCodec(),
       new TextCodec(),
@@ -107,6 +108,14 @@ export class Client extends ClientWorkerClass {
 
   get installationIdBytes() {
     return this.#installationIdBytes;
+  }
+
+  get conversations() {
+    return this.#conversations;
+  }
+
+  get preferences() {
+    return this.#preferences;
   }
 
   /**
@@ -374,28 +383,6 @@ export class Client extends ClientWorkerClass {
 
   async findInboxIdByIdentifier(identifier: Identifier) {
     return this.sendMessage("findInboxIdByIdentifier", { identifier });
-  }
-
-  async inboxState(refreshFromNetwork?: boolean) {
-    return this.sendMessage("inboxState", {
-      refreshFromNetwork: refreshFromNetwork ?? false,
-    });
-  }
-
-  async getLatestInboxState(inboxId: string) {
-    return this.sendMessage("getLatestInboxState", { inboxId });
-  }
-
-  async setConsentStates(records: SafeConsent[]) {
-    return this.sendMessage("setConsentStates", { records });
-  }
-
-  async getConsentState(entityType: ConsentEntityType, entity: string) {
-    return this.sendMessage("getConsentState", { entityType, entity });
-  }
-
-  get conversations() {
-    return this.#conversations;
   }
 
   codecFor(contentType: ContentTypeId) {

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -2,7 +2,6 @@ import {
   ConversationType,
   type ConsentState,
   type Identifier,
-  type UserPreference,
 } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
 import { AsyncStream, type StreamCallback } from "@/AsyncStream";
@@ -11,7 +10,6 @@ import { DecodedMessage } from "@/DecodedMessage";
 import { Dm } from "@/Dm";
 import { Group } from "@/Group";
 import type {
-  SafeConsent,
   SafeConversation,
   SafeCreateDmOptions,
   SafeCreateGroupOptions,
@@ -240,49 +238,5 @@ export class Conversations {
 
   async streamAllDmMessages(callback?: StreamCallback<DecodedMessage>) {
     return this.streamAllMessages(callback, ConversationType.Dm);
-  }
-
-  async streamConsent(callback?: StreamCallback<SafeConsent[]>) {
-    const streamId = v4();
-    const asyncStream = new AsyncStream<SafeConsent[]>();
-    const endStream = this.#client.handleStreamMessage<SafeConsent[]>(
-      streamId,
-      (error, value) => {
-        void asyncStream.callback(error, value ?? undefined);
-        void callback?.(error, value ?? undefined);
-      },
-    );
-    await this.#client.sendMessage("streamConsent", {
-      streamId,
-    });
-    asyncStream.onReturn = () => {
-      void this.#client.sendMessage("endStream", {
-        streamId,
-      });
-      endStream();
-    };
-    return asyncStream;
-  }
-
-  async streamPreferences(callback?: StreamCallback<UserPreference[]>) {
-    const streamId = v4();
-    const asyncStream = new AsyncStream<UserPreference[]>();
-    const endStream = this.#client.handleStreamMessage<UserPreference[]>(
-      streamId,
-      (error, value) => {
-        void asyncStream.callback(error, value ?? undefined);
-        void callback?.(error, value ?? undefined);
-      },
-    );
-    await this.#client.sendMessage("streamPreferences", {
-      streamId,
-    });
-    asyncStream.onReturn = () => {
-      void this.#client.sendMessage("endStream", {
-        streamId,
-      });
-      endStream();
-    };
-    return asyncStream;
   }
 }

--- a/sdks/browser-sdk/src/Preferences.ts
+++ b/sdks/browser-sdk/src/Preferences.ts
@@ -1,0 +1,75 @@
+import type { ConsentEntityType, UserPreference } from "@xmtp/wasm-bindings";
+import { v4 } from "uuid";
+import { AsyncStream, type StreamCallback } from "@/AsyncStream";
+import type { SafeConsent } from "@/utils/conversions";
+import type { Client } from "./Client";
+
+export class Preferences {
+  #client: Client;
+
+  constructor(client: Client) {
+    this.#client = client;
+  }
+
+  async inboxState(refreshFromNetwork?: boolean) {
+    return this.#client.sendMessage("inboxState", {
+      refreshFromNetwork: refreshFromNetwork ?? false,
+    });
+  }
+
+  async getLatestInboxState(inboxId: string) {
+    return this.#client.sendMessage("getLatestInboxState", { inboxId });
+  }
+
+  async setConsentStates(records: SafeConsent[]) {
+    return this.#client.sendMessage("setConsentStates", { records });
+  }
+
+  async getConsentState(entityType: ConsentEntityType, entity: string) {
+    return this.#client.sendMessage("getConsentState", { entityType, entity });
+  }
+
+  async streamConsent(callback?: StreamCallback<SafeConsent[]>) {
+    const streamId = v4();
+    const asyncStream = new AsyncStream<SafeConsent[]>();
+    const endStream = this.#client.handleStreamMessage<SafeConsent[]>(
+      streamId,
+      (error, value) => {
+        void asyncStream.callback(error, value ?? undefined);
+        void callback?.(error, value ?? undefined);
+      },
+    );
+    await this.#client.sendMessage("streamConsent", {
+      streamId,
+    });
+    asyncStream.onReturn = () => {
+      void this.#client.sendMessage("endStream", {
+        streamId,
+      });
+      endStream();
+    };
+    return asyncStream;
+  }
+
+  async streamPreferences(callback?: StreamCallback<UserPreference[]>) {
+    const streamId = v4();
+    const asyncStream = new AsyncStream<UserPreference[]>();
+    const endStream = this.#client.handleStreamMessage<UserPreference[]>(
+      streamId,
+      (error, value) => {
+        void asyncStream.callback(error, value ?? undefined);
+        void callback?.(error, value ?? undefined);
+      },
+    );
+    await this.#client.sendMessage("streamPreferences", {
+      streamId,
+    });
+    asyncStream.onReturn = () => {
+      void this.#client.sendMessage("endStream", {
+        streamId,
+      });
+      endStream();
+    };
+    return asyncStream;
+  }
+}

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -1,23 +1,24 @@
 import {
   verifySignedWithPublicKey,
   type Client,
-  type ConsentEntityType,
   type Identifier,
   type SignatureRequestType,
 } from "@xmtp/wasm-bindings";
 import type { ClientOptions } from "@/types";
-import { fromSafeConsent, type SafeConsent } from "@/utils/conversions";
 import { createClient } from "@/utils/createClient";
 import { WorkerConversations } from "@/WorkerConversations";
+import { WorkerPreferences } from "@/WorkerPreferences";
 
 export class WorkerClient {
   #client: Client;
-
   #conversations: WorkerConversations;
+  #preferences: WorkerPreferences;
 
   constructor(client: Client) {
     this.#client = client;
-    this.#conversations = new WorkerConversations(this, client.conversations());
+    const conversations = client.conversations();
+    this.#conversations = new WorkerConversations(this, conversations);
+    this.#preferences = new WorkerPreferences(client, conversations);
   }
 
   static async create(
@@ -47,6 +48,14 @@ export class WorkerClient {
 
   get isRegistered() {
     return this.#client.isRegistered;
+  }
+
+  get conversations() {
+    return this.#conversations;
+  }
+
+  get preferences() {
+    return this.#preferences;
   }
 
   createInboxSignatureText() {
@@ -120,26 +129,6 @@ export class WorkerClient {
 
   async findInboxIdByIdentifier(identifier: Identifier) {
     return this.#client.findInboxIdByIdentifier(identifier);
-  }
-
-  async inboxState(refreshFromNetwork: boolean) {
-    return this.#client.inboxState(refreshFromNetwork);
-  }
-
-  async getLatestInboxState(inboxId: string) {
-    return this.#client.getLatestInboxState(inboxId);
-  }
-
-  async setConsentStates(records: SafeConsent[]) {
-    return this.#client.setConsentStates(records.map(fromSafeConsent));
-  }
-
-  async getConsentState(entityType: ConsentEntityType, entity: string) {
-    return this.#client.getConsentState(entityType, entity);
-  }
-
-  get conversations() {
-    return this.#conversations;
   }
 
   signWithInstallationKey(signatureText: string) {

--- a/sdks/browser-sdk/src/WorkerConversations.ts
+++ b/sdks/browser-sdk/src/WorkerConversations.ts
@@ -1,13 +1,11 @@
 import {
   ConversationType,
-  type Consent,
   type ConsentState,
   type Conversation,
   type ConversationListItem,
   type Conversations,
   type Identifier,
   type Message,
-  type UserPreference,
 } from "@xmtp/wasm-bindings";
 import type { StreamCallback } from "@/AsyncStream";
 import {
@@ -177,28 +175,5 @@ export class WorkerConversations {
       { on_message, on_error },
       conversationType,
     );
-  }
-
-  streamConsent(callback?: StreamCallback<Consent[]>) {
-    const on_consent_update = (consent: Consent[]) => {
-      void callback?.(null, consent);
-    };
-    const on_error = (error: Error | null) => {
-      void callback?.(error, undefined);
-    };
-    return this.#conversations.streamConsent({ on_consent_update, on_error });
-  }
-
-  streamPreferences(callback?: StreamCallback<UserPreference[]>) {
-    const on_user_preference_update = (preferences: UserPreference[]) => {
-      void callback?.(null, preferences);
-    };
-    const on_error = (error: Error | null) => {
-      void callback?.(error, undefined);
-    };
-    return this.#conversations.streamPreferences({
-      on_user_preference_update,
-      on_error,
-    });
   }
 }

--- a/sdks/browser-sdk/src/WorkerPreferences.ts
+++ b/sdks/browser-sdk/src/WorkerPreferences.ts
@@ -1,0 +1,58 @@
+import {
+  type Client,
+  type Consent,
+  type ConsentEntityType,
+  type Conversations,
+  type UserPreference,
+} from "@xmtp/wasm-bindings";
+import type { StreamCallback } from "@/AsyncStream";
+import { fromSafeConsent, type SafeConsent } from "@/utils/conversions";
+
+export class WorkerPreferences {
+  #client: Client;
+  #conversations: Conversations;
+
+  constructor(client: Client, conversations: Conversations) {
+    this.#client = client;
+    this.#conversations = conversations;
+  }
+
+  async inboxState(refreshFromNetwork: boolean) {
+    return this.#client.inboxState(refreshFromNetwork);
+  }
+
+  async getLatestInboxState(inboxId: string) {
+    return this.#client.getLatestInboxState(inboxId);
+  }
+
+  async setConsentStates(records: SafeConsent[]) {
+    return this.#client.setConsentStates(records.map(fromSafeConsent));
+  }
+
+  async getConsentState(entityType: ConsentEntityType, entity: string) {
+    return this.#client.getConsentState(entityType, entity);
+  }
+
+  streamConsent(callback?: StreamCallback<Consent[]>) {
+    const on_consent_update = (consent: Consent[]) => {
+      void callback?.(null, consent);
+    };
+    const on_error = (error: Error | null) => {
+      void callback?.(error, undefined);
+    };
+    return this.#conversations.streamConsent({ on_consent_update, on_error });
+  }
+
+  streamPreferences(callback?: StreamCallback<UserPreference[]>) {
+    const on_user_preference_update = (preferences: UserPreference[]) => {
+      void callback?.(null, preferences);
+    };
+    const on_error = (error: Error | null) => {
+      void callback?.(error, undefined);
+    };
+    return this.#conversations.streamPreferences({
+      on_user_preference_update,
+      on_error,
+    });
+  }
+}

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -41,6 +41,7 @@ export {
   Message,
   MessageDisappearingSettings,
   MetadataField,
+  Opfs,
   PermissionLevel,
   PermissionPolicy,
   PermissionPolicySet,

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -194,24 +194,28 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
         break;
       }
       case "inboxState": {
-        const inboxState = await client.inboxState(data.refreshFromNetwork);
+        const inboxState = await client.preferences.inboxState(
+          data.refreshFromNetwork,
+        );
         const result = toSafeInboxState(inboxState);
         postMessage({ id, action, result });
         break;
       }
       case "getLatestInboxState": {
-        const inboxState = await client.getLatestInboxState(data.inboxId);
+        const inboxState = await client.preferences.getLatestInboxState(
+          data.inboxId,
+        );
         const result = toSafeInboxState(inboxState);
         postMessage({ id, action, result });
         break;
       }
       case "setConsentStates": {
-        await client.setConsentStates(data.records);
+        await client.preferences.setConsentStates(data.records);
         postMessage({ id, action, result: undefined });
         break;
       }
       case "getConsentState": {
-        const result = await client.getConsentState(
+        const result = await client.preferences.getConsentState(
           data.entityType,
           data.entity,
         );
@@ -325,7 +329,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             });
           }
         };
-        const streamCloser = client.conversations.streamConsent(streamCallback);
+        const streamCloser = client.preferences.streamConsent(streamCallback);
         streamClosers.set(data.streamId, streamCloser);
         postMessage({
           id,
@@ -354,7 +358,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
           }
         };
         const streamCloser =
-          client.conversations.streamPreferences(streamCallback);
+          client.preferences.streamPreferences(streamCallback);
         streamClosers.set(data.streamId, streamCloser);
         postMessage({
           id,

--- a/sdks/browser-sdk/test/Conversations.test.ts
+++ b/sdks/browser-sdk/test/Conversations.test.ts
@@ -1,15 +1,10 @@
-import {
-  ConsentEntityType,
-  ConsentState,
-  GroupPermissionsOptions,
-} from "@xmtp/wasm-bindings";
+import { ConsentState, GroupPermissionsOptions } from "@xmtp/wasm-bindings";
 import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
 import {
   createRegisteredClient,
   createSigner,
   createUser,
-  sleep,
 } from "@test/helpers";
 
 describe.concurrent("Conversations", () => {
@@ -492,7 +487,7 @@ describe.concurrent("Conversations", () => {
   });
 });
 
-describe("Conversations streaming", () => {
+describe("Streaming", () => {
   it("should stream new conversations", async () => {
     const user1 = createUser();
     const user2 = createUser();
@@ -770,117 +765,5 @@ describe("Conversations streaming", () => {
       }
     }
     expect(count).toBe(1);
-  });
-
-  it("should stream consent updates", async () => {
-    const user = createUser();
-    const user2 = createUser();
-    const signer1 = createSigner(user);
-    const signer2 = createSigner(user2);
-    const client = await createRegisteredClient(signer1);
-    const client2 = await createRegisteredClient(signer2);
-    const group = await client.conversations.newGroup([client2.inboxId!]);
-    const stream = await client.conversations.streamConsent();
-
-    await group.updateConsentState(ConsentState.Denied);
-
-    await sleep(1000);
-
-    await client.setConsentStates([
-      {
-        entity: group.id,
-        entityType: ConsentEntityType.GroupId,
-        state: ConsentState.Allowed,
-      },
-    ]);
-
-    await sleep(1000);
-    await client.setConsentStates([
-      {
-        entity: group.id,
-        entityType: ConsentEntityType.GroupId,
-        state: ConsentState.Denied,
-      },
-      {
-        entity: client2.inboxId!,
-        entityType: ConsentEntityType.InboxId,
-        state: ConsentState.Allowed,
-      },
-    ]);
-
-    setTimeout(() => {
-      void stream.callback(null, undefined);
-    }, 2000);
-
-    let count = 0;
-    for await (const updates of stream) {
-      if (updates === undefined) {
-        break;
-      }
-      count++;
-      if (count === 1) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-      }
-      if (count === 2) {
-        expect(updates.length).toBe(1);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-        expect(updates[0].state).toBe(ConsentState.Allowed);
-      }
-      if (count === 3) {
-        expect(updates.length).toBe(2);
-        expect(updates[0].entity).toBe(group.id);
-        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
-        expect(updates[0].state).toBe(ConsentState.Denied);
-        expect(updates[1].entity).toBe(client2.inboxId!);
-        expect(updates[1].entityType).toBe(ConsentEntityType.InboxId);
-        expect(updates[1].state).toBe(ConsentState.Allowed);
-      }
-    }
-    expect(count).toBe(3);
-  });
-
-  it("should stream preferences", async () => {
-    const user = createUser();
-    const signer = createSigner(user);
-    const client = await createRegisteredClient(signer);
-    const stream = await client.conversations.streamPreferences();
-
-    await sleep(2000);
-
-    const client2 = await createRegisteredClient(signer, {
-      dbPath: `./test-${v4()}.db3`,
-    });
-    const client3 = await createRegisteredClient(signer, {
-      dbPath: `./test-${v4()}.db3`,
-    });
-
-    await client3.conversations.syncAll();
-    await sleep(2000);
-    await client.conversations.syncAll();
-    await sleep(2000);
-    await client2.conversations.syncAll();
-    await sleep(2000);
-
-    setTimeout(() => {
-      void stream.callback(null, undefined);
-    }, 2000);
-
-    let count = 0;
-    for await (const preferences of stream) {
-      if (preferences === undefined) {
-        break;
-      }
-      count++;
-      expect(preferences).toBeDefined();
-      expect(preferences.length).toBe(1);
-      if (preferences[0].type === "HmacKeyUpdate") {
-        expect(preferences[0].key).toBeDefined();
-      }
-    }
-    expect(count).toBe(3);
   });
 });

--- a/sdks/browser-sdk/test/Preferences.test.ts
+++ b/sdks/browser-sdk/test/Preferences.test.ts
@@ -1,0 +1,208 @@
+import { ConsentEntityType, ConsentState } from "@xmtp/wasm-bindings";
+import { v4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import {
+  createClient,
+  createRegisteredClient,
+  createSigner,
+  createUser,
+  sleep,
+} from "@test/helpers";
+
+describe.concurrent("Preferences", () => {
+  it("should return the correct inbox state", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const inboxState = await client.preferences.inboxState(false);
+    expect(inboxState.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.map((install) => install.id)).toEqual([
+      client.installationId,
+    ]);
+    expect(inboxState.accountIdentifiers).toEqual([
+      await signer.getIdentifier(),
+    ]);
+    expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
+
+    const user2 = createUser();
+    const signer2 = createSigner(user2);
+    const client2 = await createClient(signer2);
+    const inboxState2 = await client2.preferences.getLatestInboxState(
+      client.inboxId!,
+    );
+    expect(inboxState2.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.length).toBe(1);
+    expect(inboxState.installations[0].id).toBe(client.installationId);
+    expect(inboxState.installations[0].bytes).toEqual(
+      client.installationIdBytes,
+    );
+    expect(inboxState2.accountIdentifiers).toEqual([
+      await signer.getIdentifier(),
+    ]);
+    expect(inboxState2.recoveryIdentifier).toEqual(
+      await signer.getIdentifier(),
+    );
+  });
+
+  it("should manage consent states", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client1.conversations.newGroup([client2.inboxId!]);
+
+    await client2.conversations.sync();
+    const group2 = await client2.conversations.getConversationById(group.id);
+
+    expect(group2).not.toBeNull();
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Unknown);
+
+    await client2.preferences.setConsentStates([
+      {
+        entityType: ConsentEntityType.GroupId,
+        entity: group2!.id,
+        state: ConsentState.Allowed,
+      },
+    ]);
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Allowed);
+
+    expect(await group2!.consentState()).toBe(ConsentState.Allowed);
+
+    await group2!.updateConsentState(ConsentState.Denied);
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Denied);
+  });
+
+  describe("Streaming", () => {
+    it("should stream consent updates", async () => {
+      const user = createUser();
+      const user2 = createUser();
+      const signer1 = createSigner(user);
+      const signer2 = createSigner(user2);
+      const client = await createRegisteredClient(signer1);
+      const client2 = await createRegisteredClient(signer2);
+      const group = await client.conversations.newGroup([client2.inboxId!]);
+      const stream = await client.preferences.streamConsent();
+
+      await group.updateConsentState(ConsentState.Denied);
+
+      await sleep(1000);
+
+      await client.preferences.setConsentStates([
+        {
+          entity: group.id,
+          entityType: ConsentEntityType.GroupId,
+          state: ConsentState.Allowed,
+        },
+      ]);
+
+      await sleep(1000);
+      await client.preferences.setConsentStates([
+        {
+          entity: group.id,
+          entityType: ConsentEntityType.GroupId,
+          state: ConsentState.Denied,
+        },
+        {
+          entity: client2.inboxId!,
+          entityType: ConsentEntityType.InboxId,
+          state: ConsentState.Allowed,
+        },
+      ]);
+
+      setTimeout(() => {
+        void stream.callback(null, undefined);
+      }, 2000);
+
+      let count = 0;
+      for await (const updates of stream) {
+        if (updates === undefined) {
+          break;
+        }
+        count++;
+        if (count === 1) {
+          expect(updates.length).toBe(1);
+          expect(updates[0].entity).toBe(group.id);
+          expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+          expect(updates[0].state).toBe(ConsentState.Denied);
+        }
+        if (count === 2) {
+          expect(updates.length).toBe(1);
+          expect(updates[0].entity).toBe(group.id);
+          expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+          expect(updates[0].state).toBe(ConsentState.Allowed);
+        }
+        if (count === 3) {
+          expect(updates.length).toBe(2);
+          expect(updates[0].entity).toBe(group.id);
+          expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+          expect(updates[0].state).toBe(ConsentState.Denied);
+          expect(updates[1].entity).toBe(client2.inboxId!);
+          expect(updates[1].entityType).toBe(ConsentEntityType.InboxId);
+          expect(updates[1].state).toBe(ConsentState.Allowed);
+        }
+      }
+      expect(count).toBe(3);
+    });
+
+    it("should stream preferences", async () => {
+      const user = createUser();
+      const signer = createSigner(user);
+      const client = await createRegisteredClient(signer);
+      const stream = await client.preferences.streamPreferences();
+
+      await sleep(2000);
+
+      const client2 = await createRegisteredClient(signer, {
+        dbPath: `./test-${v4()}.db3`,
+      });
+      const client3 = await createRegisteredClient(signer, {
+        dbPath: `./test-${v4()}.db3`,
+      });
+
+      await client3.conversations.syncAll();
+      await sleep(2000);
+      await client.conversations.syncAll();
+      await sleep(2000);
+      await client2.conversations.syncAll();
+      await sleep(2000);
+
+      setTimeout(() => {
+        void stream.callback(null, undefined);
+      }, 2000);
+
+      let count = 0;
+      for await (const preferences of stream) {
+        if (preferences === undefined) {
+          break;
+        }
+        count++;
+        expect(preferences).toBeDefined();
+        expect(preferences.length).toBe(1);
+        if (preferences[0].type === "HmacKeyUpdate") {
+          expect(preferences[0].key).toBeDefined();
+        }
+      }
+      expect(count).toBe(3);
+    });
+  });
+});

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -1,5 +1,4 @@
 import type {
-  Consent,
   ConsentState,
   CreateDmOptions,
   CreateGroupOptions,
@@ -12,13 +11,6 @@ import type { Client } from "@/Client";
 import { DecodedMessage } from "@/DecodedMessage";
 import { Dm } from "@/Dm";
 import { Group } from "@/Group";
-
-export type PreferenceUpdate = {
-  type: string;
-  HmacKeyUpdate?: {
-    key: Uint8Array;
-  };
-};
 
 export class Conversations {
   #client: Client;
@@ -284,44 +276,5 @@ export class Conversations {
 
   hmacKeys() {
     return this.#conversations.getHmacKeys();
-  }
-
-  streamConsent(callback?: StreamCallback<Consent[]>) {
-    const asyncStream = new AsyncStream<Consent[]>();
-
-    const stream = this.#conversations.streamConsent((err, value) => {
-      if (err) {
-        asyncStream.callback(err, undefined);
-        callback?.(err, undefined);
-        return;
-      }
-
-      asyncStream.callback(null, value);
-      callback?.(null, value);
-    });
-
-    asyncStream.onReturn = stream.end.bind(stream);
-
-    return asyncStream;
-  }
-
-  streamPreferences(callback?: StreamCallback<PreferenceUpdate>) {
-    const asyncStream = new AsyncStream<PreferenceUpdate>();
-
-    const stream = this.#conversations.streamPreferences((err, value) => {
-      if (err) {
-        asyncStream.callback(err, undefined);
-        callback?.(err, undefined);
-        return;
-      }
-
-      // TODO: remove this once the node bindings type is updated
-      asyncStream.callback(null, value as unknown as PreferenceUpdate);
-      callback?.(null, value as unknown as PreferenceUpdate);
-    });
-
-    asyncStream.onReturn = stream.end.bind(stream);
-
-    return asyncStream;
   }
 }

--- a/sdks/node-sdk/src/Preferences.ts
+++ b/sdks/node-sdk/src/Preferences.ts
@@ -1,0 +1,89 @@
+import type {
+  Client,
+  Consent,
+  ConsentEntityType,
+  Conversations,
+} from "@xmtp/node-bindings";
+import { AsyncStream, type StreamCallback } from "@/AsyncStream";
+
+export type PreferenceUpdate = {
+  type: string;
+  HmacKeyUpdate?: {
+    key: Uint8Array;
+  };
+};
+
+export class Preferences {
+  #client: Client;
+  #conversations: Conversations;
+
+  constructor(client: Client, conversations: Conversations) {
+    this.#client = client;
+    this.#conversations = conversations;
+  }
+
+  async inboxState(refreshFromNetwork: boolean = false) {
+    return this.#client.inboxState(refreshFromNetwork);
+  }
+
+  async getLatestInboxState(inboxId: string) {
+    return this.#client.getLatestInboxState(inboxId);
+  }
+
+  async inboxStateFromInboxIds(
+    inboxIds: string[],
+    refreshFromNetwork?: boolean,
+  ) {
+    return this.#client.addressesFromInboxId(
+      refreshFromNetwork ?? false,
+      inboxIds,
+    );
+  }
+
+  async setConsentStates(consentStates: Consent[]) {
+    return this.#client.setConsentStates(consentStates);
+  }
+
+  async getConsentState(entityType: ConsentEntityType, entity: string) {
+    return this.#client.getConsentState(entityType, entity);
+  }
+
+  streamConsent(callback?: StreamCallback<Consent[]>) {
+    const asyncStream = new AsyncStream<Consent[]>();
+
+    const stream = this.#conversations.streamConsent((err, value) => {
+      if (err) {
+        asyncStream.callback(err, undefined);
+        callback?.(err, undefined);
+        return;
+      }
+
+      asyncStream.callback(null, value);
+      callback?.(null, value);
+    });
+
+    asyncStream.onReturn = stream.end.bind(stream);
+
+    return asyncStream;
+  }
+
+  streamPreferences(callback?: StreamCallback<PreferenceUpdate>) {
+    const asyncStream = new AsyncStream<PreferenceUpdate>();
+
+    const stream = this.#conversations.streamPreferences((err, value) => {
+      if (err) {
+        asyncStream.callback(err, undefined);
+        callback?.(err, undefined);
+        return;
+      }
+
+      // TODO: remove this once the node bindings type is updated
+      asyncStream.callback(null, value as unknown as PreferenceUpdate);
+      callback?.(null, value as unknown as PreferenceUpdate);
+    });
+
+    asyncStream.onReturn = stream.end.bind(stream);
+
+    return asyncStream;
+  }
+}

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -10,7 +10,7 @@ export { Conversation } from "./Conversation";
 export { Conversations } from "./Conversations";
 export { Dm } from "./Dm";
 export { Group } from "./Group";
-export type { PreferenceUpdate } from "./Conversations";
+export type { PreferenceUpdate } from "./Preferences";
 export { DecodedMessage } from "./DecodedMessage";
 export type { StreamCallback } from "./AsyncStream";
 export type {

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -1,8 +1,4 @@
-import {
-  ConsentEntityType,
-  ConsentState,
-  IdentifierKind,
-} from "@xmtp/node-bindings";
+import { IdentifierKind } from "@xmtp/node-bindings";
 import { uint8ArrayToHex } from "uint8array-extras";
 import { v4 } from "uuid";
 import { describe, expect, it } from "vitest";
@@ -69,56 +65,6 @@ describe.concurrent("Client", () => {
     expect(inboxId).toBe(client.inboxId);
   });
 
-  it("should return the correct inbox state", async () => {
-    const user = createUser();
-    const signer = createSigner(user);
-    const client = await createRegisteredClient(signer);
-    const inboxState = await client.inboxState();
-    expect(inboxState.inboxId).toBe(client.inboxId);
-    expect(inboxState.installations.map((install) => install.id)).toEqual([
-      client.installationId,
-    ]);
-    expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
-    expect(inboxState.recoveryIdentifier).toStrictEqual(
-      await signer.getIdentifier(),
-    );
-
-    const user2 = createUser();
-    const signer2 = createSigner(user2);
-    const client2 = await createClient(signer2);
-    const inboxState2 = await client2.getLatestInboxState(client.inboxId);
-    expect(inboxState2.inboxId).toBe(client.inboxId);
-    expect(inboxState.installations.length).toBe(1);
-    expect(inboxState.installations[0].id).toBe(client.installationId);
-    expect(inboxState2.identifiers).toEqual([await signer.getIdentifier()]);
-    expect(inboxState2.recoveryIdentifier).toStrictEqual(
-      await signer.getIdentifier(),
-    );
-  });
-
-  it("should get inbox states from inbox IDs", async () => {
-    const user = createUser();
-    const user2 = createUser();
-    const signer = createSigner(user);
-    const signer2 = createSigner(user2);
-    const client = await createRegisteredClient(signer);
-    const client2 = await createRegisteredClient(signer2);
-    const inboxStates = await client.inboxStateFromInboxIds([client.inboxId]);
-    expect(inboxStates.length).toBe(1);
-    expect(inboxStates[0].inboxId).toBe(client.inboxId);
-    expect(inboxStates[0].identifiers).toEqual([await signer.getIdentifier()]);
-
-    const inboxStates2 = await client2.inboxStateFromInboxIds(
-      [client2.inboxId],
-      true,
-    );
-    expect(inboxStates2.length).toBe(1);
-    expect(inboxStates2[0].inboxId).toBe(client2.inboxId);
-    expect(inboxStates2[0].identifiers).toEqual([
-      await signer2.getIdentifier(),
-    ]);
-  });
-
   it("should add a wallet association to the client", async () => {
     const user = createUser();
     const user2 = createUser();
@@ -128,7 +74,7 @@ describe.concurrent("Client", () => {
 
     await client.unsafe_addAccount(signer2);
 
-    const inboxState = await client.inboxState();
+    const inboxState = await client.preferences.inboxState();
     expect(inboxState.identifiers.length).toEqual(2);
     expect(inboxState.identifiers).toContainEqual(await signer.getIdentifier());
     expect(inboxState.identifiers).toContainEqual(
@@ -146,7 +92,7 @@ describe.concurrent("Client", () => {
     await client.unsafe_addAccount(signer2);
     await client.removeAccount(await signer2.getIdentifier());
 
-    const inboxState = await client.inboxState();
+    const inboxState = await client.preferences.inboxState();
     expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
   });
 
@@ -161,7 +107,7 @@ describe.concurrent("Client", () => {
       dbPath: `./test-${v4()}.db3`,
     });
 
-    const inboxState = await client3.inboxState(true);
+    const inboxState = await client3.preferences.inboxState(true);
     expect(inboxState.installations.length).toBe(3);
 
     const installationIds = inboxState.installations.map((i) => i.id);
@@ -171,7 +117,7 @@ describe.concurrent("Client", () => {
 
     await client3.revokeAllOtherInstallations();
 
-    const inboxState2 = await client3.inboxState(true);
+    const inboxState2 = await client3.preferences.inboxState(true);
 
     expect(inboxState2.installations.length).toBe(1);
     expect(inboxState2.installations[0].id).toBe(client3.installationId);
@@ -188,7 +134,7 @@ describe.concurrent("Client", () => {
       dbPath: `./test-${v4()}.db3`,
     });
 
-    const inboxState = await client3.inboxState(true);
+    const inboxState = await client3.preferences.inboxState(true);
     expect(inboxState.installations.length).toBe(3);
 
     const installationIds = inboxState.installations.map((i) => i.id);
@@ -198,7 +144,7 @@ describe.concurrent("Client", () => {
 
     await client3.revokeInstallations([client.installationIdBytes]);
 
-    const inboxState2 = await client3.inboxState(true);
+    const inboxState2 = await client3.preferences.inboxState(true);
 
     expect(inboxState2.installations.length).toBe(2);
 
@@ -206,45 +152,6 @@ describe.concurrent("Client", () => {
     expect(installationIds2).toContain(client2.installationId);
     expect(installationIds2).toContain(client3.installationId);
     expect(installationIds2).not.toContain(client.installationId);
-  });
-
-  it("should manage consent states", async () => {
-    const user1 = createUser();
-    const user2 = createUser();
-    const signer1 = createSigner(user1);
-    const signer2 = createSigner(user2);
-    const client1 = await createRegisteredClient(signer1);
-    const client2 = await createRegisteredClient(signer2);
-    const group = await client1.conversations.newGroup([client2.inboxId]);
-
-    await client2.conversations.sync();
-    const group2 = await client2.conversations.getConversationById(group.id);
-
-    expect(group2).not.toBeNull();
-
-    expect(
-      await client2.getConsentState(ConsentEntityType.GroupId, group2!.id),
-    ).toBe(ConsentState.Unknown);
-
-    await client2.setConsentStates([
-      {
-        entityType: ConsentEntityType.GroupId,
-        entity: group2!.id,
-        state: ConsentState.Allowed,
-      },
-    ]);
-
-    expect(
-      await client2.getConsentState(ConsentEntityType.GroupId, group2!.id),
-    ).toBe(ConsentState.Allowed);
-
-    expect(group2!.consentState).toBe(ConsentState.Allowed);
-
-    group2!.updateConsentState(ConsentState.Denied);
-
-    expect(
-      await client2.getConsentState(ConsentEntityType.GroupId, group2!.id),
-    ).toBe(ConsentState.Denied);
   });
 
   it("should verify signatures", async () => {

--- a/sdks/node-sdk/test/Preferences.test.ts
+++ b/sdks/node-sdk/test/Preferences.test.ts
@@ -1,0 +1,224 @@
+import { ConsentEntityType, ConsentState } from "@xmtp/node-bindings";
+import { v4 } from "uuid";
+import { describe, expect, it } from "vitest";
+import {
+  createClient,
+  createRegisteredClient,
+  createSigner,
+  createUser,
+  sleep,
+} from "@test/helpers";
+
+describe.concurrent("Preferences", () => {
+  it("should return the correct inbox state", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const inboxState = await client.preferences.inboxState();
+    expect(inboxState.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.map((install) => install.id)).toEqual([
+      client.installationId,
+    ]);
+    expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
+    expect(inboxState.recoveryIdentifier).toStrictEqual(
+      await signer.getIdentifier(),
+    );
+
+    const user2 = createUser();
+    const signer2 = createSigner(user2);
+    const client2 = await createClient(signer2);
+    const inboxState2 = await client2.preferences.getLatestInboxState(
+      client.inboxId,
+    );
+    expect(inboxState2.inboxId).toBe(client.inboxId);
+    expect(inboxState.installations.length).toBe(1);
+    expect(inboxState.installations[0].id).toBe(client.installationId);
+    expect(inboxState2.identifiers).toEqual([await signer.getIdentifier()]);
+    expect(inboxState2.recoveryIdentifier).toStrictEqual(
+      await signer.getIdentifier(),
+    );
+  });
+
+  it("should get inbox states from inbox IDs", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const signer = createSigner(user);
+    const signer2 = createSigner(user2);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer2);
+    const inboxStates = await client.preferences.inboxStateFromInboxIds([
+      client.inboxId,
+    ]);
+    expect(inboxStates.length).toBe(1);
+    expect(inboxStates[0].inboxId).toBe(client.inboxId);
+    expect(inboxStates[0].identifiers).toEqual([await signer.getIdentifier()]);
+
+    const inboxStates2 = await client2.preferences.inboxStateFromInboxIds(
+      [client2.inboxId],
+      true,
+    );
+    expect(inboxStates2.length).toBe(1);
+    expect(inboxStates2[0].inboxId).toBe(client2.inboxId);
+    expect(inboxStates2[0].identifiers).toEqual([
+      await signer2.getIdentifier(),
+    ]);
+  });
+
+  it("should manage consent states", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client1.conversations.newGroup([client2.inboxId]);
+
+    await client2.conversations.sync();
+    const group2 = await client2.conversations.getConversationById(group.id);
+
+    expect(group2).not.toBeNull();
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Unknown);
+
+    await client2.preferences.setConsentStates([
+      {
+        entityType: ConsentEntityType.GroupId,
+        entity: group2!.id,
+        state: ConsentState.Allowed,
+      },
+    ]);
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Allowed);
+
+    expect(group2!.consentState).toBe(ConsentState.Allowed);
+
+    group2!.updateConsentState(ConsentState.Denied);
+
+    expect(
+      await client2.preferences.getConsentState(
+        ConsentEntityType.GroupId,
+        group2!.id,
+      ),
+    ).toBe(ConsentState.Denied);
+  });
+
+  it("should stream consent updates", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const signer = createSigner(user);
+    const signer2 = createSigner(user2);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer2);
+    const group = await client.conversations.newGroup([client2.inboxId]);
+    const stream = client.preferences.streamConsent();
+
+    group.updateConsentState(ConsentState.Denied);
+
+    await sleep(1000);
+
+    await client.preferences.setConsentStates([
+      {
+        entity: group.id,
+        entityType: ConsentEntityType.GroupId,
+        state: ConsentState.Allowed,
+      },
+    ]);
+
+    await sleep(1000);
+    await client.preferences.setConsentStates([
+      {
+        entity: group.id,
+        entityType: ConsentEntityType.GroupId,
+        state: ConsentState.Denied,
+      },
+      {
+        entity: client2.inboxId,
+        entityType: ConsentEntityType.InboxId,
+        state: ConsentState.Allowed,
+      },
+    ]);
+
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
+    let count = 0;
+    for await (const updates of stream) {
+      if (updates === undefined) {
+        break;
+      }
+      count++;
+      if (count === 1) {
+        expect(updates.length).toBe(1);
+        expect(updates[0].state).toBe(ConsentState.Denied);
+        expect(updates[0].entity).toBe(group.id);
+        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+      } else if (count === 2) {
+        expect(updates.length).toBe(1);
+        expect(updates[0].state).toBe(ConsentState.Allowed);
+        expect(updates[0].entity).toBe(group.id);
+        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+      } else if (count === 3) {
+        expect(updates.length).toBe(2);
+        expect(updates[0].state).toBe(ConsentState.Denied);
+        expect(updates[0].entity).toBe(group.id);
+        expect(updates[0].entityType).toBe(ConsentEntityType.GroupId);
+        expect(updates[1].state).toBe(ConsentState.Allowed);
+        expect(updates[1].entity).toBe(client2.inboxId);
+        expect(updates[1].entityType).toBe(ConsentEntityType.InboxId);
+      }
+    }
+    expect(count).toBe(3);
+  });
+
+  it("should stream preferences", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const stream = client.preferences.streamPreferences();
+
+    await sleep(2000);
+
+    const client2 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+
+    const client3 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+
+    await client3.conversations.syncAll();
+    await sleep(2000);
+    await client.conversations.syncAll();
+    await sleep(2000);
+    await client2.conversations.syncAll();
+    await sleep(2000);
+
+    setTimeout(() => {
+      stream.callback(null, undefined);
+    }, 2000);
+
+    let count = 0;
+    for await (const preferences of stream) {
+      if (preferences === undefined) {
+        break;
+      }
+      count++;
+      expect(preferences).toBeDefined();
+      expect(preferences.type).toBeDefined();
+      expect(preferences.HmacKeyUpdate).toBeDefined();
+      expect(preferences.HmacKeyUpdate?.key).toBeDefined();
+    }
+    expect(count).toBe(3);
+  });
+});


### PR DESCRIPTION
# Summary

- Created new `Preferences` class to house all private preference related functions
- Added new `preferences` property to `Client` to access these methods
- Exported `Opfs` class (Browser SDK)