### PR TITLE
AsyncStream updates

### DIFF
--- a/.changeset/spotty-pillows-shop.md
+++ b/.changeset/spotty-pillows-shop.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+AsyncStream updates

--- a/sdks/browser-sdk/src/AsyncStream.ts
+++ b/sdks/browser-sdk/src/AsyncStream.ts
@@ -95,7 +95,7 @@ export class AsyncStream<T> {
     });
   };
 
-  return = (value: T | undefined) => {
+  return = (value?: T) => {
     this.#endStream();
     this.onReturn?.();
     return Promise.resolve({
@@ -103,6 +103,8 @@ export class AsyncStream<T> {
       value,
     });
   };
+
+  end = () => this.return();
 
   [Symbol.asyncIterator]() {
     return this;

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -9,6 +9,7 @@ export { Utils } from "./Utils";
 export { ApiUrls, HistorySyncUrls } from "./constants";
 export type * from "./types";
 export * from "./utils/conversions";
+export type { AsyncStream, StreamCallback } from "./AsyncStream";
 export type {
   Identifier,
   IdentifierKind,

--- a/sdks/node-sdk/src/AsyncStream.ts
+++ b/sdks/node-sdk/src/AsyncStream.ts
@@ -96,7 +96,7 @@ export class AsyncStream<T> {
     });
   };
 
-  return = (value: T | undefined) => {
+  return = (value?: T) => {
     this.#endStream();
     this.onReturn?.();
     return Promise.resolve({
@@ -104,6 +104,8 @@ export class AsyncStream<T> {
       value,
     });
   };
+
+  end = () => this.return();
 
   [Symbol.asyncIterator]() {
     return this;

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -13,7 +13,7 @@ export { Dm } from "./Dm";
 export { Group } from "./Group";
 export type { PreferenceUpdate } from "./Preferences";
 export { DecodedMessage } from "./DecodedMessage";
-export type { StreamCallback } from "./AsyncStream";
+export type { AsyncStream, StreamCallback } from "./AsyncStream";
 export type {
   Consent,
   ContentType,


### PR DESCRIPTION
# Summary

- Changed signature of `return` to allow no argument (e.g. `stream.return()`)
- Added `end` alias that calls `return` without an argument

### Browser SDK

- Added `AsyncStream` and `StreamCallback` to exports

### Node SDK

- Added `AsyncStream` to exports