### PR TITLE
Don't kill stream on benign message errors

### DIFF
--- a/.changeset/silver-points-smell.md
+++ b/.changeset/silver-points-smell.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": patch
+---
+
+Do not stop stream on benign message processing errors

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.1.6",
+    "@xmtp/node-bindings": "1.1.8",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3630,10 +3630,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.1.6":
-  version: 1.1.6
-  resolution: "@xmtp/node-bindings@npm:1.1.6"
-  checksum: 10/8eb5991da04a38fdde053d8f54d8cf2c03b0edfa30aded13e4c277e910cd95009ca48835e437f808624e19c8702d3171a010db05a25bf310c956f4681c14f90a
+"@xmtp/node-bindings@npm:1.1.8":
+  version: 1.1.8
+  resolution: "@xmtp/node-bindings@npm:1.1.8"
+  checksum: 10/24e4bbbaaeb7717b74fc6984823d571805547bedff04092ad0a13b144142ca700ce8d664fa6a2790cf9c62117b5a8cf7c2b6299dd69c285e06368a08d4d115c2
   languageName: node
   linkType: hard
 
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.1.6"
+    "@xmtp/node-bindings": "npm:1.1.8"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
### Update @xmtp/node-sdk to prevent stream termination on benign message processing errors
Updates the `@xmtp/node-sdk` package dependencies, specifically upgrading `@xmtp/node-bindings` from version 1.1.6 to 1.1.8. The changes are documented in the new changeset file [.changeset/silver-points-smell.md](https://github.com/xmtp/xmtp-js/pull/1004/files#diff-1c58b58634e7ca8f5207f7180cffd0b46c725516dcf318bd698a723577f01cd1) and reflected in [package.json](https://github.com/xmtp/xmtp-js/pull/1004/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb).

#### 📍Where to Start
Start by reviewing the version update in [package.json](https://github.com/xmtp/xmtp-js/pull/1004/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb) to verify the dependency upgrade from `@xmtp/node-bindings` 1.1.6 to 1.1.8.

----

_[Macroscope](https://app.macroscope.com) summarized ddfc032._