### PR TITLE
Propagate original error from workers, `xmtp.chat` updates

### DIFF
--- a/.changeset/wet-buckets-repeat.md
+++ b/.changeset/wet-buckets-repeat.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": patch
+---
+
+Propagate original error from workers

--- a/apps/xmtp.chat/src/components/AddressBadge.tsx
+++ b/apps/xmtp.chat/src/components/AddressBadge.tsx
@@ -1,5 +1,6 @@
 import { Badge, Flex, Text, Tooltip } from "@mantine/core";
 import { useClipboard } from "@mantine/hooks";
+import { useCallback } from "react";
 import { shortAddress } from "@/helpers/strings";
 
 export type AddressTooltipLabelProps = {
@@ -21,20 +22,35 @@ export const AddressTooltipLabel: React.FC<AddressTooltipLabelProps> = ({
 
 export type AddressBadgeProps = {
   address: string;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
 };
 
-export const AddressBadge: React.FC<AddressBadgeProps> = ({ address }) => {
+export const AddressBadge: React.FC<AddressBadgeProps> = ({
+  address,
+  size = "lg",
+}) => {
   const clipboard = useClipboard({ timeout: 1000 });
 
-  const handleCopy = () => {
-    clipboard.copy(address);
-  };
+  const handleCopy = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLDivElement>
+        | React.KeyboardEvent<HTMLDivElement>,
+    ) => {
+      event.stopPropagation();
+      clipboard.copy(address);
+    },
+    [clipboard, address],
+  );
 
-  const handleKeyboardCopy = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      handleCopy();
-    }
-  };
+  const handleKeyboardCopy = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        handleCopy(event);
+      }
+    },
+    [handleCopy],
+  );
 
   return (
     <Tooltip
@@ -49,7 +65,7 @@ export const AddressBadge: React.FC<AddressBadgeProps> = ({ address }) => {
       events={{ hover: true, focus: true, touch: true }}>
       <Badge
         variant="default"
-        size="lg"
+        size={size}
         radius="md"
         onKeyDown={handleKeyboardCopy}
         onClick={handleCopy}
@@ -59,8 +75,7 @@ export const AddressBadge: React.FC<AddressBadgeProps> = ({ address }) => {
           label: {
             textTransform: "none",
           },
-        }}
-        flex="1 0">
+        }}>
         {shortAddress(address)}
       </Badge>
     </Tooltip>

--- a/apps/xmtp.chat/src/components/App/ErrorModal.tsx
+++ b/apps/xmtp.chat/src/components/App/ErrorModal.tsx
@@ -1,17 +1,19 @@
-import { Button, Group, Modal, ScrollArea, Stack, Title } from "@mantine/core";
-import { useEffect, useState } from "react";
+import { Box, Button, Group, Tabs } from "@mantine/core";
+import { useEffect, useMemo, useState } from "react";
 import { CodeWithCopy } from "@/components/CodeWithCopy";
