### PR TITLE
xmtp.chat fixes

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
@@ -44,6 +44,9 @@ export const Conversation: React.FC<ConversationProps> = ({ conversation }) => {
       await startStream();
     };
     void loadMessages();
+    return () => {
+      stopStream();
+    };
   }, [conversation.id]);
 
   const handleSync = useCallback(async () => {
@@ -54,12 +57,6 @@ export const Conversation: React.FC<ConversationProps> = ({ conversation }) => {
       setTitle(conversation.name || "Untitled");
     }
   }, [getMessages, conversation.id, startStream, stopStream]);
-
-  useEffect(() => {
-    return () => {
-      stopStream();
-    };
-  }, []);
 
   useEffect(() => {
     if (conversation instanceof XmtpGroup) {

--- a/apps/xmtp.chat/src/components/Messages/TextContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/TextContent.tsx
@@ -21,7 +21,7 @@ export const TextContent: React.FC<TextContentProps> = ({ text }) => {
         component="pre"
         style={{
           whiteSpace: "pre-wrap",
-          wordBreak: "break-all",
+          wordBreak: "break-word",
           fontFamily: "inherit",
         }}>
         {text}

--- a/apps/xmtp.chat/src/hooks/useConversation.ts
+++ b/apps/xmtp.chat/src/hooks/useConversation.ts
@@ -21,12 +21,12 @@ export const useConversation = (conversation?: Conversation) => {
       return;
     }
 
+    setMessages([]);
+    setLoading(true);
+
     if (syncFromNetwork) {
       await sync();
     }
-
-    setMessages([]);
-    setLoading(true);
 
     try {
       const msgs = (await conversation?.messages(options)) ?? [];


### PR DESCRIPTION
### Fix message stream cleanup, text word breaking, and loading state handling in XMTP chat components
* Relocates message stream cleanup to the main `useEffect` hook with proper conversation ID dependency in [Conversation.tsx](https://github.com/xmtp/xmtp-js/pull/1001/files#diff-9ef483f6f17229928a31eed31f06e3a44070937510afc9796f8d57b65cceac1b)
* Updates text content word breaking from `break-all` to `break-word` in [TextContent.tsx](https://github.com/xmtp/xmtp-js/pull/1001/files#diff-46120d2b2269523f40e48c0607ae0a3c3fc049cf25cde17c7b2aa2f205632cfe)
* Reorders state operations in `getMessages` function to set loading state before network sync in [useConversation.ts](https://github.com/xmtp/xmtp-js/pull/1001/files#diff-7d6bf0c4e42ce58d1bb76cdffeb19d380903c904ca4be18d58d3054a4dd4b9ab)

#### 📍Where to Start
Start with the message stream cleanup changes in the `useEffect` hook within [Conversation.tsx](https://github.com/xmtp/xmtp-js/pull/1001/files#diff-9ef483f6f17229928a31eed31f06e3a44070937510afc9796f8d57b65cceac1b), as this contains the most impactful changes related to resource management.

----

_[Macroscope](https://app.macroscope.com) summarized 7e197c5._