### PR TITLE
Add support for sepolia and base sepolia chains

### DIFF
--- a/apps/xmtp.chat/src/main.tsx
+++ b/apps/xmtp.chat/src/main.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { createConfig, http, WagmiProvider } from "wagmi";
-import { base, mainnet } from "wagmi/chains";
+import { base, baseSepolia, mainnet, sepolia } from "wagmi/chains";
 import {
   coinbaseWallet,
   injected,
@@ -27,10 +27,12 @@ export const config = createConfig({
     metaMask(),
     walletConnect({ projectId: import.meta.env.VITE_PROJECT_ID }),
   ],
-  chains: [mainnet, base],
+  chains: [mainnet, base, sepolia, baseSepolia],
   transports: {
     [mainnet.id]: http(),
+    [sepolia.id]: http(),
     [base.id]: http(),
+    [baseSepolia.id]: http(),
   },
 });
 


### PR DESCRIPTION
### Configure Wagmi provider to support Sepolia and Base Sepolia test networks in XMTP chat application
The application's blockchain network configuration in [main.tsx](https://github.com/xmtp/xmtp-js/pull/923/files#diff-11f60809f1f0b15283feb4fc7277cd6813fd3b810b9b9e8c92da6f2a1ab0b4bf) has been updated to include test networks:

* Added `sepolia` and `baseSepolia` chain imports from `wagmi/chains`
* Configured HTTP transport for both test networks
* Integrated new chains into the Wagmi provider configuration array

#### 📍Where to Start
Begin reviewing the network configuration changes in [main.tsx](https://github.com/xmtp/xmtp-js/pull/923/files#diff-11f60809f1f0b15283feb4fc7277cd6813fd3b810b9b9e8c92da6f2a1ab0b4bf), focusing on the chain imports and provider configuration.

----

_[Macroscope](https://app.macroscope.com) summarized b3eac66._