+import { Modal } from "@/components/Modal";
+import { useCollapsedMediaQuery } from "@/hooks/useCollapsedMediaQuery";
+import { ContentLayout } from "@/layouts/ContentLayout";
 
 export const ErrorModal: React.FC = () => {
-  const [unhandledRejectionError, setUnhandledRejectionError] = useState<
-    string | null
-  >(null);
+  const [unhandledRejectionError, setUnhandledRejectionError] =
+    useState<Error | null>(null);
+  const fullScreen = useCollapsedMediaQuery();
+  const contentHeight = fullScreen ? "auto" : 500;
 
   useEffect(() => {
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-      setUnhandledRejectionError(
-        (event.reason as Error).message || "Unknown error",
-      );
+      setUnhandledRejectionError(event.reason as Error);
     };
     window.addEventListener("unhandledrejection", handleUnhandledRejection);
     return () => {
@@ -22,37 +24,63 @@ export const ErrorModal: React.FC = () => {
     };
   }, []);
 
+  const footer = useMemo(() => {
+    return (
+      <Group justify="space-between" flex={1} p="md">
+        <Button
+          variant="default"
+          component="a"
+          href="https://github.com/xmtp/xmtp-js/issues/new/choose"
+          target="_blank">
+          Report issue
+        </Button>
+        <Button
+          onClick={() => {
+            setUnhandledRejectionError(null);
+          }}>
+          OK
+        </Button>
+      </Group>
+    );
+  }, []);
+
   return unhandledRejectionError ? (
     <Modal
       opened={!!unhandledRejectionError}
       onClose={() => {
         setUnhandledRejectionError(null);
       }}
+      fullScreen={fullScreen}
+      closeOnEscape={false}
+      closeOnClickOutside={false}
       withCloseButton={false}
+      padding={0}
       centered>
-      <Stack gap="md">
-        <Title order={4}>Application error</Title>
-        <ScrollArea>
-          <CodeWithCopy
-            code={JSON.stringify(unhandledRejectionError, null, 2)}
-          />
-        </ScrollArea>
-        <Group justify="space-between">
-          <Button
-            variant="default"
-            component="a"
-            href="https://github.com/xmtp/xmtp-js/issues/new/choose"
-            target="_blank">
-            Report issue
-          </Button>
-          <Button
-            onClick={() => {
-              setUnhandledRejectionError(null);
-            }}>
-            OK
-          </Button>
-        </Group>
-      </Stack>
+      <ContentLayout
+        title="Application error"
+        maxHeight={contentHeight}
+        footer={footer}
+        withScrollFade={false}
+        withScrollAreaPadding={false}>
+        <Box p="md">
+          <Tabs defaultValue="message">
+            <Tabs.List>
+              <Tabs.Tab value="message">Message</Tabs.Tab>
+              <Tabs.Tab value="stackTrace">Stack trace</Tabs.Tab>
+            </Tabs.List>
+            <Tabs.Panel value="message" py="md">
+              <CodeWithCopy code={unhandledRejectionError.message} />
+            </Tabs.Panel>
+            <Tabs.Panel value="stackTrace" py="md">
+              <CodeWithCopy
+                code={
+                  unhandledRejectionError.stack ?? "Stack trace not available"
+                }
+              />
+            </Tabs.Panel>
+          </Tabs>
+        </Box>
+      </ContentLayout>
     </Modal>
   ) : null;
 };

--- a/apps/xmtp.chat/src/components/Conversation/ManageMetadataModal.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/ManageMetadataModal.tsx
@@ -1,6 +1,6 @@
 import { Button, Group } from "@mantine/core";
 import { Group as XmtpGroup } from "@xmtp/browser-sdk";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router";
 import type { ConversationOutletContext } from "@/components/Conversation/ConversationOutletContext";
 import { Metadata } from "@/components/Conversation/Metadata";
@@ -45,6 +45,14 @@ export const ManageMetadataModal: React.FC = () => {
       }
     }
   }, [conversation.id, name, description, imageUrl, navigate]);
