### PR TITLE
Fix broken link to content-type-remote-attachment

### DIFF
--- a/content-types/content-type-remote-attachment/README.md
+++ b/content-types/content-type-remote-attachment/README.md
@@ -2,7 +2,7 @@
 
 ![Status](https://img.shields.io/badge/Content_type_status-Standards--track-yellow) ![Status](https://img.shields.io/badge/Reference_implementation_status-Stable-brightgreen)
 
-The [@xmtp/content-type-remote-attachment](https://github.com/xmtp/xmtp-js-content-types/tree/main/content-types/content-type-remote-attachment) package provides an XMTP content type to support sending file attachments that are stored off-network. Use it to enable your app to send and receive message attachments.
+The [@xmtp/content-type-remote-attachment](https://github.com/xmtp/xmtp-js-content-types/tree/main/packages/content-type-remote-attachment) package provides an XMTP content type to support sending file attachments that are stored off-network. Use it to enable your app to send and receive message attachments.
 
 > **Open for feedback**  
 > You are welcome to provide feedback on this implementation by commenting on the [Remote Attachment Content Type XIP](https://github.com/xmtp/XIPs/blob/main/XIPs/xip-17-remote-attachment-content-type-proposal.md) (XMTP Improvement Proposal).


### PR DESCRIPTION
This update corrects the link to the content-type-remote-attachment package in the README.md file. The previous link pointed to an incorrect path, and it has been updated to reference the correct directory.

File changed: content-types/content-type-remote-attachment/README.md

Old link: https://github.com/xmtp/xmtp-js-content-types/tree/main/content-types/content-type-remote-attachment
New link: https://github.com/xmtp/xmtp-js-content-types/tree/main/packages/content-type-remote-attachment