### PR TITLE
Update Browser and Node READMEs

### DIFF
--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -11,7 +11,7 @@ To keep up with the latest SDK developments, see the [Issues tab](https://githu
 
 To learn how to use the XMTP client SDK for browsers and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
 
-## Reference docs
+## SDK reference
 
 Coming soon
 

--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -4,16 +4,22 @@ This package provides the XMTP client SDK for browsers.
 
 To keep up with the latest SDK developments, see the [Issues tab](https://github.com/xmtp/xmtp-js/issues) in this repo.
 
-To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
-
 > [!CAUTION]
 > This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
+
+## Documentation
+
+To learn how to use the XMTP client SDK for browsers and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
+
+## Reference docs
+
+Coming soon
 
 ## Limitations
 
 This SDK uses the [origin private file system](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system) (OPFS) to persist a SQLite database and the [SyncAccessHandle Pool VFS](https://sqlite.org/wasm/doc/trunk/persistence.md#vfs-opfs-sahpool) to access it. This VFS does not support multiple simultaneous connections.
 
-This means that when using this SDK in your application, you must prevent multiple browser tabs or windows from accessing your application at the same time.
+This means that when using this SDK in your app, you must prevent multiple browser tabs or windows from accessing your app at the same time.
 
 ### Bundlers
 
@@ -54,42 +60,6 @@ pnpm install @xmtp/browser-sdk
 yarn add @xmtp/browser-sdk
 ```
 
-## Reference docs
-
-Access the XMTP client browser SDK [reference documentation](TBD).
-
-## Usage
-
-Check out our [official documentation](https://xmtp.org/docs/build/get-started/overview) to get started developing with XMTP.
-
-## XMTP network environments
-
-XMTP provides `production`, `dev`, and `local` network environments to support the development phases of your project. To learn more about these environments, see our [official documentation](https://xmtp.org/docs/build/authentication#environments).
-
-> **Important**  
-> When you [create a client](https://xmtp.org/docs/build/authentication#create-a-client), it connects to the XMTP `dev` environment by default. To learn how to use the `env` parameter to set your client's network environment, see [Configure the client](https://xmtp.org/docs/build/authentication#configure-the-client).
-
-## Breaking revisions
-
-Because this SDK is in active development, you should expect breaking revisions that might require you to adopt the latest SDK release to enable your app to continue working as expected.
-
-XMTP communicates about breaking revisions in the [XMTP Discord community](https://discord.gg/xmtp), providing as much advance notice as possible. Additionally, breaking revisions in a release are described on the [Releases page](https://github.com/xmtp/xmtp-js/releases).
-
-## Deprecation
-
-Older versions of the SDK will eventually be deprecated, which means:
-
-1. The network will not support and eventually actively reject connections from clients using deprecated versions.
-2. Bugs will not be fixed in deprecated versions.
-
-The following table provides the deprecation schedule.
-
-| Announced                                                      | Effective | Minimum Version | Rationale |
-| -------------------------------------------------------------- | --------- | --------------- | --------- |
-| There are no deprecations scheduled for this SDK at this time. |           |                 |           |
-
-Bug reports, feature requests, and PRs are welcome in accordance with these [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).
-
 ## Developing
 
 Run `yarn dev` to build the SDK and watch for changes, which will trigger a rebuild.
@@ -101,3 +71,24 @@ Run `yarn dev` to build the SDK and watch for changes, which will trigger a re
 - `yarn dev`: Builds the SDK and watches for changes, which will trigger a rebuild
 - `yarn test`: Runs all tests
 - `yarn typecheck`: Runs `tsc`
+
+## Breaking revisions
+
+Because this SDK is in active development, you should expect breaking revisions that might require you to adopt the latest SDK release to enable your app to continue working as expected.
+
+Breaking revisions in a Browser SDK release are described on the [Releases page](https://github.com/xmtp/xmtp-js/releases).
+
+## Deprecation
+
+Older versions of the SDK will eventually be deprecated, which means:
+
+1. The network will not support and eventually actively reject connections from clients using deprecated versions.
+2. Bugs will not be fixed in deprecated versions.
+
+The following table provides the deprecation schedule.
+
+| Announced                   | Effective   | Minimum Version | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------------------------- | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No more support for XMTP V2 | May 1, 2025 | >=1.1.4         | In a move toward better security with MLS and the ability to decentralize, we will be shutting down XMTP V2 and moving entirely to XMTP V3. To learn more about V2 deprecation, see [XIP-53: XMTP V2 deprecation plan](https://community.xmtp.org/t/xip-53-xmtp-v2-deprecation-plan/867). To learn how to upgrade, see [@xmtp/browser-sdk v1.1.4](https://github.com/xmtp/xmtp-js/releases/tag/%40xmtp%2Fbrowser-sdk%401.1.4). |
+
+Bug reports, feature requests, and PRs are welcome in accordance with these [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).

--- a/sdks/node-sdk/README.md
+++ b/sdks/node-sdk/README.md
@@ -4,10 +4,16 @@ This package provides the XMTP client SDK for Node.
 
 To keep up with the latest SDK developments, see the [Issues tab](https://github.com/xmtp/xmtp-js/issues) in this repo.
 
-To learn more about XMTP and get answers to frequently asked questions, see the [XMTP documentation](https://xmtp.org/docs).
-
 > [!CAUTION]
 > This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
+
+## Documentation
+
+To learn how to use the XMTP client SDK for Node and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
+
+## SDK reference
+
+Coming soon
 
 ## Requirements
 
@@ -34,10 +40,6 @@ pnpm install @xmtp/node-sdk
 yarn add @xmtp/node-sdk
 ```
 
-## XMTP network environments
-
-XMTP provides `production`, `dev`, and `local` network environments to support the development phases of your project. To learn more about these environments, see our [official documentation](https://xmtp.org/docs/build/authentication#environments).
-
 ## Developing
 
 Run `yarn dev` to build the SDK and watch for changes, which will trigger a rebuild.
@@ -48,3 +50,24 @@ Run `yarn dev` to build the SDK and watch for changes, which will trigger a re
 - `yarn clean`: Removes `node_modules`, `dist`, and `.turbo` folders
 - `yarn test`: Runs all tests
 - `yarn typecheck`: Runs `tsc`
+
+## Breaking revisions
+
+Because this SDK is in active development, you should expect breaking revisions that might require you to adopt the latest SDK release to enable your app to continue working as expected.
+
+Breaking revisions in a Node SDK release are described on the [Releases page](https://github.com/xmtp/xmtp-js/releases).
+
+## Deprecation
+
+Older versions of the SDK will eventually be deprecated, which means:
+
+1. The network will not support and eventually actively reject connections from clients using deprecated versions.
+2. Bugs will not be fixed in deprecated versions.
+
+The following table provides the deprecation schedule.
+
+| Announced                   | Effective   | Minimum Version | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------- | ----------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| No more support for XMTP V2 | May 1, 2025 | >=1.0.5         | In a move toward better security with MLS and the ability to decentralize, we will be shutting down XMTP V2 and moving entirely to XMTP V3. To learn more about V2 deprecation, see [XIP-53: XMTP V2 deprecation plan](https://community.xmtp.org/t/xip-53-xmtp-v2-deprecation-plan/867). To learn how to upgrade, see [@xmtp/node-sdk v1.0.5](https://github.com/xmtp/xmtp-js/releases/tag/%40xmtp%2Fnode-sdk%401.0.5). |
+
+Bug reports, feature requests, and PRs are welcome in accordance with these [contribution guidelines](https://github.com/xmtp/xmtp-js/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
### Update documentation structure and deprecation notices in Browser and Node SDK READMEs to reflect XMTP V2 end-of-support dates
Updates documentation in [browser-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/957/files#diff-a561646e4e333b5b6e55b5f396496c268bfb99bd7623dc14e4a1ed183b0cf263) and [node-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/957/files#diff-132170c207fc917bdd7a4b6acb196aa1d4c1a43c609375ba625fbd9d1e2a135c) with:

* Adds deprecation notices for XMTP V2 support ending May 1, 2025, requiring minimum versions `>=1.1.4` for browser SDK and `>=1.0.5` for node SDK
* Reorganizes documentation structure with new dedicated sections for Documentation and SDK references
* Updates documentation links to point to `docs.xmtp.org`
* Removes usage and network environment sections
   * Link to docs.xmtp.org provides definitive info 
* Standardizes README content and structure across both SDKs

#### 📍Where to Start
Start with the [browser-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/957/files#diff-a561646e4e333b5b6e55b5f396496c268bfb99bd7623dc14e4a1ed183b0cf263) as it contains the most extensive changes, followed by [node-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/957/files#diff-132170c207fc917bdd7a4b6acb196aa1d4c1a43c609375ba625fbd9d1e2a135c) which adopts a similar structure.

----

_[Macroscope](https://app.macroscope.com) summarized 78e89b2._