### PR TITLE
Update @xmtp/wasm-bindings

### DIFF
--- a/.changeset/angry-trains-smile.md
+++ b/.changeset/angry-trains-smile.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": patch
+---
+
+Update @xmtp/wasm-bindings

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -63,7 +63,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/wasm-bindings": "1.2.0",
+    "@xmtp/wasm-bindings": "1.2.1",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/wasm-bindings": "npm:1.2.0"
+    "@xmtp/wasm-bindings": "npm:1.2.1"
     playwright: "npm:^1.52.0"
     rollup: "npm:^4.41.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3889,10 +3889,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@xmtp/wasm-bindings@npm:1.2.0"
-  checksum: 10/c410730971392f173aa9e9d8e2c12901532a58c38b42400fb5b7f974b42b6ab4fb14e60c8f38f49c13637b39d72150f7ec5125c14589055614af01ea73b9f537
+"@xmtp/wasm-bindings@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@xmtp/wasm-bindings@npm:1.2.1"
+  checksum: 10/43d39d7f0b2b5d1b8edb4fac2e1ae1bd2c09301a282b482457b542546c1202ff316011891b48ecb2309c982b598676250255f8b7e3ea86f9931c418125203c27
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Update @xmtp/wasm-bindings dependency from version 1.2.0 to 1.2.1 in the browser-sdk package
This pull request updates the `@xmtp/wasm-bindings` dependency version in the browser-sdk package. The changes include updating the dependency version in [package.json](https://github.com/xmtp/xmtp-js/pull/1044/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82), adding a changeset documentation file at [.changeset/angry-trains-smile.md](https://github.com/xmtp/xmtp-js/pull/1044/files#diff-3f20b525d9be24e8a00f1a282addff92c6118c869c395698c8142bdf385d2a98), and updating the lock file to reflect the new dependency version.

#### 📍Where to Start
Start with the dependency version change in [package.json](https://github.com/xmtp/xmtp-js/pull/1044/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82) to see the updated `@xmtp/wasm-bindings` version.

----

_[Macroscope](https://app.macroscope.com) summarized 173b3a7._