### PR TITLE
Upgrade node bindings

### DIFF
--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -53,7 +53,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.0-rc2",
+    "@xmtp/node-bindings": "1.2.0-rc3",
     "@xmtp/proto": "^3.78.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3771,10 +3771,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.2.0-rc2":
-  version: 1.2.0-rc2
-  resolution: "@xmtp/node-bindings@npm:1.2.0-rc2"
-  checksum: 10/c235e9f4e81b9ed8b7dde006d2bd48f29ac0123f3ac47f97e1991376fb78221799a67550114a54bbf88d4f96881def2a3f2dd90ad69dd45ad0f927cc2a975165
+"@xmtp/node-bindings@npm:1.2.0-rc3":
+  version: 1.2.0-rc3
+  resolution: "@xmtp/node-bindings@npm:1.2.0-rc3"
+  checksum: 10/16c1acd9c975725a10e173f90b192595238f8d3cc4897bee1bde2689f79d585e469c46cb7cb9bb83928c351412369b9db3911d86622dae5172de535d06fc5b48
   languageName: node
   linkType: hard
 
@@ -3789,7 +3789,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.0-rc2"
+    "@xmtp/node-bindings": "npm:1.2.0-rc3"
     "@xmtp/proto": "npm:^3.78.0"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"


### PR DESCRIPTION
### Update `@xmtp/node-bindings` dependency from version 1.2.0-rc2 to 1.2.0-rc3 in Node SDK
Updates the dependency version in [package.json](https://github.com/xmtp/xmtp-js/pull/1019/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb) and regenerates the corresponding [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1019/files#diff-ab1da3ccaff3ebfe608f1a55c52c69d89ed62a0c07b21d8a66cf4a51b7e64038) file with the new version requirements.

#### 📍Where to Start
Start by reviewing the version update in [package.json](https://github.com/xmtp/xmtp-js/pull/1019/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb) to verify the dependency change.

----

_[Macroscope](https://app.macroscope.com) summarized 4ed24c8._