### PR TITLE
Disable auto-register with Client.build

### DIFF
--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -127,7 +127,10 @@ export class Client extends ClientWorkerClass {
    * @returns A new client instance
    */
   static async build(identifier: Identifier, options?: ClientOptions) {
-    const client = new Client(options);
+    const client = new Client({
+      ...options,
+      disableAutoRegister: true,
+    });
     await client.init(identifier);
     return client;
   }


### PR DESCRIPTION
### Disable automatic network registration in `Client.build` static method by setting `disableAutoRegister` flag to true
The `build` static method in [Client.ts](https://github.com/xmtp/xmtp-js/pull/933/files#diff-149c8bbb69d4f35878e7823c01679abcc8b01e422d1a28c0a4ef01bf21cd0a63) now sets `disableAutoRegister: true` by default when creating new client instances, modifying the default client initialization behavior.

#### 📍Where to Start
Start with the `build` static method in [Client.ts](https://github.com/xmtp/xmtp-js/pull/933/files#diff-149c8bbb69d4f35878e7823c01679abcc8b01e422d1a28c0a4ef01bf21cd0a63) which contains the core change to the client initialization logic.

----

_[Macroscope](https://app.macroscope.com) summarized 8f6958e._