### PR TITLE
Add option to force SCW signatures

### DIFF
--- a/apps/xmtp.chat/src/components/App/Connect.module.css
+++ b/apps/xmtp.chat/src/components/App/Connect.module.css
@@ -26,10 +26,6 @@
   border-top: none;
 }
 
-.options {
-  background-color: var(--mantine-color-gray-light);
-}
-
 @media screen and (max-width: 500px) {
   .options {
     flex-direction: column;

--- a/apps/xmtp.chat/src/components/App/Connect.tsx
+++ b/apps/xmtp.chat/src/components/App/Connect.tsx
@@ -1,4 +1,4 @@
-import { Box, Group, LoadingOverlay, Stack } from "@mantine/core";
+import { Group, LoadingOverlay, Stack } from "@mantine/core";
 import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { hexToUint8Array } from "uint8array-extras";
@@ -13,6 +13,7 @@ import {
 } from "wagmi";
 import { AccountCard } from "@/components/App/AccountCard";
 import { DisableAnalytics } from "@/components/App/DisableAnalytics";
+import { ForceSCW } from "@/components/App/ForceSCW";
 import { LoggingSelect } from "@/components/App/LoggingSelect";
 import { NetworkSelect } from "@/components/App/NetworkSelect";
 import { useXMTP } from "@/contexts/XMTPContext";
@@ -52,6 +53,7 @@ export const Connect = () => {
     encryptionKey,
     environment,
     loggingLevel,
+    forceSCW,
   } = useSettings();
   const { signMessageAsync } = useSignMessage();
   const handleEphemeralConnect = useCallback(() => {
@@ -112,7 +114,8 @@ export const Connect = () => {
               connectionType: string;
             };
         if (provider) {
-          const isSCW = provider.connectionType === "scw_connection_type";
+          const isSCW =
+            forceSCW || provider.connectionType === "scw_connection_type";
           void initialize({
             dbEncryptionKey: encryptionKey
               ? hexToUint8Array(encryptionKey)
@@ -187,9 +190,8 @@ export const Connect = () => {
           label="WalletConnect"
           onClick={handleWalletConnect("WalletConnect")}
         />
-        <Box className={classes.options}>
-          <DisableAnalytics />
-        </Box>
+        <ForceSCW />
+        <DisableAnalytics />
       </Stack>
     </Stack>
   );

--- a/apps/xmtp.chat/src/components/App/DisableAnalytics.tsx
+++ b/apps/xmtp.chat/src/components/App/DisableAnalytics.tsx
@@ -13,7 +13,7 @@ export const DisableAnalytics: React.FC = () => {
   };
 
   return (
-    <Stack p="md">
+    <Stack p="md" bg="var(--mantine-color-gray-light)">
       <Group gap="xs" justify="space-between">
         <Text>Disable analytics</Text>
         <Switch size="md" checked={checked} onChange={handleChange} />

--- a/apps/xmtp.chat/src/components/App/ForceSCW.tsx
+++ b/apps/xmtp.chat/src/components/App/ForceSCW.tsx
@@ -1,0 +1,24 @@
+import { Group, Stack, Switch, Text } from "@mantine/core";
+import React from "react";
+import { useSettings } from "@/hooks/useSettings";
+
+export const ForceSCW: React.FC = () => {
+  const { forceSCW, setForceSCW } = useSettings();
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setForceSCW(event.currentTarget.checked);
+  };
+
+  return (
+    <Stack p="md" bg="var(--mantine-color-gray-light)">
+      <Group gap="xs" justify="space-between">
+        <Text>Force use of Smart Contract Wallet signatures</Text>
+        <Switch size="md" checked={forceSCW} onChange={handleChange} />
+      </Group>
+      <Text size="sm">
+        Use this option if you are experiencing issues when signing with your
+        smart contract wallet.
+      </Text>
+    </Stack>
+  );
+};

--- a/apps/xmtp.chat/src/components/Messages/ReplyContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReplyContent.tsx
@@ -58,7 +58,7 @@ export const ReplyContent: React.FC<ReplyContentProps> = ({
                 size="sm"
                 style={{
                   whiteSpace: "pre-wrap",
-                  wordBreak: "break-all",
+                  wordBreak: "break-word",
                   fontFamily: "inherit",
                 }}>
                 {originalMessage?.content}

--- a/apps/xmtp.chat/src/hooks/useSettings.ts
+++ b/apps/xmtp.chat/src/hooks/useSettings.ts
@@ -33,17 +33,24 @@ export const useSettings = () => {
     defaultValue: "off",
     getInitialValueInEffect: false,
   });
+  const [forceSCW, setForceSCW] = useLocalStorage<boolean>({
+    key: "XMTP_FORCE_SCW",
+    defaultValue: false,
+    getInitialValueInEffect: false,
+  });
 
   return {
     encryptionKey,
     environment,
     ephemeralAccountEnabled,
     ephemeralAccountKey,
+    forceSCW,
     loggingLevel,
     setEncryptionKey,
     setEnvironment,
     setEphemeralAccountEnabled,
     setEphemeralAccountKey,
+    setForceSCW,
     setLoggingLevel,
   };
 };


### PR DESCRIPTION
# Summary

- Added option to force the use of Smart Contract Wallet signatures
- Fixed line breaks in the original message text of replies