### PR TITLE
WalletSendCalls: make `from` field optional

### DIFF
--- a/content-types/content-type-wallet-send-calls/src/WalletSendCalls.ts
+++ b/content-types/content-type-wallet-send-calls/src/WalletSendCalls.ts
@@ -14,7 +14,7 @@ export const ContentTypeWalletSendCalls = new ContentTypeId({
 export type WalletSendCallsParams = {
   version: string;
   chainId: `0x${string}`; // Hex chain id
-  from: `0x${string}`;
+  from?: `0x${string}`;
   calls: {
     to?: `0x${string}`;
     data?: `0x${string}`;


### PR DESCRIPTION
# Summary

- Updated the `from` field to make it optional

When the `from` field is not specified, developers can assume that wallet send calls can be initiated by anyone.