### PR TITLE
Fix AsyncStream ending

### DIFF
--- a/sdks/browser-sdk/src/AsyncStream.ts
+++ b/sdks/browser-sdk/src/AsyncStream.ts
@@ -8,30 +8,27 @@ type ResolveNext<T> = (resolveValue: ResolveValue<T>) => void;
 export type StreamCallback<T> = (
   err: Error | null,
   value: T | undefined,
-) => void | Promise<void>;
+) => void;
 
 export class AsyncStream<T> {
-  #done = false;
-  #resolveNext: ResolveNext<T> | null;
-  #rejectNext: ((error: Error) => void) | null;
+  #isDone = false;
+  #resolveNext: ResolveNext<T> | undefined;
+  #rejectNext: ((error: Error) => void) | undefined;
   #queue: (T | undefined)[];
-  #error: Error | null;
-  onReturn: (() => void) | undefined = undefined;
-  onError: ((error: Error) => void) | undefined = undefined;
+  #error: Error | undefined;
+  onReturn: (() => void) | undefined;
+  onError: ((error: Error) => void) | undefined;
 
   constructor() {
     this.#queue = [];
-    this.#resolveNext = null;
-    this.#rejectNext = null;
-    this.#error = null;
-    this.#done = false;
+    this.#isDone = false;
   }
 
-  #endStream() {
+  #done() {
     this.#queue = [];
-    this.#resolveNext = null;
-    this.#rejectNext = null;
-    this.#done = true;
+    this.#resolveNext = undefined;
+    this.#rejectNext = undefined;
+    this.#isDone = true;
   }
 
   get error() {
@@ -39,21 +36,21 @@ export class AsyncStream<T> {
   }
 
   get isDone() {
-    return this.#done;
+    return this.#isDone;
   }
 
   callback: StreamCallback<T> = (error, value) => {
+    if (this.#isDone) {
+      return;
+    }
+
     if (error) {
       this.#error = error;
       if (this.#rejectNext) {
         this.#rejectNext(error);
-        this.#endStream();
+        this.#done();
         this.onError?.(error);
       }
-      return;
-    }
-
-    if (this.#done) {
       return;
     }
 
@@ -62,7 +59,8 @@ export class AsyncStream<T> {
         done: false,
         value,
       });
-      this.#resolveNext = null;
+      this.#resolveNext = undefined;
+      this.#rejectNext = undefined;
     } else {
       this.#queue.push(value);
     }
