### PR TITLE
Add key package status table to identity modal

### DIFF
--- a/apps/xmtp.chat/src/components/Identity/IdentityModal.tsx
+++ b/apps/xmtp.chat/src/components/Identity/IdentityModal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import { BadgeWithCopy } from "@/components/BadgeWithCopy";
 import { InstallationTable } from "@/components/Identity/InstallationTable";
+import { KeyPackageStatusTable } from "@/components/Identity/KeyPackageStatusTable";
 import { useCollapsedMediaQuery } from "@/hooks/useCollapsedMediaQuery";
 import { useIdentity } from "@/hooks/useIdentity";
 import { ContentLayout } from "@/layouts/ContentLayout";
@@ -23,6 +24,7 @@ export const IdentityModal: React.FC = () => {
   const {
     installations,
     revokeAllOtherInstallations,
+    keyPackageStatuses,
     revoking,
     sync,
     syncing,
@@ -32,7 +34,7 @@ export const IdentityModal: React.FC = () => {
   );
 
   const fullScreen = useCollapsedMediaQuery();
-  const contentHeight = fullScreen ? "auto" : 600;
+  const contentHeight = fullScreen ? "auto" : "70dvh";
 
   useEffect(() => {
     setAccountIdentifier(
@@ -96,7 +98,9 @@ export const IdentityModal: React.FC = () => {
                 </Group>
               </Stack>
             </Paper>
-            <Title order={4}>Installations</Title>
+            <Title order={4} ml="md">
+              Installations
+            </Title>
             <Paper p="md" radius="md" withBorder>
               <Stack gap="md">
                 {installations.length === 0 && (
@@ -119,6 +123,21 @@ export const IdentityModal: React.FC = () => {
                       </Button>
                     </Group>
                   </>
+                )}
+              </Stack>
+            </Paper>
+            <Title order={4} ml="md">
+              Key Package Status
+            </Title>
+            <Paper p="md" radius="md" withBorder>
+              <Stack gap="md">
+                {keyPackageStatuses.length === 0 && (
+                  <Text>No key package statuses found</Text>
+                )}
+                {keyPackageStatuses.length > 0 && (
+                  <KeyPackageStatusTable
+                    keyPackageStatuses={keyPackageStatuses}
+                  />
                 )}
               </Stack>
             </Paper>

--- a/apps/xmtp.chat/src/components/Identity/InstallationTable.tsx
+++ b/apps/xmtp.chat/src/components/Identity/InstallationTable.tsx
@@ -1,4 +1,4 @@
-import { Button, Table, Text, useMatches } from "@mantine/core";
+import { Button, Table, Text, Tooltip, useMatches } from "@mantine/core";
 import type { SafeInstallation } from "@xmtp/browser-sdk";
 import { formatDistanceToNow } from "date-fns";
 import { BadgeWithCopy } from "@/components/BadgeWithCopy";
@@ -26,17 +26,21 @@ const InstallationTableRow: React.FC<InstallationTableRowProps> = ({
     sm: "20rem",
   });
 
+  const createdAt = nsToDate(installation.clientTimestampNs ?? 0n);
+
   return (
     <Table.Tr>
       <Table.Td maw={maw}>
         <BadgeWithCopy value={installation.id} />
       </Table.Td>
       <Table.Td>
-        <Text style={{ whiteSpace: "nowrap" }}>
-          {formatDistanceToNow(nsToDate(installation.clientTimestampNs ?? 0n), {
-            addSuffix: true,
-          })}
-        </Text>
+        <Tooltip label={createdAt.toISOString()}>
+          <Text style={{ whiteSpace: "nowrap" }}>
+            {formatDistanceToNow(createdAt, {
+              addSuffix: true,
+            })}
+          </Text>
+        </Tooltip>
       </Table.Td>
       <Table.Td w="100">
         <Button

--- a/apps/xmtp.chat/src/components/Identity/KeyPackageStatusTable.tsx
+++ b/apps/xmtp.chat/src/components/Identity/KeyPackageStatusTable.tsx
@@ -1,0 +1,73 @@
+import { Table, Text, Tooltip, useMatches } from "@mantine/core";
+import type { SafeKeyPackageStatus } from "@xmtp/browser-sdk";
+import { formatDistanceToNow } from "date-fns";
+import { BadgeWithCopy } from "@/components/BadgeWithCopy";
+
+type KeyPackageStatusTableRowProps = {
+  keyPackageStatus: [string, SafeKeyPackageStatus];
+};
+
+const KeyPackageStatusTableRow: React.FC<KeyPackageStatusTableRowProps> = ({
+  keyPackageStatus,
+}) => {
+  const maw = useMatches({
+    base: "12rem",
+    sm: "20rem",
+  });
+
+  const notAfter = new Date(
+    Number(keyPackageStatus[1].lifetime?.notAfter ?? 0n) * 1000,
+  );
+
+  return (
+    <Table.Tr>
+      <Table.Td maw={maw}>
+        <BadgeWithCopy value={keyPackageStatus[0]} />
+      </Table.Td>
+      <Table.Td>
+        <Tooltip label={notAfter.toISOString()}>
+          <Text style={{ whiteSpace: "nowrap" }}>
+            {formatDistanceToNow(notAfter, {
+              addSuffix: true,
+            })}
+          </Text>
+        </Tooltip>
+      </Table.Td>
+      <Table.Td>
+        {keyPackageStatus[1].validationError ? (
+          <BadgeWithCopy value={keyPackageStatus[1].validationError} />
+        ) : (
+          "None"
+        )}
+      </Table.Td>
+    </Table.Tr>
+  );
+};
+
+type KeyPackageStatusTableProps = {
+  keyPackageStatuses: [string, SafeKeyPackageStatus][];
+};
+
+export const KeyPackageStatusTable: React.FC<KeyPackageStatusTableProps> = ({
+  keyPackageStatuses,
+}) => {
+  return (
+    <Table>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th>Installation ID</Table.Th>
+          <Table.Th>Expires</Table.Th>
+          <Table.Th>Error</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {keyPackageStatuses.map((keyPackageStatus) => (
+          <KeyPackageStatusTableRow
+            key={keyPackageStatus[0]}
+            keyPackageStatus={keyPackageStatus}
+          />
+        ))}
+      </Table.Tbody>
+    </Table>
+  );
+};


### PR DESCRIPTION
### Add key package status information display to identity modal by integrating KeyPackageStatusTable component and modifying modal height to 70dvh
* Implements new `KeyPackageStatusTable` component in [KeyPackageStatusTable.tsx](https://github.com/xmtp/xmtp-js/pull/934/files#diff-eadea61413e69be46d194c892df6f38553f6b12feaaa85f1f2f59abf4010edf5) to display installation IDs, expiration times, and validation errors
* Extends `useIdentity` hook in [useIdentity.ts](https://github.com/xmtp/xmtp-js/pull/934/files#diff-1974b3ed5f707a13e308e7a9a177986898b345567c674f80b95aec7e701624ee) to fetch and sort key package statuses
* Updates [IdentityModal.tsx](https://github.com/xmtp/xmtp-js/pull/934/files#diff-6ade0e51761dfbed92d7a823735f5a115b45ad776046f7fee1f154a165c1e845) to integrate the new table and adjust modal height
* Adds timestamp tooltip functionality to [InstallationTable.tsx](https://github.com/xmtp/xmtp-js/pull/934/files#diff-9bdb6ebcba2f979c308058c26d7302f2ef3985d53005687496de476887a834ba)

#### 📍Where to Start
Start with the `useIdentity` hook in [useIdentity.ts](https://github.com/xmtp/xmtp-js/pull/934/files#diff-1974b3ed5f707a13e308e7a9a177986898b345567c674f80b95aec7e701624ee) as it contains the core logic for fetching and managing key package statuses that feed into the UI components.

----

_[Macroscope](https://app.macroscope.com) summarized 6bcb7ca._