### PR TITLE
chore: added badge and link to Twitter social network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Twitter](https://img.shields.io/twitter/follow/xmtp_)](https://x.com/xmtp_)
+
 This is the official repository for XMTP client SDKs and content types for browsers and Node, written in TypeScript.
 
 To learn more about the contents of this repository, see this README and the READMEs provided in each workspace directory.


### PR DESCRIPTION
### Add Twitter follow badge to README.md documentation
Adds a Twitter follow badge at the top of [README.md](https://github.com/xmtp/xmtp-js/pull/1048/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) that links to XMTP's Twitter/X account for social media visibility.

#### 📍Where to Start
Start with the badge addition at the top of [README.md](https://github.com/xmtp/xmtp-js/pull/1048/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

----

_[Macroscope](https://app.macroscope.com) summarized a2d3476._