### PR TITLE
Fix broken links in documents

### DIFF
--- a/content-types/content-type-reaction/README.md
+++ b/content-types/content-type-reaction/README.md
@@ -5,7 +5,7 @@
 This package provides an XMTP content type to support reactions to messages.
 
 > **Open for feedback**  
-> You are welcome to provide feedback on this implementation by commenting on the [Proposal for emoji reactions content type](https://github.com/orgs/xmtp/discussions/36).
+> You are welcome to provide feedback on this implementation by commenting on the [Proposal for emoji reactions content type](https://github.com/xmtp/xmtp/discussions/36).
 
 ## What’s a reaction?
 

--- a/content-types/content-type-read-receipt/README.md
+++ b/content-types/content-type-read-receipt/README.md
@@ -10,7 +10,7 @@ This package provides an XMTP content type to support read receipts to messages.
 Until then, if you must support read receipts, we recommend that you use this implementation and **not build your own custom content type.**
 
 > **Open for feedback**  
-> You are welcome to provide feedback on this implementation by commenting on the [Read Receipts content type proposal](https://github.com/orgs/xmtp/discussions/43).
+> You are welcome to provide feedback on this implementation by commenting on the [Read Receipts content type proposal](https://github.com/xmtp/xmtp/discussions/43).
 
 ## What’s a read receipt?
 

--- a/content-types/content-type-remote-attachment/README.md
+++ b/content-types/content-type-remote-attachment/README.md
@@ -90,7 +90,7 @@ const cid = await web3Storage.put([upload]);
 const url = `https://${cid}.ipfs.w3s.link/XMTPEncryptedContent`;
 ```
 
-_([Upload](https://github.com/xmtp/xmtp-web/blob/b87015c6f3e626ed985c6cf63dd94a68eaf9712c/packages/react-sdk/src/hooks/useSendMessage.ts##L15-L33) is a small class that implements Web3Storage's `Filelike` interface for uploading)_
+_([Upload](https://github.com/xmtp/xmtp-web/blob/b87015c6f3e626ed985c6cf63dd94a68eaf9712c/packages/react-sdk/src/hooks/useSendMessage.ts#L15-L33) is a small class that implements Web3Storage's `Filelike` interface for uploading)_
 
 ## Create a remote attachment
 

--- a/content-types/content-type-remote-attachment/README.md
+++ b/content-types/content-type-remote-attachment/README.md
@@ -90,7 +90,7 @@ const cid = await web3Storage.put([upload]);
 const url = `https://${cid}.ipfs.w3s.link/XMTPEncryptedContent`;
 ```
 
-_([Upload](https://github.com/xmtp-labs/xmtp-inbox-web/blob/5b45e05efbe0b0f49c17d66d7547be2c13a51eab/hooks/useSendMessage.ts#L15-L33) is a small class that implements Web3Storage's `Filelike` interface for uploading)_
+_([Upload](https://github.com/xmtp/xmtp-web/blob/b87015c6f3e626ed985c6cf63dd94a68eaf9712c/packages/react-sdk/src/hooks/useSendMessage.ts##L15-L33) is a small class that implements Web3Storage's `Filelike` interface for uploading)_
 
 ## Create a remote attachment
 

--- a/content-types/content-type-reply/README.md
+++ b/content-types/content-type-reply/README.md
@@ -5,7 +5,7 @@
 This package provides an XMTP content type to support direct replies to messages.
 
 > **Open for feedback**  
-> You are welcome to provide feedback on this implementation by commenting on the [Proposal for Reply content type](https://github.com/orgs/xmtp/discussions/35).
+> You are welcome to provide feedback on this implementation by commenting on the [Proposal for Reply content type](https://github.com/xmtp/xmtp/discussions/35).
 
 ## What’s a reply?
 

--- a/content-types/content-type-transaction-reference/README.md
+++ b/content-types/content-type-transaction-reference/README.md
@@ -5,7 +5,7 @@
 This package provides an XMTP content type to support on-chain transaction references.
 
 > **Open for feedback**  
-> You are welcome to provide feedback on this implementation by commenting on the [Proposal for on-chain transaction reference content type](https://github.com/orgs/xmtp/discussions/37).
+> You are welcome to provide feedback on this implementation by commenting on the [Proposal for on-chain transaction reference content type](https://github.com/xmtp/xmtp/discussions/37).
 
 ## What’s a transaction reference?
 


### PR DESCRIPTION
# Summary

Fix broken links to github discussions and source links in multiple content-type README files.

Affected files:

- content-type-read-receipt/README.md

- content-type-reply/README.md

- content-type-reaction/README.md

- content-type-transaction-reference/README.md

- content-type-remote-attachment/README.md

# Description

1. Updated GitHub Discussions links: 
The original links pointed to "https://github.com/orgs/xmtp/discussions", which returned 404 errors.  
   Replaced them with the correct path: "https://github.com/xmtp/xmtp/discussions".

2. Updated source link: 
The link "xmtp-labs/xmtp-inbox-web" is returned 404.
Updated to the correct path:
From: https://github.com/xmtp-labs/xmtp-inbox-web/blob/5b45e05efbe0b0f49c17d66d7547be2c13a51eab/hooks/useSendMessage.ts#L15-L33
To: https://github.com/xmtp/xmtp-web/blob/b87015c6f3e626ed985c6cf63dd94a68eaf9712c/packages/react-sdk/src/hooks/useSendMessage.ts#L15-L33

Let me know if anything’s off. Thank you. (This PR does not include any major changes, so XIP proposal was not submitted.)