### PR TITLE
fix: missing `content` arguments and add explicit return types

### DIFF
--- a/content-types/content-type-text/src/Text.ts
+++ b/content-types/content-type-text/src/Text.ts
@@ -25,7 +25,7 @@ export class TextCodec implements ContentCodec<string, TextParameters> {
     return ContentTypeText;
   }
 
-  encode(content: string) {
+  encode(content: string): EncodedContent<TextParameters> {
     return {
       type: ContentTypeText,
       parameters: { encoding: Encoding.utf8 },
@@ -33,18 +33,18 @@ export class TextCodec implements ContentCodec<string, TextParameters> {
     };
   }
 
-  decode(content: EncodedContent<TextParameters>) {
+  decode(content: EncodedContent<TextParameters>): string {
     if (content.parameters.encoding !== Encoding.utf8) {
       throw new Error(`unrecognized encoding ${content.parameters.encoding}`);
     }
     return new TextDecoder().decode(content.content);
   }
 
-  fallback() {
+  fallback(content: string): string | undefined {
     return undefined;
   }
 
-  shouldPush() {
+  shouldPush(content: string): boolean {
     return true;
   }
 }


### PR DESCRIPTION
fixed a couple of missing `content: string` arguments in `fallback` and `shouldPush` to match the required interface.
also added explicit return types to `encode` and `decode` for better clarity and consistency.