@@ -70,7 +68,7 @@ export class AsyncStream<T> {
 
   next = (): Promise<ResolveValue<T>> => {
     if (this.#error) {
-      this.#endStream();
+      this.#done();
       this.onError?.(this.#error);
       return Promise.reject(this.#error);
     }
@@ -82,13 +80,6 @@ export class AsyncStream<T> {
       });
     }
 
-    if (this.#done) {
-      return Promise.resolve({
-        done: true,
-        value: undefined,
-      });
-    }
-
     return new Promise((resolve, reject) => {
       this.#resolveNext = resolve;
       this.#rejectNext = reject;
@@ -96,12 +87,16 @@ export class AsyncStream<T> {
   };
 
   return = (value?: T) => {
-    this.#endStream();
-    this.onReturn?.();
-    return Promise.resolve({
+    this.#resolveNext?.({
       done: true,
       value,
     });
+    this.onReturn?.();
+    this.#done();
+    return {
+      done: true,
+      value,
+    };
   };
 
   end = () => this.return();

--- a/sdks/browser-sdk/test/AsyncStream.test.ts
+++ b/sdks/browser-sdk/test/AsyncStream.test.ts
@@ -10,9 +10,9 @@ describe("AsyncStream", () => {
     stream.onReturn = () => {
       onReturnCalled = true;
     };
-    void stream.callback(null, 1);
-    void stream.callback(null, 2);
-    void stream.callback(null, 3);
+    stream.callback(null, 1);
+    stream.callback(null, 2);
+    stream.callback(null, 3);
 
     let count = 0;
 
@@ -39,7 +39,7 @@ describe("AsyncStream", () => {
     stream.onReturn = () => {
       onReturnCalled = true;
     };
-    void stream.callback(null, 1);
+    stream.callback(null, 1);
 
     try {
       for await (const value of stream) {
@@ -59,7 +59,7 @@ describe("AsyncStream", () => {
     stream.onError = () => {
       onErrorCalled = true;
     };
-    void stream.callback(testError, 1);
+    stream.callback(testError, 1);
     try {
       for await (const _value of stream) {
         // this block should never be reached
@@ -79,7 +79,7 @@ describe("AsyncStream", () => {
       onErrorCalled = true;
     };
     setTimeout(() => {
-      void stream.callback(testError, 1);
+      stream.callback(testError, 1);
     }, 100);
     try {
       for await (const _value of stream) {
@@ -91,5 +91,16 @@ describe("AsyncStream", () => {
     expect(onErrorCalled).toBe(true);
     expect(stream.isDone).toBe(true);
     expect(stream.error).toBe(testError);
+  });
+
+  it("should end for await..of loop when stream is ended", async () => {
+    const stream = new AsyncStream<number>();
+    setTimeout(() => {
+      void stream.end();
+    }, 100);
+    for await (const _value of stream) {
+      // this block intentionally left blank
+    }
+    expect(stream.isDone).toBe(true);
   });
 });

--- a/sdks/node-sdk/src/AsyncStream.ts
+++ b/sdks/node-sdk/src/AsyncStream.ts
@@ -11,27 +11,24 @@ export type StreamCallback<T> = (
 ) => void;
 
 export class AsyncStream<T> {
-  #done = false;
-  #resolveNext: ResolveNext<T> | null;
-  #rejectNext: ((error: Error) => void) | null;
+  #isDone = false;
+  #resolveNext: ResolveNext<T> | undefined;
+  #rejectNext: ((error: Error) => void) | undefined;
   #queue: (T | undefined)[];
-  #error: Error | null;
-  onReturn: (() => void) | undefined = undefined;
-  onError: ((error: Error) => void) | undefined = undefined;
+  #error: Error | undefined;
+  onReturn: (() => void) | undefined;
+  onError: ((error: Error) => void) | undefined;
 
   constructor() {
     this.#queue = [];
-    this.#resolveNext = null;
-    this.#rejectNext = null;
-    this.#error = null;
-    this.#done = false;
+    this.#isDone = false;
   }
 
-  #endStream() {
+  #done() {
     this.#queue = [];
-    this.#resolveNext = null;
-    this.#rejectNext = null;
-    this.#done = true;
+    this.#resolveNext = undefined;
+    this.#rejectNext = undefined;
+    this.#isDone = true;
   }
 
   get error() {
@@ -39,21 +36,21 @@ export class AsyncStream<T> {
   }
 
   get isDone() {
-    return this.#done;
+    return this.#isDone;
   }
 
   callback: StreamCallback<T> = (error, value) => {
+    if (this.#isDone) {
+      return;
+    }
+
     if (error) {
       this.#error = error;
       if (this.#rejectNext) {
         this.#rejectNext(error);
-        this.#endStream();
+        this.#done();
         this.onError?.(error);
       }
-      return;
-    }
-
-    if (this.#done) {
       return;
     }
 
@@ -62,8 +59,8 @@ export class AsyncStream<T> {
         done: false,
         value,
       });
-      this.#resolveNext = null;
-      this.#rejectNext = null;
+      this.#resolveNext = undefined;
+      this.#rejectNext = undefined;
     } else {
       this.#queue.push(value);
     }
@@ -71,7 +68,7 @@ export class AsyncStream<T> {
 
   next = (): Promise<ResolveValue<T>> => {
     if (this.#error) {
-      this.#endStream();
+      this.#done();
       this.onError?.(this.#error);
       return Promise.reject(this.#error);
     }
@@ -83,13 +80,6 @@ export class AsyncStream<T> {
       });
     }
 
-    if (this.#done) {
-      return Promise.resolve({
-        done: true,
-        value: undefined,
-      });
-    }
-
     return new Promise((resolve, reject) => {
       this.#resolveNext = resolve;
       this.#rejectNext = reject;
@@ -97,12 +87,16 @@ export class AsyncStream<T> {
   };
 
   return = (value?: T) => {
-    this.#endStream();
-    this.onReturn?.();
-    return Promise.resolve({
+    this.#resolveNext?.({
       done: true,
       value,
     });
+    this.onReturn?.();
+    this.#done();
+    return {
+      done: true,
+      value,
+    };
   };
 
   end = () => this.return();

--- a/sdks/node-sdk/test/AsyncStream.test.ts
+++ b/sdks/node-sdk/test/AsyncStream.test.ts
@@ -92,4 +92,15 @@ describe("AsyncStream", () => {
     expect(stream.isDone).toBe(true);
     expect(stream.error).toBe(testError);
   });
+
+  it("should end for await..of loop when stream is ended", async () => {
+    const stream = new AsyncStream<number>();
+    setTimeout(() => {
+      void stream.end();
+    }, 100);
+    for await (const _value of stream) {
+      // this block intentionally left blank
+    }
+    expect(stream.isDone).toBe(true);
+  });
 });


### PR DESCRIPTION
# Summary

- Fixed async iterator exit when calling `end()` on `AsyncStream` instances