+
+  useEffect(() => {
+    if (conversation instanceof XmtpGroup) {
+      initialName.current = conversation.name ?? "";
+      initialDescription.current = conversation.description ?? "";
+      initialImageUrl.current = conversation.imageUrl ?? "";
+    }
+  }, [conversation]);
 
   const footer = useMemo(() => {
     return (

--- a/apps/xmtp.chat/src/components/DateLabel.tsx
+++ b/apps/xmtp.chat/src/components/DateLabel.tsx
@@ -19,18 +19,31 @@ export const DateLabelTooltip: React.FC<DateLabelTooltipProps> = ({ date }) => {
 
 export type DateLabelProps = {
   date: Date;
+  size?: "sm" | "xs" | "md" | "lg" | "xl";
+  align?: "left" | "right" | "center";
+  padding?: "xs" | "sm" | "md" | "lg" | "xl";
 };
 
-export const DateLabel: React.FC<DateLabelProps> = ({ date }) => {
+export const DateLabel: React.FC<DateLabelProps> = ({
+  date,
+  size = "sm",
+  align = "left",
+  padding,
+}) => {
   const clipboard = useClipboard({ timeout: 1000 });
 
-  const handleCopy = () => {
+  const handleCopy = (
+    event:
+      | React.MouseEvent<HTMLDivElement>
+      | React.KeyboardEvent<HTMLDivElement>,
+  ) => {
+    event.stopPropagation();
     clipboard.copy(formatRFC3339(date, { fractionDigits: 3 }));
   };
 
   const handleKeyboardCopy = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === "Enter" || event.key === " ") {
-      handleCopy();
+      handleCopy(event);
     }
   };
 
@@ -46,7 +59,9 @@ export const DateLabel: React.FC<DateLabelProps> = ({ date }) => {
       withArrow
       events={{ hover: true, focus: true, touch: true }}>
       <Text
-        size="sm"
+        p={padding}
+        size={size}
+        ta={align}
         onKeyDown={handleKeyboardCopy}
         onClick={handleCopy}
         miw={100}

--- a/apps/xmtp.chat/src/components/Messages/GroupUpdatedContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/GroupUpdatedContent.tsx
@@ -1,0 +1,120 @@
+import { Group, Text } from "@mantine/core";
+import type { GroupUpdated } from "@xmtp/content-type-group-updated";
+import { useMemo } from "react";
+import { AddressBadge } from "@/components/AddressBadge";
+import { DateLabel } from "@/components/DateLabel";
+import { nsToDate } from "@/helpers/date";
+
+type GroupMembersAddedContentProps = {
+  type: "added" | "removed";
+  members: string[];
+  initiatedBy: string;
+};
+
+const GroupMembersUpdatedContent: React.FC<GroupMembersAddedContentProps> = ({
+  type,
+  members,
+  initiatedBy,
+}) => {
+  return (
+    <Group gap="4" wrap="wrap" justify="center">
+      <AddressBadge address={initiatedBy} size="lg" />
+      <Text size="sm">{type === "added" ? "added" : "removed"}</Text>
+      {members.map((member) => (
+        <AddressBadge key={member} address={member} size="lg" />
+      ))}
+      <Text size="sm">{type === "added" ? "to" : "from"} the group</Text>
+    </Group>
+  );
+};
+
+type GroupMetadataUpdatedContentProps = {
+  metadataFieldChange: GroupUpdated["metadataFieldChanges"][number];
+  initiatedBy: string;
+};
+
+const GroupMetadataUpdatedContent: React.FC<
+  GroupMetadataUpdatedContentProps
+> = ({ metadataFieldChange, initiatedBy }) => {
+  const field = useMemo(() => {
+    switch (metadataFieldChange.fieldName) {
+      case "group_name":
+        return "name";
+      case "description":
+        return "description";
+      case "group_image_url_square":
+        return "image URL";
+    }
+  }, [metadataFieldChange.fieldName]);
+
+  return (
+    <Group gap="4" wrap="wrap" justify="center">
+      <AddressBadge address={initiatedBy} size="lg" />
+      <Text size="sm">
+        {metadataFieldChange.newValue ? "changed" : "removed"} the group
+      </Text>
+      <Text size="sm">{field}</Text>
+      {metadataFieldChange.newValue !== "" && (
+        <>
+          <Text size="sm">to</Text>
+          <Text size="sm" fw={700} truncate>
+            {metadataFieldChange.newValue}
+          </Text>
+        </>
+      )}
+    </Group>
+  );
+};
+
+export type GroupUpdatedContentProps = {
+  content: GroupUpdated;
+  sentAtNs: bigint;
+};
+
+export const GroupUpdatedContent: React.FC<GroupUpdatedContentProps> = ({
+  content,
+  sentAtNs,
+}) => {
+  if (content.addedInboxes.length > 0) {
+    return (
+      <>
+        <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+        <GroupMembersUpdatedContent
+          type="added"
+          members={content.addedInboxes.map((inbox) => inbox.inboxId)}
+          initiatedBy={content.initiatedByInboxId}
+        />
+      </>
+    );
+  }
+
+  if (content.removedInboxes.length > 0) {
+    return (
+      <>
+        <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+        <GroupMembersUpdatedContent
+          type="removed"
+          members={content.removedInboxes.map((inbox) => inbox.inboxId)}
+          initiatedBy={content.initiatedByInboxId}
+        />
+      </>
+    );
+  }
+
+  if (content.metadataFieldChanges.length > 0) {
+    return (
+      <>
+        <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+        {content.metadataFieldChanges.map((change) => (
+          <GroupMetadataUpdatedContent
+            key={change.fieldName}
+            metadataFieldChange={change}
+            initiatedBy={content.initiatedByInboxId}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return null;
+};

--- a/apps/xmtp.chat/src/components/Messages/Message.tsx
+++ b/apps/xmtp.chat/src/components/Messages/Message.tsx
@@ -1,9 +1,6 @@
-import { Box, Flex, Paper, Stack, Text } from "@mantine/core";
+import { Box } from "@mantine/core";
 import type { Client, DecodedMessage } from "@xmtp/browser-sdk";
-import { intlFormat } from "date-fns";
 import { useNavigate, useOutletContext } from "react-router";
-import { nsToDate } from "@/helpers/date";
-import { shortAddress } from "@/helpers/strings";
 import classes from "./Message.module.css";
 import { MessageContent } from "./MessageContent";
 
@@ -16,52 +13,28 @@ export const Message: React.FC<MessageProps> = ({ message }) => {
   const isSender = client.inboxId === message.senderInboxId;
   const align = isSender ? "right" : "left";
   const navigate = useNavigate();
-
   return (
-    <Box px="md">
-      <Flex justify={align === "left" ? "flex-start" : "flex-end"}>
-        <Paper
-          p="md"
-          withBorder
-          shadow="md"
-          maw="80%"
-          tabIndex={0}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              void navigate(
-                `/conversations/${message.conversationId}/message/${message.id}`,
-              );
-            }
-          }}
-          className={classes.root}
-          onClick={() =>
-            void navigate(
-              `/conversations/${message.conversationId}/message/${message.id}`,
-            )
-          }>
-          <Stack gap="xs" align={align === "left" ? "flex-start" : "flex-end"}>
-            <Flex
-              align="center"
-              gap="xs"
-              direction={align === "left" ? "row" : "row-reverse"}
-              justify={align === "left" ? "flex-start" : "flex-end"}>
-              <Text size="sm" fw={700} c="text.primary">
-                {shortAddress(message.senderInboxId)}
-              </Text>
-              <Text size="sm" c="dimmed">
-                {intlFormat(nsToDate(message.sentAtNs), {
-                  year: "numeric",
-                  month: "2-digit",
-                  day: "2-digit",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })}
-              </Text>
-            </Flex>
-            <MessageContent message={message} />
-          </Stack>
-        </Paper>
-      </Flex>
+    <Box
+      p="md"
+      tabIndex={0}
+      className={classes.root}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          void navigate(
+            `/conversations/${message.conversationId}/message/${message.id}`,
+          );
+        }
+      }}
+      onClick={() =>
+        void navigate(
+          `/conversations/${message.conversationId}/message/${message.id}`,
+        )
+      }>
+      <MessageContent
+        message={message}
+        align={align}
+        senderInboxId={message.senderInboxId}
+      />
     </Box>
   );
 };

--- a/apps/xmtp.chat/src/components/Messages/MessageContent.module.css
+++ b/apps/xmtp.chat/src/components/Messages/MessageContent.module.css
@@ -1,0 +1,3 @@
+.text {
+  cursor: text;
+}

--- a/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
@@ -1,4 +1,4 @@
-import { Code, Paper, Text } from "@mantine/core";
+import { Box, Code, Flex, Group, Paper, Stack, Text } from "@mantine/core";
 import type { DecodedMessage } from "@xmtp/browser-sdk";
 import {
   ContentTypeTransactionReference,
@@ -8,51 +8,114 @@ import {
   ContentTypeWalletSendCalls,
   type WalletSendCallsParams,
 } from "@xmtp/content-type-wallet-send-calls";
+import { AddressBadge } from "@/components/AddressBadge";
+import { DateLabel } from "@/components/DateLabel";
 import { TransactionReferenceContent } from "@/components/Messages/TransactionReferenceContent";
 import { WalletSendCallsContent } from "@/components/Messages/WalletSendCallsContent";
+import { nsToDate } from "@/helpers/date";
+import classes from "./MessageContent.module.css";
+
+type MessageAlign = "left" | "right";
+
+type MessageContentWrapperProps = React.PropsWithChildren<{
+  align: MessageAlign;
+  senderInboxId?: string;
+  sentAtNs: bigint;
+}>;
+
+const MessageContentWrapper: React.FC<MessageContentWrapperProps> = ({
+  align,
+  senderInboxId,
+  children,
+  sentAtNs,
+}) => {
+  return (
+    <Group justify={align === "left" ? "flex-start" : "flex-end"}>
+      <Stack gap="xs" align={align === "left" ? "flex-start" : "flex-end"}>
+        <Flex
+          gap="xs"
+          direction={align === "right" ? "row" : "row-reverse"}
+          align="center">
+          <DateLabel date={nsToDate(sentAtNs)} />
+          {senderInboxId && <AddressBadge address={senderInboxId} size="lg" />}
+        </Flex>
+        <Box maw="80%">{children}</Box>
+      </Stack>
+    </Group>
+  );
+};
 
 export type MessageContentProps = {
+  align: MessageAlign;
+  senderInboxId: string;
   message: DecodedMessage;
 };
 
-export const MessageContent: React.FC<MessageContentProps> = ({ message }) => {
+export const MessageContent: React.FC<MessageContentProps> = ({
+  message,
+  align,
+  senderInboxId,
+}) => {
   if (message.contentType.sameAs(ContentTypeTransactionReference)) {
     return (
-      <TransactionReferenceContent
-        content={message.content as TransactionReference}
-      />
+      <MessageContentWrapper
+        align={align}
+        senderInboxId={senderInboxId}
+        sentAtNs={message.sentAtNs}>
+        <TransactionReferenceContent
+          content={message.content as TransactionReference}
+        />
+      </MessageContentWrapper>
     );
   }
 
   if (message.contentType.sameAs(ContentTypeWalletSendCalls)) {
     return (
-      <WalletSendCallsContent
-        content={message.content as WalletSendCallsParams}
-        conversationId={message.conversationId}
-      />
+      <MessageContentWrapper
+        align={align}
+        senderInboxId={senderInboxId}
+        sentAtNs={message.sentAtNs}>
+        <WalletSendCallsContent
+          content={message.content as WalletSendCallsParams}
+          conversationId={message.conversationId}
+        />
+      </MessageContentWrapper>
     );
   }
 
   if (typeof message.content === "string") {
     return (
-      <Paper
-        bg="var(--mantine-color-blue-filled)"
-        c="white"
-        py="xs"
-        px="sm"
-        radius="md">
-        <Text style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
-      </Paper>
+      <MessageContentWrapper
+        align={align}
+        senderInboxId={senderInboxId}
+        sentAtNs={message.sentAtNs}>
+        <Paper
+          className={classes.text}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          bg="var(--mantine-color-blue-filled)"
+          c="white"
+          py="xs"
+          px="sm"
+          radius="md">
+          <Text style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
+        </Paper>
+      </MessageContentWrapper>
     );
   }
 
   return (
-    <Code
-      block
-      maw={420}
-      w="100%"
-      style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
-      {JSON.stringify(message.content ?? message.fallback, null, 2)}
-    </Code>
+    <MessageContentWrapper
+      align={align}
+      senderInboxId={senderInboxId}
+      sentAtNs={message.sentAtNs}>
+      <Code
+        block
+        w="100%"
+        style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+        {JSON.stringify(message.content ?? message.fallback, null, 2)}
+      </Code>
+    </MessageContentWrapper>
   );
 };

--- a/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
@@ -1,6 +1,10 @@
 import { Box, Code, Flex, Group, Paper, Stack, Text } from "@mantine/core";
 import type { DecodedMessage } from "@xmtp/browser-sdk";
 import {
+  ContentTypeGroupUpdated,
+  type GroupUpdated,
+} from "@xmtp/content-type-group-updated";
+import {
   ContentTypeTransactionReference,
   type TransactionReference,
 } from "@xmtp/content-type-transaction-reference";
@@ -10,6 +14,7 @@ import {
 } from "@xmtp/content-type-wallet-send-calls";
 import { AddressBadge } from "@/components/AddressBadge";
 import { DateLabel } from "@/components/DateLabel";
+import { GroupUpdatedContent } from "@/components/Messages/GroupUpdatedContent";
 import { TransactionReferenceContent } from "@/components/Messages/TransactionReferenceContent";
 import { WalletSendCallsContent } from "@/components/Messages/WalletSendCallsContent";
 import { nsToDate } from "@/helpers/date";
@@ -80,6 +85,15 @@ export const MessageContent: React.FC<MessageContentProps> = ({
           conversationId={message.conversationId}
         />
       </MessageContentWrapper>
+    );
+  }
+
+  if (message.contentType.sameAs(ContentTypeGroupUpdated)) {
+    return (
+      <GroupUpdatedContent
+        content={message.content as GroupUpdated}
+        sentAtNs={message.sentAtNs}
+      />
     );
   }
 

--- a/sdks/browser-sdk/src/ClientWorkerClass.ts
+++ b/sdks/browser-sdk/src/ClientWorkerClass.ts
@@ -66,7 +66,7 @@ export class ClientWorkerClass {
     if (promise) {
       this.#promises.delete(eventData.id);
       if ("error" in eventData) {
-        promise.reject(new Error(eventData.error));
+        promise.reject(eventData.error);
       } else {
         promise.resolve(eventData.result);
       }
@@ -83,7 +83,7 @@ export class ClientWorkerClass {
       const eventData = event.data;
       if (eventData.streamId === streamId) {
         if ("error" in eventData) {
-          callback(new Error(eventData.error), null);
+          callback(eventData.error, null);
         } else {
           callback(null, eventData.result as T);
         }

--- a/sdks/browser-sdk/src/UtilsWorkerClass.ts
+++ b/sdks/browser-sdk/src/UtilsWorkerClass.ts
@@ -66,7 +66,7 @@ export class UtilsWorkerClass {
     if (promise) {
       this.#promises.delete(eventData.id);
       if ("error" in eventData) {
-        promise.reject(new Error(eventData.error));
+        promise.reject(eventData.error);
       } else {
         promise.resolve(eventData.result);
       }

--- a/sdks/browser-sdk/src/types/utils.ts
+++ b/sdks/browser-sdk/src/types/utils.ts
@@ -42,7 +42,7 @@ export type EventsClientPostMessageData<
 export type EventsErrorData<Events extends GenericEvent> = {
   id: string;
   action: Events["action"];
-  error: string;
+  error: Error;
 };
 
 export type GenericStreamEvent = {
@@ -68,5 +68,5 @@ export type StreamEventsClientPostMessageData<
 export type StreamEventsErrorData<Events extends GenericStreamEvent> = {
   streamId: string;
   type: Events["type"];
-  error: string;
+  error: Error;
 };

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -296,7 +296,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             postStreamMessageError({
               type: "group",
               streamId: data.streamId,
-              error: error.message,
+              error,
             });
           } else {
             postStreamMessage({
@@ -327,7 +327,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             postStreamMessageError({
               type: "message",
               streamId: data.streamId,
-              error: error.message,
+              error,
             });
           } else {
             postStreamMessage({
@@ -354,7 +354,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             postStreamMessageError({
               type: "consent",
               streamId: data.streamId,
-              error: error.message,
+              error,
             });
           } else {
             postStreamMessage({
@@ -382,7 +382,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             postStreamMessageError({
               type: "preferences",
               streamId: data.streamId,
-              error: error.message,
+              error,
             });
           } else {
             postStreamMessage({
@@ -720,7 +720,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
             postStreamMessageError({
               type: "message",
               streamId: data.streamId,
-              error: error.message,
+              error,
             });
           } else {
             postStreamMessage({
@@ -752,7 +752,7 @@ self.onmessage = async (event: MessageEvent<ClientEventsClientMessageData>) => {
     postMessageError({
       id,
       action,
-      error: (e as Error).message,
+      error: e as Error,
     });
   }
 };

--- a/sdks/browser-sdk/src/workers/utils.ts
+++ b/sdks/browser-sdk/src/workers/utils.ts
@@ -77,7 +77,7 @@ self.onmessage = async (event: MessageEvent<UtilsEventsClientMessageData>) => {
     postMessageError({
       id,
       action,
-      error: (e as Error).message,
+      error: e as Error,
     });
   }
 };


### PR DESCRIPTION
# Summary

### Browser SDK

- Replaced error message with original error when sending errors from workers

### xmtp.chat

- Fixed initial values in `ManageMetadataModal`
- Added props and prevented event propagation in `DateLabel` component
- Added props and prevented event propagation in `AddressBadge` component
- Refactored `ErrorModal` to also display a stack trace
- Refactored message rendering
- Added custom content rendering for group updated messages

#### Group updated message rendering

![Screenshot 2025-04-18 at 3 07 04 PM](https://github.com/user-attachments/assets/574cc2e1-78c8-4c53-9c13-0e46e59f2a4a)

#### Stack trace in error modal

![Screenshot 2025-04-18 at 3 07 26 PM](https://github.com/user-attachments/assets/02336d3d-8154-4842-9fd8-56b6ebd7a842)
