### PR TITLE
Expose group member addresses

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Outlet, useOutletContext } from "react-router";
 import { ConversationMenu } from "@/components/Conversation/ConversationMenu";
 import { Messages } from "@/components/Messages/Messages";
+import { ConversationProvider } from "@/contexts/ConversationContext";
 import { useConversation } from "@/hooks/useConversation";
 import { ContentLayout } from "@/layouts/ContentLayout";
 import { Composer } from "./Composer";
@@ -82,7 +83,9 @@ export const Conversation: React.FC<ConversationProps> = ({ conversation }) => {
         }
         footer={<Composer conversation={conversation} />}
         withScrollArea={false}>
-        <Messages messages={messages} />
+        <ConversationProvider conversation={conversation}>
+          <Messages messages={messages} />
+        </ConversationProvider>
       </ContentLayout>
       <Outlet context={{ conversation, client }} />
     </>

--- a/apps/xmtp.chat/src/components/Conversation/Members.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Members.tsx
@@ -1,4 +1,14 @@
-import { Badge, Button, Group, Stack, Text, TextInput } from "@mantine/core";
+import {
+  Badge,
+  Button,
+  Divider,
+  Group,
+  SegmentedControl,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
 import {
   Utils,
   Group as XmtpGroup,
@@ -17,6 +27,8 @@ export type MembersProps = {
   onMembersRemoved?: (members: SafeGroupMember[]) => void;
 };
 
+type MemberType = "inboxID" | "address";
+
 export const Members: React.FC<MembersProps> = ({
   conversation,
   inboxId,
@@ -28,6 +40,7 @@ export const Members: React.FC<MembersProps> = ({
   const [members, setMembers] = useState<SafeGroupMember[]>([]);
   const [addedMembers, setAddedMembers] = useState<string[]>([]);
   const [removedMembers, setRemovedMembers] = useState<SafeGroupMember[]>([]);
+  const [memberType, setMemberType] = useState<MemberType>("inboxID");
   const { environment } = useSettings();
   const utilsRef = useRef<Utils | null>(null);
 
@@ -199,6 +212,27 @@ export const Members: React.FC<MembersProps> = ({
       {conversation && (
         <>
           <Stack gap="xs">
+            <Group justify="space-between" gap="xs">
+              <Title order={4}>Existing members</Title>
+              <SegmentedControl
+                withItemsBorders={false}
+                value={memberType}
+                onChange={(value) => {
+                  setMemberType(value as MemberType);
+                }}
+                data={[
+                  {
+                    label: "Inbox ID",
+                    value: "inboxID",
+                  },
+                  {
+                    label: "Address",
+                    value: "address",
+                  },
+                ]}
+              />
+            </Group>
+            <Divider mb="md" />
             <Group gap="xs">
               <Text fw={700}>Removed members</Text>
               <Badge color="gray" size="lg">
@@ -208,11 +242,17 @@ export const Members: React.FC<MembersProps> = ({
             <Stack gap="4px">
               {removedMembers.map((member) => (
                 <Group
-                  key={member.inboxId}
+                  key={`${member.inboxId}-removed`}
                   justify="space-between"
                   align="center"
                   wrap="nowrap">
-                  <BadgeWithCopy value={member.inboxId} />
+                  <BadgeWithCopy
+                    value={
+                      memberType === "inboxID"
+                        ? member.inboxId
+                        : member.accountIdentifiers[0].identifier
+                    }
+                  />
                   <Button
                     flex="0 0 auto"
                     size="xs"
@@ -241,7 +281,13 @@ export const Members: React.FC<MembersProps> = ({
                       justify="space-between"
                       align="center"
                       wrap="nowrap">
-                      <BadgeWithCopy value={member.inboxId} />
+                      <BadgeWithCopy
+                        value={
+                          memberType === "inboxID"
+                            ? member.inboxId
+                            : member.accountIdentifiers[0].identifier
+                        }
+                      />
                       <Button
                         flex="0 0 auto"
                         size="xs"

--- a/apps/xmtp.chat/src/components/InboxId.tsx
+++ b/apps/xmtp.chat/src/components/InboxId.tsx
@@ -1,0 +1,55 @@
+import { Button, Popover, Stack, Text } from "@mantine/core";
+import { useState } from "react";
+import { BadgeWithCopy } from "@/components/BadgeWithCopy";
+import { shortAddress } from "@/helpers/strings";
+
+export type InboxIdBadgeProps = {
+  inboxId: string;
+  address: string;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+};
+
+export const InboxIdBadge: React.FC<InboxIdBadgeProps> = ({
+  inboxId,
+  address,
+  size = "lg",
+}) => {
+  const [opened, setOpened] = useState(false);
+  return (
+    <Popover
+      width={300}
+      position="bottom"
+      withArrow
+      shadow="md"
+      trapFocus
+      opened={opened}
+      onChange={setOpened}
+      closeOnEscape>
+      <Popover.Target>
+        <Button
+          variant="default"
+          size={size}
+          radius="md"
+          miw={100}
+          onClick={(e) => {
+            e.stopPropagation();
+            setOpened((o) => !o);
+          }}>
+          {shortAddress(inboxId)}
+        </Button>
+      </Popover.Target>
+      <Popover.Dropdown p="xs">
+        <Stack gap="xs">
+          <Text truncate size="sm" ml="xs">
+            Inbox ID
+          </Text>
+          <BadgeWithCopy value={inboxId} />
+          <Text truncate size="sm" ml="xs">
+            Address
+          </Text>
+          <BadgeWithCopy value={address} />
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+};

--- a/apps/xmtp.chat/src/components/InboxId.tsx
+++ b/apps/xmtp.chat/src/components/InboxId.tsx
@@ -23,8 +23,7 @@ export const InboxIdBadge: React.FC<InboxIdBadgeProps> = ({
       shadow="md"
       trapFocus
       opened={opened}
-      onChange={setOpened}
-      closeOnEscape>
+      onChange={setOpened}>
       <Popover.Target>
         <Button
           variant="default"
@@ -38,7 +37,11 @@ export const InboxIdBadge: React.FC<InboxIdBadgeProps> = ({
           {shortAddress(inboxId)}
         </Button>
       </Popover.Target>
-      <Popover.Dropdown p="xs">
+      <Popover.Dropdown
+        p="xs"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}>
         <Stack gap="xs">
           <Text truncate size="sm" ml="xs">
             Inbox ID

--- a/apps/xmtp.chat/src/components/Messages/FallbackContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/FallbackContent.tsx
@@ -7,13 +7,7 @@ export type FallbackContentProps = {
 
 export const FallbackContent: React.FC<FallbackContentProps> = ({ text }) => {
   return (
-    <Paper
-      className={classes.text}
-      withBorder
-      c="white"
-      py="xs"
-      px="sm"
-      radius="md">
+    <Paper className={classes.text} withBorder py="xs" px="sm" radius="md">
       <Text
         component="pre"
         style={{

--- a/apps/xmtp.chat/src/components/Messages/Message.module.css
+++ b/apps/xmtp.chat/src/components/Messages/Message.module.css
@@ -1,5 +1,8 @@
 .root:hover {
-  background-color: var(--mantine-color-default-hover);
+  background-color: light-dark(
+    var(--mantine-color-dark-light-hover),
+    var(--mantine-color-dark-6)
+  );
   cursor: pointer;
 }
 

--- a/apps/xmtp.chat/src/components/Messages/MessageContentWrapper.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContentWrapper.tsx
@@ -1,13 +1,14 @@
 import { Box, Flex, Group, Stack } from "@mantine/core";
-import { AddressBadge } from "@/components/AddressBadge";
 import { DateLabel } from "@/components/DateLabel";
+import { InboxIdBadge } from "@/components/InboxId";
+import { useConversationContext } from "@/contexts/ConversationContext";
 import { nsToDate } from "@/helpers/date";
 
 export type MessageContentAlign = "left" | "right";
 
 export type MessageContentWrapperProps = React.PropsWithChildren<{
   align: MessageContentAlign;
-  senderInboxId?: string;
+  senderInboxId: string;
   sentAtNs: bigint;
   stopClickPropagation?: boolean;
 }>;
@@ -19,6 +20,7 @@ export const MessageContentWrapper: React.FC<MessageContentWrapperProps> = ({
   sentAtNs,
   stopClickPropagation = true,
 }) => {
+  const { members } = useConversationContext();
   return (
     <Group justify={align === "left" ? "flex-start" : "flex-end"}>
       <Stack gap="xs" align={align === "left" ? "flex-start" : "flex-end"}>
@@ -27,7 +29,11 @@ export const MessageContentWrapper: React.FC<MessageContentWrapperProps> = ({
           direction={align === "right" ? "row" : "row-reverse"}
           align="center">
           <DateLabel date={nsToDate(sentAtNs)} />
-          {senderInboxId && <AddressBadge address={senderInboxId} size="lg" />}
+          <InboxIdBadge
+            address={members.get(senderInboxId) ?? ""}
+            inboxId={senderInboxId}
+            size="xs"
+          />
         </Flex>
         <Box
           onClick={(event) => {

--- a/apps/xmtp.chat/src/components/Messages/ReplyContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReplyContent.tsx
@@ -46,13 +46,7 @@ export const ReplyContent: React.FC<ReplyContentProps> = ({
             Replied to
           </Text>
           <Tooltip label="Click to scroll to the original message">
-            <Paper
-              withBorder
-              c="white"
-              py="xs"
-              px="sm"
-              radius="md"
-              onClick={handleClick}>
+            <Paper withBorder py="xs" px="sm" radius="md" onClick={handleClick}>
               <Text
                 component="pre"
                 size="sm"

--- a/apps/xmtp.chat/src/contexts/ConversationContext.tsx
+++ b/apps/xmtp.chat/src/contexts/ConversationContext.tsx
@@ -1,0 +1,60 @@
+import { Group, type Conversation } from "@xmtp/browser-sdk";
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type ConversationContextType = {
+  conversation?: Conversation;
+  members: Map<string, string>;
+};
+
+const ConversationContext = createContext<ConversationContextType>({
+  members: new Map(),
+});
+
+export type ConversationProviderProps = React.PropsWithChildren<{
+  conversation: Conversation;
+}>;
+
+export const ConversationProvider: React.FC<ConversationProviderProps> = ({
+  children,
+  conversation,
+}) => {
+  const [members, setMembers] = useState<Map<string, string>>(new Map());
+
+  useEffect(() => {
+    if (!(conversation instanceof Group)) {
+      return;
+    }
+
+    const loadMembers = async () => {
+      const members = await conversation.members();
+      setMembers(
+        new Map(
+          members.map((m) => [m.inboxId, m.accountIdentifiers[0].identifier]),
+        ),
+      );
+    };
+
+    void loadMembers();
+  }, [conversation.id]);
+
+  const value = useMemo(
+    () => ({ conversation, members }),
+    [conversation, members],
+  );
+
+  return (
+    <ConversationContext.Provider value={value}>
+      {children}
+    </ConversationContext.Provider>
+  );
+};
+
+export const useConversationContext = () => {
+  const context = useContext(ConversationContext);
+  if (!context.conversation) {
+    throw new Error(
+      "useConversationContext must be used within a ConversationProvider",
+    );
+  }
+  return context as Required<ConversationContextType>;
+};


### PR DESCRIPTION
# Summary

- Added switch to members modal to display inbox IDs or addresses

![Screenshot 2025-05-07 at 11 59 49 AM](https://github.com/user-attachments/assets/9605bc84-9341-46d0-bc2c-df1b68ed9e57)

- Added popover to member inbox IDs in messages list to display member addresses

![Screenshot 2025-05-07 at 11 59 19 AM](https://github.com/user-attachments/assets/2aff6541-0350-4f96-a6e8-c1a7347ce02c)
