### PR TITLE
Refactor Node client, add `Client.build` method

### DIFF
--- a/.changeset/witty-goats-lay.md
+++ b/.changeset/witty-goats-lay.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": major
+---
+
+Refactor Node client, add `Client.build` method

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ next-env.d.ts
 
 # Benchmark results
 sdks/js-sdk/bench/results
+
+# local database files
+**/*.db3*

--- a/sdks/node-sdk/scripts/groups.ts
+++ b/sdks/node-sdk/scripts/groups.ts
@@ -1,12 +1,14 @@
-import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { IdentifierKind } from "@xmtp/node-bindings";
 import { Client } from "@/Client";
 import { createSigner, createUser, type User } from "@test/helpers";
 
-export const createRegisteredClient = async (user: User, dbPath?: string) => {
-  return Client.create(createSigner(user), randomBytes(32), {
+export const createRegisteredClient = async (
+  user: User,
+  dbPath?: string | null,
+) => {
+  return Client.create(createSigner(user), {
     env: "local",
     dbPath,
   });
@@ -32,7 +34,7 @@ const primaryAccountClient = await createRegisteredClient(
 console.log("Registering accounts...");
 
 for (const a of accounts) {
-  await createRegisteredClient(createUser(a.key as `0x${string}`));
+  await createRegisteredClient(createUser(a.key as `0x${string}`), null);
 }
 
 const groups = [];

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -570,14 +570,6 @@ export class Client {
     return codec.decode(message.content as EncodedContent, this);
   }
 
-  async requestHistorySync() {
-    if (!this.#client) {
-      throw new ClientNotInitializedError();
-    }
-
-    return this.#client.sendHistorySyncRequest();
-  }
-
   async getInboxIdByIdentifier(identifier: Identifier) {
     if (!this.#client) {
       throw new ClientNotInitializedError();

--- a/sdks/node-sdk/src/types.ts
+++ b/sdks/node-sdk/src/types.ts
@@ -34,7 +34,11 @@ export type StorageOptions = {
   /**
    * Path to the local DB
    */
-  dbPath?: string;
+  dbPath?: string | null;
+  /**
+   * Encryption key for the local DB
+   */
+  dbEncryptionKey?: Uint8Array;
 };
 
 export type ContentOptions = {

--- a/sdks/node-sdk/src/utils/createClient.ts
+++ b/sdks/node-sdk/src/utils/createClient.ts
@@ -12,7 +12,6 @@ import { generateInboxId, getInboxIdForIdentifier } from "@/utils/inboxId";
 
 export const createClient = async (
   identifier: Identifier,
-  encryptionKey?: Uint8Array,
   options?: ClientOptions,
 ) => {
   const env = options?.env || "dev";
@@ -22,7 +21,10 @@ export const createClient = async (
     (await getInboxIdForIdentifier(identifier, env)) ||
     generateInboxId(identifier);
   const dbPath =
-    options?.dbPath || join(process.cwd(), `xmtp-${env}-${inboxId}.db3`);
+    options?.dbPath === undefined
+      ? join(process.cwd(), `xmtp-${env}-${inboxId}.db3`)
+      : options.dbPath;
+
   const logOptions: LogOptions = {
     structured: options?.structuredLogging ?? false,
     level: options?.loggingLevel ?? LogLevel.off,
@@ -35,7 +37,7 @@ export const createClient = async (
     dbPath,
     inboxId,
     identifier,
-    encryptionKey,
+    options?.dbEncryptionKey,
     historySyncUrl,
     logOptions,
   );

--- a/sdks/node-sdk/src/utils/errors.ts
+++ b/sdks/node-sdk/src/utils/errors.ts
@@ -58,3 +58,19 @@ export class MissingContentTypeError extends Error {
     super("Content type is required when sending content other than text");
   }
 }
+
+export class SignerUnavailableError extends Error {
+  constructor() {
+    super(
+      "Signer unavailable, use Client.create to create a client with a signer",
+    );
+  }
+}
+
+export class ClientNotInitializedError extends Error {
+  constructor() {
+    super(
+      "Client not initialized, use Client.create or Client.build to create a client",
+    );
+  }
+}

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -385,9 +385,6 @@ describe.concurrent("Client", () => {
     await expect(async () =>
       client.getKeyPackageStatusesForInstallationIds([]),
     ).rejects.toThrow(new ClientNotInitializedError());
-    await expect(async () => client.requestHistorySync()).rejects.toThrow(
-      new ClientNotInitializedError(),
-    );
     await expect(async () =>
       client.getInboxIdByIdentifier(createIdentifier(createUser())),
     ).rejects.toThrow(new ClientNotInitializedError());


### PR DESCRIPTION
# Summary

This PR refactors the node SDK client to match the recently updated browser SDK client.

### BREAKING CHANGES

- Refactored `Client` constructor to only accept client options
- Removed DB encryption key argument from `Client.create`
- Moved DB encryption key to client options, made optional
- Removed `requestHistorySync` method
- Renamed `identifier` property to `accountIdentifier`

### Other changes

- Added `init` method to client
- Added `null` as a `dbPath` option to prevent the creation of a local database
- Added `Client.build` static method to create a client without a signer
- Added more custom errors
- Added `options` property to client
- Added `signer` property to client