### PR TITLE
Upgrade browser SDK in dev tool

### DIFF
--- a/apps/xmtp.chat/package.json
+++ b/apps/xmtp.chat/package.json
@@ -21,7 +21,7 @@
     "@mantine/modals": "^7.17.2",
     "@mantine/notifications": "^7.17.2",
     "@tanstack/react-query": "^5.69.0",
-    "@xmtp/browser-sdk": "1.1.0",
+    "@xmtp/browser-sdk": "1.1.1",
     "@xmtp/content-type-group-updated": "^2.0.0",
     "@xmtp/content-type-primitives": "^2.0.0",
     "@xmtp/content-type-reaction": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,21 +3406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/browser-sdk@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@xmtp/browser-sdk@npm:1.1.0"
-  dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.0"
-    "@xmtp/content-type-primitives": "npm:^2.0.0"
-    "@xmtp/content-type-text": "npm:^2.0.0"
-    "@xmtp/proto": "npm:^3.72.3"
-    "@xmtp/wasm-bindings": "npm:^1.1.0"
-    uuid: "npm:^11.0.3"
-  checksum: 10/220dffb75594d16ded0bbf6448a3923c55e4e0b26b253aa663df3ebae372378735c24d0268c9f76a17da0a87ad5e7aab0b2fdf59666e759332676391c2c3c57e
-  languageName: node
-  linkType: hard
-
-"@xmtp/browser-sdk@workspace:sdks/browser-sdk":
+"@xmtp/browser-sdk@npm:1.1.1, @xmtp/browser-sdk@workspace:sdks/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/browser-sdk@workspace:sdks/browser-sdk"
   dependencies:
@@ -3645,7 +3631,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/proto@npm:^3.72.3, @xmtp/proto@npm:^3.78.0":
+"@xmtp/proto@npm:^3.78.0":
   version: 3.78.0
   resolution: "@xmtp/proto@npm:3.78.0"
   dependencies:
@@ -3690,7 +3676,7 @@ __metadata:
     "@types/react": "npm:^19.0.12"
     "@types/react-dom": "npm:^19.0.4"
     "@vitejs/plugin-react": "npm:^4.3.4"
-    "@xmtp/browser-sdk": "npm:1.1.0"
+    "@xmtp/browser-sdk": "npm:1.1.1"
     "@xmtp/content-type-group-updated": "npm:^2.0.0"
     "@xmtp/content-type-primitives": "npm:^2.0.0"
     "@xmtp/content-type-reaction": "npm:^2.0.0"
@@ -10423,7 +10409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.0.3, uuid@npm:^11.1.0":
+"uuid@npm:^11.1.0":
   version: 11.1.0
   resolution: "uuid@npm:11.1.0"
   bin:


### PR DESCRIPTION
## Update `@xmtp/browser-sdk` to v1.1.1
Dependency version update for `@xmtp/browser-sdk` from v1.1.0 to v1.1.1 in XMTP chat application

### 📍Where to Start
The dependency update in [package.json](https://github.com/xmtp/xmtp-js/pull/895/files#diff-0b676dbdc3fa949b9bfafb55bb5fbfb04054a499b5490d6d853830ee6b69a4d8)

----

_[Macroscope](https://app.macroscope.com) summarized 8f69207._