### PR TITLE
Upgrade Wasm bindings to RC3

### DIFF
--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -64,7 +64,7 @@
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/proto": "^3.78.0",
-    "@xmtp/wasm-bindings": "1.2.0-rc2",
+    "@xmtp/wasm-bindings": "1.2.0-rc3",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3580,7 +3580,7 @@ __metadata:
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/proto": "npm:^3.78.0"
-    "@xmtp/wasm-bindings": "npm:1.2.0-rc2"
+    "@xmtp/wasm-bindings": "npm:1.2.0-rc3"
     playwright: "npm:^1.52.0"
     rollup: "npm:^4.40.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3833,10 +3833,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.0-rc2":
-  version: 1.2.0-rc2
-  resolution: "@xmtp/wasm-bindings@npm:1.2.0-rc2"
-  checksum: 10/37533bbcc6e02df2a7703978a36a6c456791d6fb978081de44dc807e55fb6c8ea58776de7f2501e77cfd59fe88e8188aae1cdf005791bb722b47c93d9d021f84
+"@xmtp/wasm-bindings@npm:1.2.0-rc3":
+  version: 1.2.0-rc3
+  resolution: "@xmtp/wasm-bindings@npm:1.2.0-rc3"
+  checksum: 10/c8ea5cd31d29bfeafe12bc4bd979b3b8dd6d7a9e95d1f45b5f78725e335e95bc6872d50861050090b8c1d8488d80c83027b3a87208c0a8dc446683e2e0dfa39d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Update `@xmtp/wasm-bindings` dependency from version 1.2.0-rc2 to 1.2.0-rc3 in browser SDK
Updates the `@xmtp/wasm-bindings` package version in [package.json](https://github.com/xmtp/xmtp-js/pull/1018/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82) with corresponding changes reflected in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1018/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)

#### 📍Where to Start
Start with the dependency version update in [package.json](https://github.com/xmtp/xmtp-js/pull/1018/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82)

----

_[Macroscope](https://app.macroscope.com) summarized 8dcd81f._