### PR TITLE
Add changeRecoveryIdentifier, getKeyPackageStatusesForInstallationIds to Node SDK

### DIFF
--- a/.changeset/tidy-turtles-teach.md
+++ b/.changeset/tidy-turtles-teach.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": minor
+---
+
+Add changeRecoveryIdentifier, getKeyPackageStatusesForInstallationIds to Node SDK

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.1",
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
-    "@xmtp/node-bindings": "1.2.0-dev.3d6d1ef",
+    "@xmtp/node-bindings": "^1.2.0-dev.bed98df",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.1",
     "@xmtp/content-type-primitives": "^2.0.1",
     "@xmtp/content-type-text": "^2.0.1",
-    "@xmtp/node-bindings": "^1.1.3",
+    "@xmtp/node-bindings": "1.2.0-dev.3d6d1ef",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -18,7 +18,6 @@ import {
   IdentifierKind,
   isAddressAuthorized as isAddressAuthorizedBinding,
   isInstallationAuthorized as isInstallationAuthorizedBinding,
-  KeyPackageStatus,
   LogLevel,
   SignatureRequestType,
   verifySignedWithPublicKey as verifySignedWithPublicKeyBinding,
@@ -515,35 +514,10 @@ export class Client {
     return client.canMessage(identifiers);
   }
 
-  static async keyPackageStatusForInstallations(
-    installationIds: string[],
-    env?: XmtpEnv,
-  ): Promise<Record<string, KeyPackageStatus | undefined>> {
-    const accountAddress = "0x0000000000000000000000000000000000000000";
-    const host = ApiUrls[env || "dev"];
-    const isSecure = host.startsWith("https");
-    const identifier: Identifier = {
-      identifierKind: IdentifierKind.Ethereum,
-      identifier: accountAddress,
-    };
-    const inboxId =
-      (await getInboxIdForIdentifier(host, isSecure, identifier)) ||
-      generateInboxId(identifier);
-    const signer: Signer = {
-      type: "EOA",
-      getIdentifier: () => identifier,
-      signMessage: () => new Uint8Array(),
-    };
-    const client = new Client(
-      await createClient(host, isSecure, undefined, inboxId, identifier),
-      signer,
-      [],
+  async getKeyPackageStatusesForInstallationIds(installationIds: string[]) {
+    return this.#innerClient.getKeyPackageStatusesForInstallationIds(
+      installationIds,
     );
-    const map =
-      await client.#innerClient.getKeyPackageStatusesForInstallationIds(
-        installationIds,
-      );
-    return map;
   }
 
   codecFor(contentType: ContentTypeId) {

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -299,7 +299,7 @@ export class Client {
    *
    * It is highly recommended to use the `changeRecoveryIdentifer` function instead.
    */
-  async unsafe_changeRecoveryIdentiferSignatureText(identifier: Identifier) {
+  async unsafe_changeRecoveryIdentifierSignatureText(identifier: Identifier) {
     try {
       const signatureText =
         await this.#innerClient.changeRecoveryIdentifierSignatureText(

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -297,6 +297,35 @@ export class Client {
    * for use in special cases where the provided workflows do not meet the
    * requirements of an application.
    *
+   * It is highly recommended to use the `changeRecoveryIdentifer` function instead.
+   */
+  async unsafe_changeRecoveryIdentiferSignatureText(identifier: Identifier) {
+    try {
+      const signatureText =
+        await this.#innerClient.changeRecoveryIdentifierSignatureText(
+          identifier,
+        );
+      if (!signatureText) {
+        throw new Error("Unable to generate add account signature text");
+      }
+
+      await this.unsafe_addSignature(
+        SignatureRequestType.ChangeRecoveryIdentifier,
+        signatureText,
+        this.#signer,
+      );
+
+      await this.unsafe_applySignatures();
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * WARNING: This function should be used with caution. It is only provided
+   * for use in special cases where the provided workflows do not meet the
+   * requirements of an application.
+   *
    * It is highly recommended to use the `register`, `addAccount`,
    * `removeAccount`, `revokeAllOtherInstallations`, or `revokeInstallations`
    * functions instead.

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -317,7 +317,7 @@ export class Client {
    * for use in special cases where the provided workflows do not meet the
    * requirements of an application.
    *
-   * It is highly recommended to use the `register`, `addAccount`,
+   * It is highly recommended to use the `register`, `unsafe_addAccount`,
    * `removeAccount`, `revokeAllOtherInstallations`, or `revokeInstallations`
    * functions instead.
    */
@@ -349,7 +349,7 @@ export class Client {
    * for use in special cases where the provided workflows do not meet the
    * requirements of an application.
    *
-   * It is highly recommended to use the `register`, `addAccount`,
+   * It is highly recommended to use the `register`, `unsafe_addAccount`,
    * `removeAccount`, `revokeAllOtherInstallations`, or `revokeInstallations`
    * functions instead.
    */

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -306,17 +306,7 @@ export class Client {
         await this.#innerClient.changeRecoveryIdentifierSignatureText(
           identifier,
         );
-      if (!signatureText) {
-        throw new Error("Unable to generate add account signature text");
-      }
-
-      await this.unsafe_addSignature(
-        SignatureRequestType.ChangeRecoveryIdentifier,
-        signatureText,
-        this.#signer,
-      );
-
-      await this.unsafe_applySignatures();
+      return signatureText;
     } catch {
       return undefined;
     }
@@ -470,6 +460,25 @@ export class Client {
 
     await this.unsafe_addSignature(
       SignatureRequestType.RevokeInstallations,
+      signatureText,
+      this.#signer,
+    );
+
+    await this.unsafe_applySignatures();
+  }
+
+  async changeRecoveryIdentifier(identifier: Identifier) {
+    const signatureText =
+      await this.unsafe_changeRecoveryIdentifierSignatureText(identifier);
+
+    if (!signatureText) {
+      throw new Error(
+        "Unable to generate change recovery identifier signature text",
+      );
+    }
+
+    await this.unsafe_addSignature(
+      SignatureRequestType.ChangeRecoveryIdentifier,
       signatureText,
       this.#signer,
     );

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -31,6 +31,7 @@ export type {
   Message,
   MessageDisappearingSettings,
   PermissionPolicySet,
+  KeyPackageStatus,
 } from "@xmtp/node-bindings";
 export {
   ConsentEntityType,

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -25,13 +25,14 @@ export type {
   Identifier,
   InboxState,
   Installation,
+  KeyPackageStatus,
+  Lifetime,
   ListConversationsOptions,
   ListMessagesOptions,
   LogOptions,
   Message,
   MessageDisappearingSettings,
   PermissionPolicySet,
-  KeyPackageStatus,
 } from "@xmtp/node-bindings";
 export {
   ConsentEntityType,

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -231,4 +231,24 @@ describe.concurrent("Client", () => {
   it("should return a version", () => {
     expect(Client.version).toBeDefined();
   });
+
+  it("should change the recovery identifier", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const signer = createSigner(user);
+    const signer2 = createSigner(user2);
+    const client = await createRegisteredClient(signer);
+
+    const inboxState = await client.preferences.inboxState();
+    expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
+
+    await client.unsafe_changeRecoveryIdentiferSignatureText(
+      await signer2.getIdentifier(),
+    );
+
+    const inboxState2 = await client.preferences.inboxState();
+    expect(inboxState2.recoveryIdentifier).toEqual(
+      await signer2.getIdentifier(),
+    );
+  });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -264,13 +264,15 @@ describe.concurrent("Client", () => {
     const inboxState = await client3.preferences.inboxState(true);
     expect(inboxState.installations.length).toBe(3);
 
-    const keyPackageStatuses = await Client.keyPackageStatusForInstallations(
-      [client.installationId, client2.installationId, client3.installationId],
-      "local",
-    );
+    const keyPackageStatuses =
+      await client3.getKeyPackageStatusesForInstallationIds([
+        client.installationId,
+        client2.installationId,
+        client3.installationId,
+      ]);
     expect(
-      (keyPackageStatuses[client.installationId]?.lifetime?.notAfter ?? 0n) -
-        (keyPackageStatuses[client.installationId]?.lifetime?.notBefore ?? 0n),
+      (keyPackageStatuses[client.installationId].lifetime?.notAfter ?? 0n) -
+        (keyPackageStatuses[client.installationId].lifetime?.notBefore ?? 0n),
     ).toEqual(BigInt(3600 * 24 * 28 * 3 + 3600));
   });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -242,7 +242,7 @@ describe.concurrent("Client", () => {
     const inboxState = await client.preferences.inboxState();
     expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
-    await client.unsafe_changeRecoveryIdentiferSignatureText(
+    await client.unsafe_changeRecoveryIdentifierSignatureText(
       await signer2.getIdentifier(),
     );
 

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -242,9 +242,7 @@ describe.concurrent("Client", () => {
     const inboxState = await client.preferences.inboxState();
     expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
-    await client.unsafe_changeRecoveryIdentifierSignatureText(
-      await signer2.getIdentifier(),
-    );
+    await client.changeRecoveryIdentifier(await signer2.getIdentifier());
 
     const inboxState2 = await client.preferences.inboxState();
     expect(inboxState2.recoveryIdentifier).toEqual(

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -251,4 +251,28 @@ describe.concurrent("Client", () => {
       await signer2.getIdentifier(),
     );
   });
+
+  it("should read key package lifetime for specific installations", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+    const client3 = await createRegisteredClient(signer, {
+      dbPath: `./test-${v4()}.db3`,
+    });
+
+    const inboxState = await client3.preferences.inboxState(true);
+    expect(inboxState.installations.length).toBe(3);
+
+    const keyPackageStatuses = await Client.keyPackageStatusForInstallations(
+      [client.installationId, client2.installationId, client3.installationId],
+      "local",
+    );
+    expect(
+      (keyPackageStatuses[client.installationId]?.lifetime?.notAfter ?? 0n) -
+        (keyPackageStatuses[client.installationId]?.lifetime?.notBefore ?? 0n),
+    ).toEqual(BigInt(3600 * 24 * 28 * 3 + 3600));
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef":
-  version: 1.2.0-dev.3d6d1ef
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef"
-  checksum: 10/fbe4f2c5299cd5fe821df29e382816809a64a60e847c302eb63c2b04bb972ebffebd09fae9729ff89665cffc06141b5058f7122be2f4a2ec5a870b64a93a947f
+"@xmtp/node-bindings@npm:^1.2.0-dev.bed98df":
+  version: 1.2.0-dev.bed98df
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
+  checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
   languageName: node
   linkType: hard
 
@@ -3798,7 +3798,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:1.2.0-dev.3d6d1ef"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,10 +3780,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@xmtp/node-bindings@npm:1.1.3"
-  checksum: 10/729473bbb36fcc0da5a700aad65e2ef2441639591ae091a35c605d1294dfac7c7201b0504706d78bc8cabcd7f6473245ed0018c65e92d78e8eaf3b741b87c6fd
+"@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef":
+  version: 1.2.0-dev.3d6d1ef
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.3d6d1ef"
+  checksum: 10/fbe4f2c5299cd5fe821df29e382816809a64a60e847c302eb63c2b04bb972ebffebd09fae9729ff89665cffc06141b5058f7122be2f4a2ec5a870b64a93a947f
   languageName: node
   linkType: hard
 
@@ -3798,7 +3798,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.1"
     "@xmtp/content-type-primitives": "npm:^2.0.1"
     "@xmtp/content-type-text": "npm:^2.0.1"
-    "@xmtp/node-bindings": "npm:^1.1.3"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.3d6d1ef"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
# Summary

- Upgraded `@xmtp/node-bindings`
- Added `unsafe_changeRecoveryIdentifierSignatureText` client method
- Added `changeRecoveryIdentifier` client method
- Added `KeyPackageStatus` and `Lifetime` types to exports