### PR TITLE
Adds change recovery address function

### DIFF
--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.1",
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
-    "@xmtp/node-bindings": "^1.1.1",
+    "@xmtp/node-bindings": "1.2.0-dev.3d6d1ef",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -299,7 +299,7 @@ export class Client {
    *
    * It is highly recommended to use the `changeRecoveryIdentifer` function instead.
    */
-  async unsafe_changeRecoveryIdentiferSignatureText(identifier: Identifier) {
+  async unsafe_changeRecoveryIdentifierSignatureText(identifier: Identifier) {
     try {
       const signatureText =
         await this.#innerClient.changeRecoveryIdentifierSignatureText(

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -297,6 +297,35 @@ export class Client {
    * for use in special cases where the provided workflows do not meet the
    * requirements of an application.
    *
+   * It is highly recommended to use the `changeRecoveryIdentifer` function instead.
+   */
+  async unsafe_changeRecoveryIdentiferSignatureText(identifier: Identifier) {
+    try {
+      const signatureText =
+        await this.#innerClient.changeRecoveryIdentifierSignatureText(
+          identifier,
+        );
+      if (!signatureText) {
+        throw new Error("Unable to generate add account signature text");
+      }
+
+      await this.unsafe_addSignature(
+        SignatureRequestType.ChangeRecoveryIdentifier,
+        signatureText,
+        this.#signer,
+      );
+
+      await this.unsafe_applySignatures();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * WARNING: This function should be used with caution. It is only provided
+   * for use in special cases where the provided workflows do not meet the
+   * requirements of an application.
+   *
    * It is highly recommended to use the `register`, `addAccount`,
    * `removeAccount`, `revokeAllOtherInstallations`, or `revokeInstallations`
    * functions instead.

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -231,4 +231,24 @@ describe.concurrent("Client", () => {
   it("should return a version", () => {
     expect(Client.version).toBeDefined();
   });
+
+  it("should change the recovery identifier", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const signer = createSigner(user);
+    const signer2 = createSigner(user2);
+    const client = await createRegisteredClient(signer);
+
+    const inboxState = await client.preferences.inboxState();
+    expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
+
+    await client.unsafe_changeRecoveryIdentiferSignatureText(
+      await signer2.getIdentifier(),
+    );
+
+    const inboxState2 = await client.preferences.inboxState();
+    expect(inboxState2.recoveryIdentifier).toEqual(
+      await signer2.getIdentifier(),
+    );
+  });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -242,7 +242,7 @@ describe.concurrent("Client", () => {
     const inboxState = await client.preferences.inboxState();
     expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
-    await client.unsafe_changeRecoveryIdentiferSignatureText(
+    await client.unsafe_changeRecoveryIdentifierSignatureText(
       await signer2.getIdentifier(),
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3594,10 +3594,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@xmtp/node-bindings@npm:1.1.1"
-  checksum: 10/90756102b7160506fddfe4cf3ecf6ff7a3b11015d28efbca4c9049e3d2c3005ccc85e30e1f77d1ada80a9e3bedaeee952a8cf7c8867581f0459dde78737a307d
+"@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef":
+  version: 1.2.0-dev.3d6d1ef
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef"
+  checksum: 10/fbe4f2c5299cd5fe821df29e382816809a64a60e847c302eb63c2b04bb972ebffebd09fae9729ff89665cffc06141b5058f7122be2f4a2ec5a870b64a93a947f
   languageName: node
   linkType: hard
 
@@ -3612,7 +3612,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.1.1"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.3d6d1ef"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
## Add Recovery Address Change Function to Node SDK
Added `unsafe_changeRecoveryIdentifierSignatureText` method to Client class to enable changing recovery identifiers, updated `@xmtp/node-bindings` dependency to version `1.2.0-dev.3d6d1ef`, and added corresponding test coverage.

### 📍Where to Start
The `unsafe_changeRecoveryIdentifierSignatureText` method implementation in [Client.ts](https://github.com/xmtp/xmtp-js/pull/909/files#diff-e7637ca578d57e5d723c000e1253fce171547e1cfb6548a8c99b618b5e620d38R0)

----

_[Macroscope](https://app.macroscope.com) summarized d48d8a5._