### PR TITLE
Add more chains to xmtp.chat

### DIFF
--- a/apps/xmtp.chat/src/components/App/Connect.tsx
+++ b/apps/xmtp.chat/src/components/App/Connect.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect } from "react";
 import { useNavigate } from "react-router";
 import { hexToUint8Array } from "uint8array-extras";
 import { generatePrivateKey } from "viem/accounts";
-import { mainnet } from "viem/chains";
 import {
   useAccount,
   useConnect,
@@ -126,7 +125,7 @@ export const Connect = () => {
               ? createSCWSigner(
                   data.account.address,
                   (message: string) => signMessageAsync({ message }),
-                  mainnet.id,
+                  account.chainId,
                 )
               : createEOASigner(data.account.address, (message: string) =>
                   signMessageAsync({ message }),
@@ -136,7 +135,7 @@ export const Connect = () => {
       }
     };
     void initClient();
-  }, [account.address, data?.account, signMessageAsync]);
+  }, [account.address, account.chainId, data?.account, signMessageAsync]);
 
   useEffect(() => {
     if (client) {

--- a/apps/xmtp.chat/src/helpers/createSigner.ts
+++ b/apps/xmtp.chat/src/helpers/createSigner.ts
@@ -41,6 +41,7 @@ export const createSCWSigner = (
   signMessage: (message: string) => Promise<string> | string,
   chainId: number = 1,
 ): Signer => {
+  console.log("Creating SCW signer with chain ID:", chainId);
   return {
     type: "SCW",
     getIdentifier: () => ({

--- a/apps/xmtp.chat/src/main.tsx
+++ b/apps/xmtp.chat/src/main.tsx
@@ -6,7 +6,14 @@ import pkg from "@xmtp/browser-sdk/package.json";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router";
 import { createConfig, http, WagmiProvider } from "wagmi";
-import { base, baseSepolia, mainnet, sepolia } from "wagmi/chains";
+import {
+  base,
+  baseSepolia,
+  mainnet,
+  polygon,
+  polygonAmoy,
+  sepolia,
+} from "wagmi/chains";
 import {
   coinbaseWallet,
   injected,
@@ -27,12 +34,14 @@ export const config = createConfig({
     metaMask(),
     walletConnect({ projectId: import.meta.env.VITE_PROJECT_ID }),
   ],
-  chains: [mainnet, base, sepolia, baseSepolia],
+  chains: [mainnet, base, sepolia, baseSepolia, polygon, polygonAmoy],
   transports: {
     [mainnet.id]: http(),
     [sepolia.id]: http(),
     [base.id]: http(),
     [baseSepolia.id]: http(),
+    [polygon.id]: http(),
+    [polygonAmoy.id]: http(),
   },
 });
 


### PR DESCRIPTION
# Summary

- Added `polygon` and `polygonAmoy` chains
- Refactored connection code to use account chainId
- Added log to show chainId used for SCW signer