### PR TITLE
Upgrade bindings

### DIFF
--- a/.changeset/chilly-shoes-wonder.md
+++ b/.changeset/chilly-shoes-wonder.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+- Fixed incorrect key package associations
+- Resolved DM stitching issues for conversations without messages

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
     "@xmtp/proto": "^3.78.0",
-    "@xmtp/wasm-bindings": "^1.1.1",
+    "@xmtp/wasm-bindings": "^1.1.2",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.1",
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
-    "@xmtp/node-bindings": "^1.1.1",
+    "@xmtp/node-bindings": "^1.1.2",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,7 +3422,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
     "@xmtp/proto": "npm:^3.78.0"
-    "@xmtp/wasm-bindings": "npm:^1.1.1"
+    "@xmtp/wasm-bindings": "npm:^1.1.2"
     playwright: "npm:^1.51.1"
     rollup: "npm:^4.36.0"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3594,10 +3594,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@xmtp/node-bindings@npm:1.1.1"
-  checksum: 10/90756102b7160506fddfe4cf3ecf6ff7a3b11015d28efbca4c9049e3d2c3005ccc85e30e1f77d1ada80a9e3bedaeee952a8cf7c8867581f0459dde78737a307d
+"@xmtp/node-bindings@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@xmtp/node-bindings@npm:1.1.2"
+  checksum: 10/9f4abc51ed76be5e4279d5123ca72096888410a4c7b99b2717beea8bea3c46c62cbaa8d0e6e1889a248e78675cddb9408e11a6902578cb8c76ea2b035691dd55
   languageName: node
   linkType: hard
 
@@ -3612,7 +3612,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.1.1"
+    "@xmtp/node-bindings": "npm:^1.1.2"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
@@ -3656,10 +3656,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@xmtp/wasm-bindings@npm:1.1.1"
-  checksum: 10/524d535a09e778331ed0d0cfb4363e3ca8cd6954bdc9bc21e37d7ce3d62138b34090c7e52e14e15fe88ee1d064e855d6b8743768a147b378573ca52c7799ede2
+"@xmtp/wasm-bindings@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@xmtp/wasm-bindings@npm:1.1.2"
+  checksum: 10/0dfbc93e80cc576804fbbf44169205804831e06d1298d12af6323b20b383ce33be0b2fc296209f4fc3a5d1c13c122f72532802a69f8fd5fae8e4d16cf70f7967
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
libxmtp 1.1.2 PR for reference: https://github.com/xmtp/libxmtp/pull/1801

## Upgrade XMTP bindings to v1.1.2
Updated dependency versions of `@xmtp/wasm-bindings` and `@xmtp/node-bindings` from v1.1.1 to v1.1.2 in browser and node SDKs. Added changelog entry for patch release addressing key package associations and DM stitching fixes.

### 📍Where to Start
Review the version updates in [package.json](https://github.com/xmtp/xmtp-js/pull/910/files#diff-0b5ce3295c49d5f7fa161f0ec5f7901507aa0a7b4412014a922a6f7cdf4208f4R0) for browser SDK and [package.json](https://github.com/xmtp/xmtp-js/pull/910/files#diff-2c53d8c6487a7120d47542e0d8b9e87dee5c6beb549d996cdad1ce8b62d045d0R0) for node SDK.

----

_[Macroscope](https://app.macroscope.com) summarized 7a961c7._