### PR TITLE
Update libxmtp ref for welcome processing fix

### DIFF
--- a/.changeset/wet-apples-lay.md
+++ b/.changeset/wet-apples-lay.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Fix new group processing issue that could lead incorrect group state

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/proto": "^3.78.0",
-    "@xmtp/wasm-bindings": "1.2.0-dev.b600c5c",
+    "@xmtp/wasm-bindings": "1.2.0-dev.5d15935",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.0-dev.c24af30",
+    "@xmtp/node-bindings": "1.2.0-dev.068bb4c",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3439,7 +3439,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/proto": "npm:^3.78.0"
-    "@xmtp/wasm-bindings": "npm:1.2.0-dev.b600c5c"
+    "@xmtp/wasm-bindings": "npm:1.2.0-dev.5d15935"
     playwright: "npm:^1.51.1"
     rollup: "npm:^4.39.0"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3692,10 +3692,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.0-dev.b600c5c":
-  version: 1.2.0-dev.b600c5c
-  resolution: "@xmtp/wasm-bindings@npm:1.2.0-dev.b600c5c"
-  checksum: 10/98deae5efd5f38eead79f574415357871da5f7ca6349a56724843a06ac07b9bbbede6a0d0b74b5bf96821b91513ba4bd0ea25a7694c751e3e0159fd8a32e304e
+"@xmtp/wasm-bindings@npm:1.2.0-dev.5d15935":
+  version: 1.2.0-dev.5d15935
+  resolution: "@xmtp/wasm-bindings@npm:1.2.0-dev.5d15935"
+  checksum: 10/1ce0ec1043a7b7c1ebdb813e948b84711ffcbe142cf4601810001b775d6eef3568c33536fe2f937dd84eea989e4a770f3f13fa122e5de169ab395e0573590592
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.2.0-dev.c24af30":
-  version: 1.2.0-dev.c24af30
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.c24af30"
-  checksum: 10/51ba1d46bbf6016e9eaa6c9909f39392ea3bc48826f61514b9b68dcc706f9d3318c0eb283cdcba30bc5fc65e8c6f3614610231b92548bc2722e0aa70090d655b
+"@xmtp/node-bindings@npm:1.2.0-dev.068bb4c":
+  version: 1.2.0-dev.068bb4c
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.068bb4c"
+  checksum: 10/80b77efecb6624b57e3cee7f506acfbb0579a6246c20c376ff2019cac3419d13338bfa553098ccae825412c86da8289807a99b0253a838348065ef71ac356039
   languageName: node
   linkType: hard
 
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.0-dev.c24af30"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.068bb4c"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
### Update XMTP SDK dependencies to fix group welcome message processing issue
Updates dependency versions in both browser and node SDKs:
* Updates `@xmtp/wasm-bindings` to version `1.2.0-dev.5d15935` in [package.json](https://github.com/xmtp/xmtp-js/pull/975/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82)
* Updates `@xmtp/node-bindings` to version `1.2.0-dev.068bb4c` in [package.json](https://github.com/xmtp/xmtp-js/pull/975/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
* Adds changeset in [wet-apples-lay.md](https://github.com/xmtp/xmtp-js/pull/975/files#diff-a2bd6c16c85e1fc7199c8bba9b103950d2d2067eb971da06c451c57b0bd0726b) documenting patch updates

#### 📍Where to Start
Start with the version updates in [package.json](https://github.com/xmtp/xmtp-js/pull/975/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82) and [package.json](https://github.com/xmtp/xmtp-js/pull/975/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb) to verify the correct dependency versions are being used.

----

_[Macroscope](https://app.macroscope.com) summarized 4bfa071._