### PR TITLE
Adding key package status to node-sdk

### DIFF
--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.1",
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
-    "@xmtp/node-bindings": "^1.1.3",
+    "@xmtp/node-bindings": "^1.2.0-dev.bed98df",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -18,6 +18,7 @@ import {
   IdentifierKind,
   isAddressAuthorized as isAddressAuthorizedBinding,
   isInstallationAuthorized as isInstallationAuthorizedBinding,
+  KeyPackageStatus,
   LogLevel,
   SignatureRequestType,
   verifySignedWithPublicKey as verifySignedWithPublicKeyBinding,
@@ -474,6 +475,37 @@ export class Client {
       [],
     );
     return client.canMessage(identifiers);
+  }
+
+  static async keyPackageStatusForInstallations(
+    installationIds: string[],
+    env?: XmtpEnv,
+  ): Promise<Record<string, KeyPackageStatus | undefined>> {
+    const accountAddress = "0x0000000000000000000000000000000000000000";
+    const host = ApiUrls[env || "dev"];
+    const isSecure = host.startsWith("https");
+    const identifier: Identifier = {
+      identifierKind: IdentifierKind.Ethereum,
+      identifier: accountAddress,
+    };
+    const inboxId =
+      (await getInboxIdForIdentifier(host, isSecure, identifier)) ||
+      generateInboxId(identifier);
+    const signer: Signer = {
+      type: "EOA",
+      getIdentifier: () => identifier,
+      signMessage: () => new Uint8Array(),
+    };
+    const client = new Client(
+      await createClient(host, isSecure, undefined, inboxId, identifier),
+      signer,
+      [],
+    );
+    const map =
+      await client.#innerClient.getKeyPackageStatusesForInstallationIds(
+        installationIds,
+      );
+    return map;
   }
 
   codecFor(contentType: ContentTypeId) {

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -31,6 +31,7 @@ export type {
   Message,
   MessageDisappearingSettings,
   PermissionPolicySet,
+  KeyPackageStatus,
 } from "@xmtp/node-bindings";
 export {
   ConsentEntityType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,10 +3612,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@xmtp/node-bindings@npm:1.1.3"
-  checksum: 10/729473bbb36fcc0da5a700aad65e2ef2441639591ae091a35c605d1294dfac7c7201b0504706d78bc8cabcd7f6473245ed0018c65e92d78e8eaf3b741b87c6fd
+"@xmtp/node-bindings@npm:^1.2.0-dev.bed98df":
+  version: 1.2.0-dev.bed98df
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
+  checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
   languageName: node
   linkType: hard
 
@@ -3630,7 +3630,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.1.3"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
### Add `keyPackageStatusForInstallations` static method to node-sdk Client class to enable key package status checking
* Adds new static method `keyPackageStatusForInstallations` to [Client.ts](https://github.com/xmtp/xmtp-js/pull/929/files#diff-d9b065e84339083d0f433b13652fdd58440125da85d29af761cf27029f6e2e60) that queries key package statuses for multiple installation IDs using a temporary client
* Exports `KeyPackageStatus` type from [index.ts](https://github.com/xmtp/xmtp-js/pull/929/files#diff-a799851ddab26b071b3e6753eb77936fa9fc3da7839b22d80d9f257177cdd070)
* Updates `@xmtp/node-bindings` dependency to version `1.2.0-dev.bed98df` in [package.json](https://github.com/xmtp/xmtp-js/pull/929/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
* Adds test coverage in [Client.test.ts](https://github.com/xmtp/xmtp-js/pull/929/files#diff-c00658c71eee5bdefef8b17b8d65ffb08e066b43f77200db2e049e2e6f137442) verifying key package lifetime duration of approximately 3 months plus 1 hour

#### 📍Where to Start
Start with the `keyPackageStatusForInstallations` static method implementation in [Client.ts](https://github.com/xmtp/xmtp-js/pull/929/files#diff-d9b065e84339083d0f433b13652fdd58440125da85d29af761cf27029f6e2e60), which contains the core functionality for querying key package statuses.

----

_[Macroscope](https://app.macroscope.com) summarized b518755._