### PR TITLE
Fix AsyncStream

### DIFF
--- a/.changeset/old-kangaroos-smash.md
+++ b/.changeset/old-kangaroos-smash.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Fix AsyncStream

--- a/sdks/browser-sdk/src/AsyncStream.ts
+++ b/sdks/browser-sdk/src/AsyncStream.ts
@@ -13,14 +13,29 @@ export type StreamCallback<T> = (
 export class AsyncStream<T> {
   #done = false;
   #resolveNext: ResolveNext<T> | null;
+  #rejectNext: ((error: Error) => void) | null;
   #queue: (T | undefined)[];
-
+  #error: Error | null;
   onReturn: (() => void) | undefined = undefined;
+  onError: ((error: Error) => void) | undefined = undefined;
 
   constructor() {
     this.#queue = [];
     this.#resolveNext = null;
+    this.#rejectNext = null;
+    this.#error = null;
     this.#done = false;
+  }
+
+  #endStream() {
+    this.#queue = [];
+    this.#resolveNext = null;
+    this.#rejectNext = null;
+    this.#done = true;
+  }
+
+  get error() {
+    return this.#error;
   }
 
   get isDone() {
@@ -29,7 +44,13 @@ export class AsyncStream<T> {
 
   callback: StreamCallback<T> = (error, value) => {
     if (error) {
-      throw error;
+      this.#error = error;
+      if (this.#rejectNext) {
+        this.#rejectNext(error);
+        this.#endStream();
+        this.onError?.(error);
+      }
+      return;
     }
 
     if (this.#done) {
@@ -48,25 +69,34 @@ export class AsyncStream<T> {
   };
 
   next = (): Promise<ResolveValue<T>> => {
+    if (this.#error) {
+      this.#endStream();
+      this.onError?.(this.#error);
+      return Promise.reject(this.#error);
+    }
+
     if (this.#queue.length > 0) {
       return Promise.resolve({
         done: false,
         value: this.#queue.shift(),
       });
-    } else if (this.#done) {
+    }
+
+    if (this.#done) {
       return Promise.resolve({
         done: true,
         value: undefined,
       });
-    } else {
-      return new Promise((resolve) => {
-        this.#resolveNext = resolve;
-      });
     }
+
+    return new Promise((resolve, reject) => {
+      this.#resolveNext = resolve;
+      this.#rejectNext = reject;
+    });
   };
 
   return = (value: T | undefined) => {
-    this.#done = true;
+    this.#endStream();
     this.onReturn?.();
     return Promise.resolve({
       done: true,

--- a/sdks/browser-sdk/test/AsyncStream.test.ts
+++ b/sdks/browser-sdk/test/AsyncStream.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { AsyncStream } from "@/AsyncStream";
+
+const testError = new Error("test");
+
+describe("AsyncStream", () => {
+  it("should return values from callbacks", async () => {
+    const stream = new AsyncStream<number>();
+    let onReturnCalled = false;
+    stream.onReturn = () => {
+      onReturnCalled = true;
+    };
+    void stream.callback(null, 1);
+    void stream.callback(null, 2);
+    void stream.callback(null, 3);
+
+    let count = 0;
+
+    for await (const value of stream) {
+      if (count === 0) {
+        expect(value).toBe(1);
+      }
+      if (count === 1) {
+        expect(value).toBe(2);
+      }
+      if (count === 2) {
+        expect(value).toBe(3);
+        break;
+      }
+      count++;
+    }
+    expect(onReturnCalled).toBe(true);
+    expect(stream.isDone).toBe(true);
+  });
+
+  it("should catch an error thrown in the for..await loop", async () => {
+    const stream = new AsyncStream<number>();
+    let onReturnCalled = false;
+    stream.onReturn = () => {
+      onReturnCalled = true;
+    };
+    void stream.callback(null, 1);
+
+    try {
+      for await (const value of stream) {
+        expect(value).toBe(1);
+        throw testError;
+      }
+    } catch (error) {
+      expect(error).toBe(testError);
+    }
+    expect(onReturnCalled).toBe(true);
+    expect(stream.isDone).toBe(true);
+  });
+
+  it("should catch an error passed to callback", async () => {
+    const stream = new AsyncStream<number>();
+    let onErrorCalled = false;
+    stream.onError = () => {
+      onErrorCalled = true;
+    };
+    void stream.callback(testError, 1);
+    try {
+      for await (const _value of stream) {
+        // this block should never be reached
+      }
+    } catch (error) {
+      expect(error).toBe(testError);
+    }
+    expect(onErrorCalled).toBe(true);
+    expect(stream.isDone).toBe(true);
+    expect(stream.error).toBe(testError);
+  });
+
+  it("should catch an error passed to callback (delayed)", async () => {
+    const stream = new AsyncStream<number>();
+    let onErrorCalled = false;
+    stream.onError = () => {
+      onErrorCalled = true;
+    };
+    setTimeout(() => {
+      void stream.callback(testError, 1);
+    }, 100);
+    try {
+      for await (const _value of stream) {
+        // this block should never be reached
+      }
+    } catch (error) {
+      expect(error).toBe(testError);
+    }
+    expect(onErrorCalled).toBe(true);
+    expect(stream.isDone).toBe(true);
+    expect(stream.error).toBe(testError);
+  });
+});

--- a/sdks/node-sdk/src/AsyncStream.ts
+++ b/sdks/node-sdk/src/AsyncStream.ts
@@ -13,14 +13,29 @@ export type StreamCallback<T> = (
 export class AsyncStream<T> {
   #done = false;
   #resolveNext: ResolveNext<T> | null;
+  #rejectNext: ((error: Error) => void) | null;
   #queue: (T | undefined)[];
-
+  #error: Error | null;
   onReturn: (() => void) | undefined = undefined;
+  onError: ((error: Error) => void) | undefined = undefined;
 
   constructor() {
     this.#queue = [];
     this.#resolveNext = null;
+    this.#rejectNext = null;
+    this.#error = null;
     this.#done = false;
+  }
+
+  #endStream() {
+    this.#queue = [];
+    this.#resolveNext = null;
+    this.#rejectNext = null;
+    this.#done = true;
+  }
+
+  get error() {
+    return this.#error;
   }
 
   get isDone() {
@@ -29,7 +44,13 @@ export class AsyncStream<T> {
 
   callback: StreamCallback<T> = (error, value) => {
     if (error) {
-      throw error;
+      this.#error = error;
+      if (this.#rejectNext) {
+        this.#rejectNext(error);
+        this.#endStream();
+        this.onError?.(error);
+      }
+      return;
     }
 
     if (this.#done) {
@@ -42,31 +63,41 @@ export class AsyncStream<T> {
         value,
       });
       this.#resolveNext = null;
+      this.#rejectNext = null;
     } else {
       this.#queue.push(value);
     }
   };
 
   next = (): Promise<ResolveValue<T>> => {
+    if (this.#error) {
+      this.#endStream();
+      this.onError?.(this.#error);
+      return Promise.reject(this.#error);
+    }
+
     if (this.#queue.length > 0) {
       return Promise.resolve({
         done: false,
         value: this.#queue.shift(),
       });
-    } else if (this.#done) {
+    }
+
+    if (this.#done) {
       return Promise.resolve({
         done: true,
         value: undefined,
       });
-    } else {
-      return new Promise((resolve) => {
-        this.#resolveNext = resolve;
-      });
     }
+
+    return new Promise((resolve, reject) => {
+      this.#resolveNext = resolve;
+      this.#rejectNext = reject;
+    });
   };
 
   return = (value: T | undefined) => {
-    this.#done = true;
+    this.#endStream();
     this.onReturn?.();
     return Promise.resolve({
       done: true,


### PR DESCRIPTION
# Summary

The `AsyncStream` async iterator didn't handle stream errors properly. Instead of rejecting the current pending promise, it would just throw an error. This didn't end the stream and the error could not be caught. This update properly rejects the current pending promise and calls a new optional `onError` callback.