### PR TITLE
Update bindings for fork fixes

### DIFF
--- a/.changeset/cyan-carrots-cry.md
+++ b/.changeset/cyan-carrots-cry.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Fixes message processing issue that could sometimes fork groups

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/proto": "^3.78.0",
-    "@xmtp/wasm-bindings": "1.2.0-dev.878fd38",
+    "@xmtp/wasm-bindings": "1.2.0-dev.b600c5c",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "^1.2.0-dev.bed98df",
+    "@xmtp/node-bindings": "^1.2.0-dev.d811cc6",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "^1.2.0-dev.d811cc6",
+    "@xmtp/node-bindings": "1.2.0-dev.c24af30",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,7 +3439,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/proto": "npm:^3.78.0"
-    "@xmtp/wasm-bindings": "npm:1.2.0-dev.878fd38"
+    "@xmtp/wasm-bindings": "npm:1.2.0-dev.b600c5c"
     playwright: "npm:^1.51.1"
     rollup: "npm:^4.39.0"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3630,10 +3630,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.2.0-dev.bed98df":
-  version: 1.2.0-dev.bed98df
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.bed98df"
-  checksum: 10/a7e57fb3a1fa462ba49be33ad4ec05e3f164cfd198b5011a12968e57f477abe822c754a74a6fb7b529789408caee38ed1291e1e0165b4f5f3969e50ce98d1e15
+"@xmtp/node-bindings@npm:^1.2.0-dev.d811cc6":
+  version: 1.2.0-dev.d811cc6
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.d811cc6"
+  checksum: 10/4188fb1baf7e4daee5faeb0d99bdbe4986cc935e57f6ac64151c07dc8a6f9bc9ba7393b0fdc8aa01ffe6f821789a1a50ed336a299f1a2365a8381fafae1c623b
   languageName: node
   linkType: hard
 
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:^1.2.0-dev.bed98df"
+    "@xmtp/node-bindings": "npm:^1.2.0-dev.d811cc6"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
@@ -3692,10 +3692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.0-dev.878fd38":
-  version: 1.2.0-dev.878fd38
-  resolution: "@xmtp/wasm-bindings@npm:1.2.0-dev.878fd38"
-  checksum: 10/962101000ec1ae93dd3a2e9ee2e2988297129d8adc22dd5a4de251f1273205eb5cc0e0d6e766f14e22fdbbc7f9c3149ac162f3acf64e0d1c669183e908f0ceb0
+"@xmtp/wasm-bindings@npm:1.2.0-dev.b600c5c":
+  version: 1.2.0-dev.b600c5c
+  resolution: "@xmtp/wasm-bindings@npm:1.2.0-dev.b600c5c"
+  checksum: 10/98deae5efd5f38eead79f574415357871da5f7ca6349a56724843a06ac07b9bbbede6a0d0b74b5bf96821b91513ba4bd0ea25a7694c751e3e0159fd8a32e304e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:^1.2.0-dev.d811cc6":
-  version: 1.2.0-dev.d811cc6
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.d811cc6"
-  checksum: 10/4188fb1baf7e4daee5faeb0d99bdbe4986cc935e57f6ac64151c07dc8a6f9bc9ba7393b0fdc8aa01ffe6f821789a1a50ed336a299f1a2365a8381fafae1c623b
+"@xmtp/node-bindings@npm:1.2.0-dev.c24af30":
+  version: 1.2.0-dev.c24af30
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.c24af30"
+  checksum: 10/51ba1d46bbf6016e9eaa6c9909f39392ea3bc48826f61514b9b68dcc706f9d3318c0eb283cdcba30bc5fc65e8c6f3614610231b92548bc2722e0aa70090d655b
   languageName: node
   linkType: hard
 
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:^1.2.0-dev.d811cc6"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.c24af30"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
### Update XMTP SDK bindings to fix message processing fork issues in group conversations
Updates dependency versions for both browser and node SDKs:
* Updates `@xmtp/browser-sdk` to use `@xmtp/wasm-bindings` version `1.2.0-dev.b600c5c` in [package.json](https://github.com/xmtp/xmtp-js/pull/966/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82)
* Updates `@xmtp/node-sdk` to use `@xmtp/node-bindings` version `1.2.0-dev.c24af30` with exact version pinning in [package.json](https://github.com/xmtp/xmtp-js/pull/966/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
* Adds changeset documentation in [cyan-carrots-cry.md](https://github.com/xmtp/xmtp-js/pull/966/files#diff-4ca14d8ec576931b4427a06f4cbd6b44fe4f7a97d74fa9a0349602345b1c0eb8)

#### 📍Where to Start
Start by reviewing the version updates in [package.json](https://github.com/xmtp/xmtp-js/pull/966/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82) for the browser SDK, followed by the node SDK's [package.json](https://github.com/xmtp/xmtp-js/pull/966/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb) to understand the dependency changes.

----

_[Macroscope](https://app.macroscope.com) summarized af5ab82._