### PR TITLE
docs: new content type added (content-type-wallet-send-calls)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To learn more about the contents of this repository, see this README and the REA
 - [`content-type-reply`](content-types/content-type-reply): Content type for direct replies to messages
 - [`content-type-text`](content-types/content-type-text): Content type for plain text messages
 - [`content-type-transaction-reference`](content-types/content-type-transaction-reference): Content type for on-chain transaction references
+- [`content-types/content-type-wallet-send-calls`](content-types/content-type-wallet-send-calls): Content type to support wallet transactions 
 
 ## Contributing
 


### PR DESCRIPTION
### Document new `content-type-wallet-send-calls` content type in README for supporting wallet transactions
Updates the 'Content types' section in [README.md](https://github.com/xmtp/xmtp-js/pull/1017/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to include the new `content-type-wallet-send-calls` content type, which is located in the `content-types/content-type-wallet-send-calls` directory.

#### 📍Where to Start
Start with the 'Content types' section in [README.md](https://github.com/xmtp/xmtp-js/pull/1017/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) where the new content type entry has been added.

----

_[Macroscope](https://app.macroscope.com) summarized bfbb84b._