### PR TITLE
`any` to `unknown`, prevent error when codec is missing

### DIFF
--- a/apps/xmtp.chat/src/components/Conversations/ConversationCard.tsx
+++ b/apps/xmtp.chat/src/components/Conversations/ConversationCard.tsx
@@ -31,7 +31,7 @@ export const ConversationCard: React.FC<ConversationCardProps> = ({
         setName(inboxId);
       });
     }
-  }, [conversation]);
+  }, [conversation.id]);
 
   return (
     <Box px="sm">

--- a/content-types/content-type-primitives/src/index.ts
+++ b/content-types/content-type-primitives/src/index.ts
@@ -46,17 +46,17 @@ export type EncodedContent<Parameters = Record<string, string>> = {
 };
 
 export type ContentCodec<
-  ContentType = any,
+  ContentType = unknown,
   Parameters = Record<string, string>,
 > = {
   contentType: ContentTypeId;
   encode(
     content: ContentType,
-    registry: CodecRegistry<ContentType>,
+    registry: CodecRegistry,
   ): EncodedContent<Parameters>;
   decode(
     content: EncodedContent<Parameters>,
-    registry: CodecRegistry<ContentType>,
+    registry: CodecRegistry,
   ): ContentType;
   fallback(content: ContentType): string | undefined;
   shouldPush: (content: ContentType) => boolean;
@@ -64,10 +64,9 @@ export type ContentCodec<
 
 /**
  * An interface implemented for accessing codecs by content type.
- * @deprecated
  */
-export interface CodecRegistry<T = any> {
+export interface CodecRegistry<T = unknown> {
   codecFor(contentType: ContentTypeId): ContentCodec<T> | undefined;
 }
 
-export type CodecMap<T = any> = Map<string, ContentCodec<T>>;
+export type CodecMap<T = unknown> = Map<string, ContentCodec<T>>;

--- a/content-types/content-type-read-receipt/src/ReadReceipt.test.ts
+++ b/content-types/content-type-read-receipt/src/ReadReceipt.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -8,8 +7,6 @@ import {
   ReadReceiptCodec,
   type ReadReceipt,
 } from "./ReadReceipt";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -43,13 +40,13 @@ describe("ReadReceiptContentType", () => {
 
   it("can send a read receipt", async () => {
     const signer1 = createSigner();
-    const client1 = await Client.create(signer1, testEncryptionKey, {
+    const client1 = await Client.create(signer1, {
       codecs: [new ReadReceiptCodec()],
       env: "local",
     });
 
     const signer2 = createSigner();
-    const client2 = await Client.create(signer2, testEncryptionKey, {
+    const client2 = await Client.create(signer2, {
       codecs: [new ReadReceiptCodec()],
       env: "local",
     });

--- a/content-types/content-type-remote-attachment/src/Attachment.test.ts
+++ b/content-types/content-type-remote-attachment/src/Attachment.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -8,8 +7,6 @@ import {
   ContentTypeAttachment,
   type Attachment,
 } from "./Attachment";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -42,13 +39,13 @@ test("content type exists", () => {
 
 test("can send an attachment", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new AttachmentCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new AttachmentCodec()],
     env: "local",
   });

--- a/content-types/content-type-remote-attachment/src/RemoteAttachment.test.ts
+++ b/content-types/content-type-remote-attachment/src/RemoteAttachment.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -9,8 +8,6 @@ import {
   RemoteAttachmentCodec,
   type RemoteAttachment,
 } from "./RemoteAttachment";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -43,13 +40,13 @@ test("content type exists", () => {
 
 test("can create a remote attachment", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });
@@ -117,13 +114,13 @@ test("can create a remote attachment", async () => {
 
 test("fails if url is not https", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });
@@ -158,13 +155,13 @@ test("fails if url is not https", async () => {
 
 test("fails if content digest does not match", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new AttachmentCodec(), new RemoteAttachmentCodec()],
     env: "local",
   });

--- a/content-types/content-type-remote-attachment/src/RemoteAttachment.ts
+++ b/content-types/content-type-remote-attachment/src/RemoteAttachment.ts
@@ -47,9 +47,9 @@ export type RemoteAttachmentParameters = {
 export class RemoteAttachmentCodec
   implements ContentCodec<RemoteAttachment, RemoteAttachmentParameters>
 {
-  static async load<T>(
+  static async load<T = unknown>(
     remoteAttachment: RemoteAttachment,
-    codecRegistry: CodecRegistry<T>,
+    codecRegistry: CodecRegistry,
   ): Promise<T> {
     const response = await fetch(remoteAttachment.url);
     const payload = new Uint8Array(await response.arrayBuffer());
@@ -95,7 +95,7 @@ export class RemoteAttachmentCodec
       throw new Error(`no codec found for ${encodedContent.type.typeId}`);
     }
 
-    return codec.decode(encodedContent as EncodedContent, codecRegistry);
+    return codec.decode(encodedContent as EncodedContent, codecRegistry) as T;
   }
 
   static async encodeEncrypted<T>(

--- a/content-types/content-type-reply/src/Reply.test.ts
+++ b/content-types/content-type-reply/src/Reply.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import {
   AttachmentCodec,
   ContentTypeAttachment,
@@ -10,8 +9,6 @@ import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 import { ContentTypeReply, ReplyCodec, type Reply } from "./Reply";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -45,13 +42,13 @@ describe("ReplyContentType", () => {
 
   it("can send a text reply", async () => {
     const signer1 = createSigner();
-    const client1 = await Client.create(signer1, testEncryptionKey, {
+    const client1 = await Client.create(signer1, {
       codecs: [new ReplyCodec()],
       env: "local",
     });
 
     const signer2 = createSigner();
-    const client2 = await Client.create(signer2, testEncryptionKey, {
+    const client2 = await Client.create(signer2, {
       codecs: [new ReplyCodec()],
       env: "local",
     });
@@ -85,13 +82,13 @@ describe("ReplyContentType", () => {
 
   it("can send an attachment reply", async () => {
     const signer1 = createSigner();
-    const client1 = await Client.create(signer1, testEncryptionKey, {
+    const client1 = await Client.create(signer1, {
       codecs: [new ReplyCodec(), new AttachmentCodec()],
       env: "local",
     });
 
     const signer2 = createSigner();
-    const client2 = await Client.create(signer2, testEncryptionKey, {
+    const client2 = await Client.create(signer2, {
       codecs: [new ReplyCodec(), new AttachmentCodec()],
       env: "local",
     });

--- a/content-types/content-type-reply/src/Reply.ts
+++ b/content-types/content-type-reply/src/Reply.ts
@@ -27,7 +27,7 @@ export type Reply = {
   /**
    * The content of the reply
    */
-  content: any;
+  content: unknown;
   /**
    * The content type of the reply
    */
@@ -45,7 +45,10 @@ export class ReplyCodec implements ContentCodec<Reply, ReplyParameters> {
     return ContentTypeReply;
   }
 
-  encode(content: Reply, registry: CodecRegistry) {
+  encode(
+    content: Reply,
+    registry: CodecRegistry,
+  ): EncodedContent<ReplyParameters> {
     const codec = registry.codecFor(content.contentType);
     if (!codec) {
       throw new Error(
@@ -94,7 +97,6 @@ export class ReplyCodec implements ContentCodec<Reply, ReplyParameters> {
       reference: content.parameters.reference,
       referenceInboxId: content.parameters.referenceInboxId,
       contentType,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       content: codec.decode(decodedContent as EncodedContent, registry),
     };
   }

--- a/content-types/content-type-transaction-reference/src/TransactionReference.test.ts
+++ b/content-types/content-type-transaction-reference/src/TransactionReference.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -8,8 +7,6 @@ import {
   TransactionReferenceCodec,
   type TransactionReference,
 } from "./TransactionReference";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -42,13 +39,13 @@ test("content type exists", () => {
 
 test("should successfully send and receive a TransactionReference message", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new TransactionReferenceCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new TransactionReferenceCodec()],
     env: "local",
   });

--- a/content-types/content-type-wallet-send-calls/src/WalletSendCalls.test.ts
+++ b/content-types/content-type-wallet-send-calls/src/WalletSendCalls.test.ts
@@ -1,4 +1,3 @@
-import { getRandomValues } from "node:crypto";
 import { Client, IdentifierKind, type Signer } from "@xmtp/node-sdk";
 import { createWalletClient, http, toBytes } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
@@ -8,8 +7,6 @@ import {
   WalletSendCallsCodec,
   type WalletSendCallsParams,
 } from "./WalletSendCalls";
-
-const testEncryptionKey = getRandomValues(new Uint8Array(32));
 
 export const createSigner = (): Signer => {
   const account = privateKeyToAccount(generatePrivateKey());
@@ -42,13 +39,13 @@ test("content type exists", () => {
 
 test("should successfully send and receive a WalletSendCalls message", async () => {
   const signer1 = createSigner();
-  const client1 = await Client.create(signer1, testEncryptionKey, {
+  const client1 = await Client.create(signer1, {
     codecs: [new WalletSendCallsCodec()],
     env: "local",
   });
 
   const signer2 = createSigner();
-  const client2 = await Client.create(signer2, testEncryptionKey, {
+  const client2 = await Client.create(signer2, {
     codecs: [new WalletSendCallsCodec()],
     env: "local",
   });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,7 @@ export default tseslint.config(
   },
   {
     rules: {
+      "@typescript-eslint/no-unnecessary-type-parameters": "off",
       "@typescript-eslint/consistent-type-exports": [
         "error",
         {

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -618,8 +618,10 @@ export class Client extends ClientWorkerClass {
    * @param contentType - The content type to get the codec for
    * @returns The codec, if found
    */
-  codecFor(contentType: ContentTypeId) {
-    return this.#codecs.get(contentType.toString());
+  codecFor<T = unknown>(contentType: ContentTypeId) {
+    return this.#codecs.get(contentType.toString()) as
+      | ContentCodec<T>
+      | undefined;
   }
 
   /**
@@ -630,7 +632,7 @@ export class Client extends ClientWorkerClass {
    * @returns The encoded content
    * @throws {CodecNotFoundError} if no codec is found for the content type
    */
-  encodeContent(content: any, contentType: ContentTypeId) {
+  encodeContent(content: unknown, contentType: ContentTypeId) {
     const codec = this.codecFor(contentType);
     if (!codec) {
       throw new CodecNotFoundError(contentType);
@@ -652,8 +654,8 @@ export class Client extends ClientWorkerClass {
    * @throws {CodecNotFoundError} if no codec is found for the content type
    * @throws {InvalidGroupMembershipChangeError} if the message is an invalid group membership change
    */
-  decodeContent(message: SafeMessage, contentType: ContentTypeId) {
-    const codec = this.codecFor(contentType);
+  decodeContent<T = unknown>(message: SafeMessage, contentType: ContentTypeId) {
+    const codec = this.codecFor<T>(contentType);
     if (!codec) {
       throw new CodecNotFoundError(contentType);
     }
@@ -667,7 +669,7 @@ export class Client extends ClientWorkerClass {
     }
 
     const encodedContent = fromSafeEncodedContent(message.content);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+
     return codec.decode(encodedContent, this);
   }
 

--- a/sdks/browser-sdk/src/ClientWorkerClass.ts
+++ b/sdks/browser-sdk/src/ClientWorkerClass.ts
@@ -23,7 +23,10 @@ export class ClientWorkerClass {
 
   #promises = new Map<
     string,
-    { resolve: (value: any) => void; reject: (reason?: any) => void }
+    {
+      resolve: (value: unknown) => void;
+      reject: (reason?: unknown) => void;
+    }
   >();
 
   constructor(worker: Worker, enableLogging: boolean) {
@@ -44,7 +47,10 @@ export class ClientWorkerClass {
       data,
     });
     const promise = new Promise<ClientEventsResult<A>>((resolve, reject) => {
-      this.#promises.set(promiseId, { resolve, reject });
+      this.#promises.set(promiseId, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
     });
     return promise;
   }

--- a/sdks/browser-sdk/src/ClientWorkerClass.ts
+++ b/sdks/browser-sdk/src/ClientWorkerClass.ts
@@ -67,7 +67,6 @@ export class ClientWorkerClass {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   handleStreamMessage = <T extends ClientStreamEvents["result"]>(
     streamId: string,
     callback: (error: Error | null, value: T | null) => void,

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -113,7 +113,7 @@ export class Conversation {
    * @returns Promise that resolves with the message ID
    * @throws {MissingContentTypeError} When content type is required but not provided
    */
-  async sendOptimistic(content: any, contentType?: ContentTypeId) {
+  async sendOptimistic(content: unknown, contentType?: ContentTypeId) {
     if (typeof content !== "string" && !contentType) {
       throw new MissingContentTypeError();
     }
@@ -138,7 +138,7 @@ export class Conversation {
    * @returns Promise that resolves with the message ID after it has been sent
    * @throws {MissingContentTypeError} When content type is required but not provided
    */
-  async send(content: any, contentType?: ContentTypeId) {
+  async send(content: unknown, contentType?: ContentTypeId) {
     if (typeof content !== "string" && !contentType) {
       throw new MissingContentTypeError();
     }

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -81,11 +81,11 @@ export class Conversations {
    * @param id - The message ID to look up
    * @returns Promise that resolves with the decoded message, if found
    */
-  async getMessageById(id: string) {
+  async getMessageById<T = unknown>(id: string) {
     const data = await this.#client.sendMessage("getMessageById", {
       id,
     });
-    return data ? new DecodedMessage(this.#client, data) : undefined;
+    return data ? new DecodedMessage<T>(this.#client, data) : undefined;
   }
 
   /**

--- a/sdks/browser-sdk/src/DecodedMessage.ts
+++ b/sdks/browser-sdk/src/DecodedMessage.ts
@@ -26,9 +26,9 @@ export type MessageDeliveryStatus = "unpublished" | "published" | "failed";
  * @property {string} senderInboxId - Identifier for the sender's inbox
  * @property {bigint} sentAtNs - Timestamp when the message was sent (in nanoseconds)
  */
-export class DecodedMessage {
+export class DecodedMessage<T = unknown> {
   #client: Client;
-  content: any;
+  content: T | undefined;
   contentType: ContentTypeId;
   conversationId: string;
   deliveryStatus: MessageDeliveryStatus;

--- a/sdks/browser-sdk/src/DecodedMessage.ts
+++ b/sdks/browser-sdk/src/DecodedMessage.ts
@@ -76,7 +76,11 @@ export class DecodedMessage<T = unknown> {
     this.parameters = new Map(Object.entries(message.content.parameters));
     this.fallback = message.content.fallback;
     this.compression = message.content.compression;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this.content = this.#client.decodeContent(message, this.contentType);
+
+    try {
+      this.content = this.#client.decodeContent<T>(message, this.contentType);
+    } catch {
+      this.content = undefined;
+    }
   }
 }

--- a/sdks/browser-sdk/src/UtilsWorkerClass.ts
+++ b/sdks/browser-sdk/src/UtilsWorkerClass.ts
@@ -19,7 +19,7 @@ export class UtilsWorkerClass {
 
   #promises = new Map<
     string,
-    { resolve: (value: any) => void; reject: (reason?: any) => void }
+    { resolve: (value: unknown) => void; reject: (reason?: unknown) => void }
   >();
 
   constructor(worker: Worker, enableLogging: boolean) {
@@ -47,7 +47,10 @@ export class UtilsWorkerClass {
       data,
     });
     const promise = new Promise<UtilsEventsResult<A>>((resolve, reject) => {
-      this.#promises.set(promiseId, { resolve, reject });
+      this.#promises.set(promiseId, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
     });
     return promise;
   }

--- a/sdks/browser-sdk/src/types/clientEvents.ts
+++ b/sdks/browser-sdk/src/types/clientEvents.ts
@@ -667,6 +667,7 @@ export type ClientEvents =
         id: string;
       };
     };
+
 export type ClientEventsActions = ClientEvents["action"];
 
 export type ClientEventsClientMessageData =

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -535,11 +535,13 @@ export class Client {
     );
   }
 
-  codecFor(contentType: ContentTypeId) {
-    return this.#codecs.get(contentType.toString());
+  codecFor<T = unknown>(contentType: ContentTypeId) {
+    return this.#codecs.get(contentType.toString()) as
+      | ContentCodec<T>
+      | undefined;
   }
 
-  encodeContent(content: any, contentType: ContentTypeId) {
+  encodeContent(content: unknown, contentType: ContentTypeId) {
     const codec = this.codecFor(contentType);
     if (!codec) {
       throw new CodecNotFoundError(contentType);
@@ -552,8 +554,8 @@ export class Client {
     return encoded;
   }
 
-  decodeContent(message: Message, contentType: ContentTypeId) {
-    const codec = this.codecFor(contentType);
+  decodeContent<T = unknown>(message: Message, contentType: ContentTypeId) {
+    const codec = this.codecFor<T>(contentType);
     if (!codec) {
       throw new CodecNotFoundError(contentType);
     }
@@ -566,7 +568,6 @@ export class Client {
       throw new InvalidGroupMembershipChangeError(message.id);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return codec.decode(message.content as EncodedContent, this);
   }
 

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -93,7 +93,7 @@ export class Conversation {
     return this.#conversation.publishMessages();
   }
 
-  sendOptimistic(content: any, contentType?: ContentTypeId) {
+  sendOptimistic(content: unknown, contentType?: ContentTypeId) {
     if (typeof content !== "string" && !contentType) {
       throw new MissingContentTypeError();
     }
@@ -107,7 +107,7 @@ export class Conversation {
     return this.#conversation.sendOptimistic(encodedContent);
   }
 
-  async send(content: any, contentType?: ContentTypeId) {
+  async send(content: unknown, contentType?: ContentTypeId) {
     if (typeof content !== "string" && !contentType) {
       throw new MissingContentTypeError();
     }

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -44,7 +44,7 @@ export class Conversations {
     }
   }
 
-  getMessageById<T = any>(id: string) {
+  getMessageById<T = unknown>(id: string) {
     try {
       // findMessageById will throw if message is not found
       const message = this.#conversations.findMessageById(id);

--- a/sdks/node-sdk/src/DecodedMessage.ts
+++ b/sdks/node-sdk/src/DecodedMessage.ts
@@ -10,9 +10,9 @@ import { nsToDate } from "@/utils/date";
 export type MessageKind = "application" | "membership_change";
 export type MessageDeliveryStatus = "unpublished" | "published" | "failed";
 
-export class DecodedMessage<T = any> {
+export class DecodedMessage<T = unknown> {
   #client: Client;
-  content: T;
+  content: T | undefined;
   contentType: ContentTypeId | undefined;
   conversationId: string;
   deliveryStatus: MessageDeliveryStatus;

--- a/sdks/node-sdk/src/DecodedMessage.ts
+++ b/sdks/node-sdk/src/DecodedMessage.ts
@@ -62,9 +62,13 @@ export class DecodedMessage<T = unknown> {
     this.parameters = message.content.parameters;
     this.fallback = message.content.fallback;
     this.compression = message.content.compression;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    this.content = this.contentType
-      ? this.#client.decodeContent(message, this.contentType)
-      : undefined;
+    this.content = undefined;
+    if (this.contentType) {
+      try {
+        this.content = this.#client.decodeContent<T>(message, this.contentType);
+      } catch {
+        this.content = undefined;
+      }
+    }
   }
 }

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -329,9 +329,8 @@ describe.concurrent("Conversation", () => {
     expect(conversation2.length).toBe(1);
     expect(conversation2[0].id).toBe(conversation.id);
 
-    const streamedMessages: string[] = [];
+    const streamedMessages: unknown[] = [];
     const stream = conversation2[0].stream((_, message) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       streamedMessages.push(message!.content);
     });
 


### PR DESCRIPTION
# Summary

### Browser + Node SDK

- Converted all `any` types to `unknown`
- Added generics for types with `unknown` where applicable
- Prevented `CodecNotFoundError` from throwing when instantiating `DecodedMessage`

### Content types

- Converted all `any` types to `unknown`
- Removed `@deprecated` warning from `CodecRegistry` type
- Updated some generics and other types

### xmtp.chat

- Updated `useEffect` in `ConversationCard` to run when the conversation ID changes
