### PR TITLE
Add optimistic group tests

### DIFF
--- a/sdks/browser-sdk/test/Conversation.test.ts
+++ b/sdks/browser-sdk/test/Conversation.test.ts
@@ -303,6 +303,78 @@ describe("Conversation", () => {
     ).resolves.not.toThrow();
   });
 
+  it("should optimistically create a group", async () => {
+    const user1 = createUser();
+    const signer1 = createSigner(user1);
+    const client1 = await createRegisteredClient(signer1);
+    const conversation = await client1.conversations.newGroupOptimistic({
+      name: "foo",
+      description: "bar",
+    });
+
+    expect(conversation.id).toBeDefined();
+    expect(conversation.name).toBe("foo");
+    expect(conversation.description).toBe("bar");
+    expect(conversation.imageUrl).toBe("");
+    expect(conversation.addedByInboxId).toBe(client1.inboxId);
+
+    const text = "gm";
+    await conversation.sendOptimistic(text);
+
+    const messages = await conversation.messages();
+    expect(messages.length).toBe(1);
+    expect(messages[0].content).toBe(text);
+    expect(messages[0].deliveryStatus).toBe("unpublished");
+
+    await conversation.publishMessages();
+
+    const messages2 = await conversation.messages();
+    expect(messages2.length).toBe(1);
+    expect(messages2[0].content).toBe(text);
+    expect(messages2[0].deliveryStatus).toBe("published");
+  });
+
+  it("should optimistically create a group with members", async () => {
+    const user1 = createUser();
+    const user2 = createUser();
+    const signer1 = createSigner(user1);
+    const signer2 = createSigner(user2);
+    const client1 = await createRegisteredClient(signer1);
+    const client2 = await createRegisteredClient(signer2);
+    const conversation = await client1.conversations.newGroupOptimistic({
+      name: "foo",
+      description: "bar",
+    });
+
+    expect(conversation.id).toBeDefined();
+    expect(conversation.name).toBe("foo");
+    expect(conversation.description).toBe("bar");
+    expect(conversation.imageUrl).toBe("");
+    expect(conversation.addedByInboxId).toBe(client1.inboxId);
+
+    const text = "gm";
+    await conversation.sendOptimistic(text);
+
+    const messages = await conversation.messages();
+    expect(messages.length).toBe(1);
+    expect(messages[0].content).toBe(text);
+    expect(messages[0].deliveryStatus).toBe("unpublished");
+
+    await conversation.addMembers([client2.inboxId!]);
+
+    const members = await conversation.members();
+    const memberInboxIds = members.map((member) => member.inboxId);
+    expect(memberInboxIds.length).toBe(2);
+    expect(memberInboxIds).toContain(client1.inboxId);
+    expect(memberInboxIds).toContain(client2.inboxId);
+
+    const messages3 = await conversation.messages();
+    expect(messages3.length).toBe(2);
+    expect(messages3[0].content).toBe(text);
+    expect(messages3[0].deliveryStatus).toBe("published");
+    expect(messages3[1].deliveryStatus).toBe("published");
+  });
+
   it("should throw when sending content without a codec", async () => {
     const user1 = createUser();
     const user2 = createUser();


### PR DESCRIPTION
### Add test coverage for optimistic group creation functionality in browser and node SDK Conversation test suites
Adds four new test cases across both SDK test suites to verify optimistic group creation behavior:

- Two test cases in [sdks/browser-sdk/test/Conversation.test.ts](https://github.com/xmtp/xmtp-js/pull/1037/files#diff-af2cf47ba8387a2a9e8f48fd023928d98871acbb121a3bb3e50242fe2847eec0) that test creating groups optimistically with `name` and `description` parameters, sending messages with `unpublished` delivery status, publishing messages, and adding members
- Two corresponding test cases in [sdks/node-sdk/test/Conversation.test.ts](https://github.com/xmtp/xmtp-js/pull/1037/files#diff-4d082636d2af8ef2629b7f2b11bda18a2879370d5fedf26f3e61156becc27bee) with similar functionality but using `groupName` and `groupDescription` parameters and different async/sync method patterns

#### 📍Where to Start
Start with the first new test case "should optimistically create a group" in [sdks/browser-sdk/test/Conversation.test.ts](https://github.com/xmtp/xmtp-js/pull/1037/files#diff-af2cf47ba8387a2a9e8f48fd023928d98871acbb121a3bb3e50242fe2847eec0) to understand the optimistic group creation flow being tested.

----

_[Macroscope](https://app.macroscope.com) summarized 0e266fa._