### PR TITLE
Lowercase addresses on static Client.canMessage calls

### DIFF
--- a/.changeset/dirty-bats-judge.md
+++ b/.changeset/dirty-bats-judge.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Lowercase addresses on static Client.canMessage calls

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -603,7 +603,10 @@ export class Client extends ClientWorkerClass {
     const utils = new Utils();
     for (const identifier of identifiers) {
       const inboxId = await utils.getInboxIdForIdentifier(identifier, env);
-      canMessageMap.set(identifier.identifier, inboxId !== undefined);
+      canMessageMap.set(
+        identifier.identifier.toLowerCase(),
+        inboxId !== undefined,
+      );
     }
     utils.close();
     return canMessageMap;

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -709,7 +709,7 @@ export class Client {
     const canMessageMap = new Map<string, boolean>();
     for (const identifier of identifiers) {
       const inboxId = await getInboxIdForIdentifier(identifier, env);
-      canMessageMap.set(identifier.identifier, inboxId !== null);
+      canMessageMap.set(identifier.identifier.toLowerCase(), inboxId !== null);
     }
     return canMessageMap;
   }


### PR DESCRIPTION
# Summary

When calling the static client method `Client.canMessage`, the addresses returned in the `Map` are not lowercased like in the rest of the SDK.