### PR TITLE
Refactor default `Client` type

### DIFF
--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -32,12 +32,17 @@ import {
 } from "@/utils/errors";
 import { type Signer } from "@/utils/signer";
 
-type ExtractCodecContentType<C> = C extends ContentCodec<infer T> ? T : never;
+export type ExtractCodecContentTypes<C extends ContentCodec[] = []> =
+  [...C, GroupUpdatedCodec, TextCodec][number] extends ContentCodec<infer T>
+    ? T
+    : never;
 
 /**
  * Client for interacting with the XMTP network
  */
-export class Client<ContentTypes = unknown> extends ClientWorkerClass {
+export class Client<
+  ContentTypes = ExtractCodecContentTypes,
+> extends ClientWorkerClass {
   #codecs: Map<string, ContentCodec>;
   #conversations: Conversations<ContentTypes>;
   #identifier?: Identifier;
@@ -111,11 +116,7 @@ export class Client<ContentTypes = unknown> extends ClientWorkerClass {
       codecs?: ContentCodecs;
     },
   ) {
-    const client = new Client<
-      ExtractCodecContentType<
-        [...ContentCodecs, GroupUpdatedCodec, TextCodec][number]
-      >
-    >(options);
+    const client = new Client<ExtractCodecContentTypes<ContentCodecs>>(options);
     client.#signer = signer;
 
     await client.init(await signer.getIdentifier());
@@ -143,11 +144,7 @@ export class Client<ContentTypes = unknown> extends ClientWorkerClass {
       codecs?: ContentCodecs;
     },
   ) {
-    const client = new Client<
-      ExtractCodecContentType<
-        [...ContentCodecs, GroupUpdatedCodec, TextCodec][number]
-      >
-    >({
+    const client = new Client<ExtractCodecContentTypes<ContentCodecs>>({
       ...options,
       disableAutoRegister: true,
     });

--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export { Client } from "./Client";
+export type { ExtractCodecContentTypes } from "./Client";
 export { Conversations } from "./Conversations";
 export { Conversation } from "./Conversation";
 export { Dm } from "./Dm";
@@ -50,3 +51,4 @@ export {
   SortDirection,
 } from "@xmtp/wasm-bindings";
 export type { Signer } from "./utils/signer";
+export * from "./utils/errors";

--- a/sdks/browser-sdk/src/utils/errors.ts
+++ b/sdks/browser-sdk/src/utils/errors.ts
@@ -3,7 +3,9 @@ import { SignatureRequestType } from "@xmtp/wasm-bindings";
 
 export class ClientNotInitializedError extends Error {
   constructor() {
-    super("Client not initialized");
+    super(
+      "Client not initialized, use Client.create or Client.build to create a client",
+    );
   }
 }
 

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -36,12 +36,15 @@ import { getInboxIdForIdentifier } from "@/utils/inboxId";
 import { type Signer } from "@/utils/signer";
 import { version } from "@/utils/version";
 
-type ExtractCodecContentType<C> = C extends ContentCodec<infer T> ? T : never;
+export type ExtractCodecContentTypes<C extends ContentCodec[] = []> =
+  [...C, GroupUpdatedCodec, TextCodec][number] extends ContentCodec<infer T>
+    ? T
+    : never;
 
 /**
  * Client for interacting with the XMTP network
  */
-export class Client<ContentTypes = unknown> {
+export class Client<ContentTypes = ExtractCodecContentTypes> {
   #client?: NodeClient;
   #conversations?: Conversations<ContentTypes>;
   #preferences?: Preferences;
@@ -104,11 +107,7 @@ export class Client<ContentTypes = unknown> {
     },
   ) {
     const identifier = await signer.getIdentifier();
-    const client = new Client<
-      ExtractCodecContentType<
-        [...ContentCodecs, GroupUpdatedCodec, TextCodec][number]
-      >
-    >(options);
+    const client = new Client<ExtractCodecContentTypes<ContentCodecs>>(options);
     client.#signer = signer;
     await client.init(identifier);
 
@@ -135,11 +134,7 @@ export class Client<ContentTypes = unknown> {
       codecs?: ContentCodecs;
     },
   ) {
-    const client = new Client<
-      ExtractCodecContentType<
-        [...ContentCodecs, GroupUpdatedCodec, TextCodec][number]
-      >
-    >({
+    const client = new Client<ExtractCodecContentTypes<ContentCodecs>>({
       ...options,
       disableAutoRegister: true,
     });

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "./types";
 export { ApiUrls, HistorySyncUrls } from "./constants";
 export { Client } from "./Client";
+export type { ExtractCodecContentTypes } from "./Client";
 export { Conversation } from "./Conversation";
 export { Conversations } from "./Conversations";
 export { Dm } from "./Dm";
@@ -57,3 +58,4 @@ export {
 } from "@xmtp/node-bindings";
 export { generateInboxId, getInboxIdForIdentifier } from "./utils/inboxId";
 export type { Signer } from "./utils/signer";
+export * from "./utils/errors";


### PR DESCRIPTION
# Summary

- Removed `ExtractCodecContentType` type
- Added `ExtractCodecContentTypes` type
- Added `ExtractCodecContentTypes` type to exports
- Added custom errors to exports
- Updated error message for `ClientNotInitializedError` (Browser SDK)
- Changed default `Client` type from `Client<unknown>` to `Client<GroupUpdated | string>`