### PR TITLE
Upgrade node bindings, prevent unexpected conversation types

### DIFF
--- a/.changeset/wise-bears-cheat.md
+++ b/.changeset/wise-bears-cheat.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+Prevent unexpected conversation types

--- a/sdks/browser-sdk/src/Conversations.ts
+++ b/sdks/browser-sdk/src/Conversations.ts
@@ -112,11 +112,18 @@ export class Conversations {
       options,
     });
 
-    return conversations.map((conversation) =>
-      conversation.metadata.conversationType === "group"
-        ? new Group(this.#client, conversation.id, conversation)
-        : new Dm(this.#client, conversation.id, conversation),
-    );
+    return conversations
+      .map((conversation) => {
+        switch (conversation.metadata.conversationType) {
+          case "dm":
+            return new Dm(this.#client, conversation.id, conversation);
+          case "group":
+            return new Group(this.#client, conversation.id, conversation);
+          default:
+            return undefined;
+        }
+      })
+      .filter((conversation) => conversation !== undefined);
   }
 
   /**

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.0-dev.068bb4c",
+    "@xmtp/node-bindings": "1.2.0-dev.b96f93d",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -149,14 +149,21 @@ export class Conversations {
    */
   async list(options?: ListConversationsOptions) {
     const groups = this.#conversations.list(options);
-    return Promise.all(
+    const conversations = await Promise.all(
       groups.map(async (item) => {
         const metadata = await item.conversation.groupMetadata();
-        return metadata.conversationType() === "dm"
-          ? new Dm(this.#client, item.conversation, item.lastMessage)
-          : new Group(this.#client, item.conversation, item.lastMessage);
+        const conversationType = metadata.conversationType();
+        switch (conversationType) {
+          case "dm":
+            return new Dm(this.#client, item.conversation, item.lastMessage);
+          case "group":
+            return new Group(this.#client, item.conversation, item.lastMessage);
+          default:
+            return undefined;
+        }
       }),
     );
+    return conversations.filter((conversation) => conversation !== undefined);
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.2.0-dev.068bb4c":
-  version: 1.2.0-dev.068bb4c
-  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.068bb4c"
-  checksum: 10/80b77efecb6624b57e3cee7f506acfbb0579a6246c20c376ff2019cac3419d13338bfa553098ccae825412c86da8289807a99b0253a838348065ef71ac356039
+"@xmtp/node-bindings@npm:1.2.0-dev.b96f93d":
+  version: 1.2.0-dev.b96f93d
+  resolution: "@xmtp/node-bindings@npm:1.2.0-dev.b96f93d"
+  checksum: 10/f4c200dce0a41e0991328eca9a225e8c38909c72474fe73f14eb62cbba0ae5261aa37a4261e41b577f29e82be0be39e2ef1c3a7dacd5720246b6eeea5fc07e9c
   languageName: node
   linkType: hard
 
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.0-dev.068bb4c"
+    "@xmtp/node-bindings": "npm:1.2.0-dev.b96f93d"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
# Summary

- Upgraded node bindings, which include a change to always exclude sync groups when querying for conversations
- Added guard against unexpected conversation types