### PR TITLE
Add `Client.inboxStateFromInboxIds`

### DIFF
--- a/apps/xmtp.chat/src/hooks/useIdentity.ts
+++ b/apps/xmtp.chat/src/hooks/useIdentity.ts
@@ -38,7 +38,7 @@ export const useIdentity = (syncOnMount: boolean = false) => {
     try {
       const inboxState = await client.preferences.inboxState(true);
       setInboxId(inboxState.inboxId);
-      setAccountIdentifiers(inboxState.accountIdentifiers);
+      setAccountIdentifiers(inboxState.identifiers);
       setRecoveryIdentifier(inboxState.recoveryIdentifier);
       const installations = inboxState.installations.sort((a, b) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -63,7 +63,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/wasm-bindings": "1.2.3",
+    "@xmtp/wasm-bindings": "1.2.4",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -531,14 +531,28 @@ export class Client<
    * @param installationIds - The installation IDs to revoke
    */
   static async revokeInstallations(
-    env: XmtpEnv,
     signer: Signer,
     inboxId: string,
     installationIds: Uint8Array[],
+    env?: XmtpEnv,
   ) {
     const utils = new Utils();
-    await utils.revokeInstallations(env, signer, inboxId, installationIds);
+    await utils.revokeInstallations(signer, inboxId, installationIds, env);
     utils.close();
+  }
+
+  /**
+   * Gets the inbox state for the specified inbox IDs without a client
+   *
+   * @param inboxIds - The inbox IDs to get the state for
+   * @param env - The environment to use
+   * @returns The inbox state for the specified inbox IDs
+   */
+  static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
+    const utils = new Utils();
+    const result = await utils.inboxStateFromInboxIds(inboxIds, env);
+    utils.close();
+    return result;
   }
 
   /**

--- a/sdks/browser-sdk/src/Utils.ts
+++ b/sdks/browser-sdk/src/Utils.ts
@@ -61,10 +61,10 @@ export class Utils extends UtilsWorkerClass {
    * @returns The signature text
    */
   async revokeInstallationsSignatureText(
-    env: XmtpEnv,
     identifier: Identifier,
     inboxId: string,
     installationIds: Uint8Array[],
+    env?: XmtpEnv,
   ) {
     return this.sendMessage("utils.revokeInstallationsSignatureText", {
       env,
@@ -84,26 +84,40 @@ export class Utils extends UtilsWorkerClass {
    * @returns Promise that resolves with the result of the revoke installations operation
    */
   async revokeInstallations(
-    env: XmtpEnv,
     signer: Signer,
     inboxId: string,
     installationIds: Uint8Array[],
+    env?: XmtpEnv,
   ) {
     const identifier = await signer.getIdentifier();
     const signatureText = await this.revokeInstallationsSignatureText(
-      env,
       identifier,
       inboxId,
       installationIds,
+      env,
     );
     const signature = await signer.signMessage(signatureText);
     const safeSigner = await toSafeSigner(signer, signature);
 
     return this.sendMessage("utils.revokeInstallations", {
-      env,
       signer: safeSigner,
       inboxId,
       installationIds,
+      env,
+    });
+  }
+
+  /**
+   * Gets the inbox state for the specified inbox IDs without a client
+   *
+   * @param inboxIds - The inbox IDs to get the state for
+   * @param env - The environment to use
+   * @returns The inbox state for the specified inbox IDs
+   */
+  async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
+    return this.sendMessage("utils.inboxStateFromInboxIds", {
+      inboxIds,
+      env,
     });
   }
 }

--- a/sdks/browser-sdk/src/types/actions/utils.ts
+++ b/sdks/browser-sdk/src/types/actions/utils.ts
@@ -1,5 +1,6 @@
 import type { Identifier } from "@xmtp/wasm-bindings";
 import type { XmtpEnv } from "@/types/options";
+import type { SafeInboxState } from "@/utils/conversions";
 import type { SafeSigner } from "@/utils/signer";
 
 export type UtilsWorkerAction =
@@ -33,7 +34,7 @@ export type UtilsWorkerAction =
       id: string;
       result: string;
       data: {
-        env: XmtpEnv;
+        env?: XmtpEnv;
         identifier: Identifier;
         inboxId: string;
         installationIds: Uint8Array[];
@@ -44,9 +45,18 @@ export type UtilsWorkerAction =
       id: string;
       result: undefined;
       data: {
-        env: XmtpEnv;
+        env?: XmtpEnv;
         signer: SafeSigner;
         inboxId: string;
         installationIds: Uint8Array[];
+      };
+    }
+  | {
+      action: "utils.inboxStateFromInboxIds";
+      id: string;
+      result: SafeInboxState[];
+      data: {
+        inboxIds: string[];
+        env?: XmtpEnv;
       };
     };

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -403,14 +403,14 @@ export const toSafeInstallation = (
 });
 
 export type SafeInboxState = {
-  accountIdentifiers: Identifier[];
+  identifiers: Identifier[];
   inboxId: string;
   installations: SafeInstallation[];
   recoveryIdentifier: Identifier;
 };
 
 export const toSafeInboxState = (inboxState: InboxState): SafeInboxState => ({
-  accountIdentifiers: inboxState.accountIdentifiers,
+  identifiers: inboxState.accountIdentifiers,
   inboxId: inboxState.inboxId,
   installations: inboxState.installations.map(toSafeInstallation),
   recoveryIdentifier: inboxState.recoveryIdentifier,

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -161,17 +161,20 @@ self.onmessage = async (
         break;
       }
       case "client.createInboxSignatureText": {
-        const signatureRequest = client.createInboxSignatureRequest();
         const result: Partial<SignatureRequestResult> = {
           signatureText: undefined,
           signatureRequestId: undefined,
         };
-        if (signatureRequest) {
-          result.signatureText = await signatureRequest.signatureText();
-          result.signatureRequestId = data.signatureRequestId;
-          signatureRequests.set(data.signatureRequestId, signatureRequest);
+        try {
+          const signatureRequest = client.createInboxSignatureRequest();
+          if (signatureRequest) {
+            result.signatureText = await signatureRequest.signatureText();
+            result.signatureRequestId = data.signatureRequestId;
+            signatureRequests.set(data.signatureRequestId, signatureRequest);
+          }
+        } finally {
+          postMessage({ id, action, result });
         }
-        postMessage({ id, action, result });
         break;
       }
       case "client.addAccountSignatureText": {

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -75,9 +75,7 @@ describe("Client", () => {
     expect(inboxState.installations.map((install) => install.id)).toEqual([
       client.installationId,
     ]);
-    expect(inboxState.accountIdentifiers).toEqual([
-      await signer.getIdentifier(),
-    ]);
+    expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
     expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
     const user2 = createUser();
@@ -92,9 +90,7 @@ describe("Client", () => {
     expect(inboxState.installations[0].bytes).toEqual(
       client.installationIdBytes,
     );
-    expect(inboxState2.accountIdentifiers).toEqual([
-      await signer.getIdentifier(),
-    ]);
+    expect(inboxState2.identifiers).toEqual([await signer.getIdentifier()]);
     expect(inboxState2.recoveryIdentifier).toEqual(
       await signer.getIdentifier(),
     );
@@ -110,11 +106,9 @@ describe("Client", () => {
 
     await client.unsafe_addAccount(signer2, true);
     const inboxState = await client.preferences.inboxState();
-    expect(inboxState.accountIdentifiers.length).toEqual(2);
-    expect(inboxState.accountIdentifiers).toContainEqual(
-      await signer.getIdentifier(),
-    );
-    expect(inboxState.accountIdentifiers).toContainEqual(
+    expect(inboxState.identifiers.length).toEqual(2);
+    expect(inboxState.identifiers).toContainEqual(await signer.getIdentifier());
+    expect(inboxState.identifiers).toContainEqual(
       await signer2.getIdentifier(),
     );
   });
@@ -131,9 +125,7 @@ describe("Client", () => {
     await client.removeAccount(await signer2.getIdentifier());
 
     const inboxState = await client.preferences.inboxState();
-    expect(inboxState.accountIdentifiers).toEqual([
-      await signer.getIdentifier(),
-    ]);
+    expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
   });
 
   it("should revoke all other installations", async () => {
@@ -311,5 +303,18 @@ describe("Client", () => {
     await expect(async () =>
       client.changeRecoveryIdentifier(await signer2.getIdentifier()),
     ).rejects.toThrow(new SignerUnavailableError());
+  });
+
+  it("should get inbox state from inbox ids without a client", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const inboxState = await Client.inboxStateFromInboxIds(
+      [client.inboxId!],
+      "local",
+    );
+    expect(inboxState.length).toBe(1);
+    expect(inboxState[0].inboxId).toBe(client.inboxId);
+    expect(inboxState[0].identifiers).toEqual([await signer.getIdentifier()]);
   });
 });

--- a/sdks/browser-sdk/test/Preferences.test.ts
+++ b/sdks/browser-sdk/test/Preferences.test.ts
@@ -19,9 +19,7 @@ describe("Preferences", () => {
     expect(inboxState.installations.map((install) => install.id)).toEqual([
       client.installationId,
     ]);
-    expect(inboxState.accountIdentifiers).toEqual([
-      await signer.getIdentifier(),
-    ]);
+    expect(inboxState.identifiers).toEqual([await signer.getIdentifier()]);
     expect(inboxState.recoveryIdentifier).toEqual(await signer.getIdentifier());
 
     const user2 = createUser();
@@ -36,9 +34,7 @@ describe("Preferences", () => {
     expect(inboxState.installations[0].bytes).toEqual(
       client.installationIdBytes,
     );
-    expect(inboxState2.accountIdentifiers).toEqual([
-      await signer.getIdentifier(),
-    ]);
+    expect(inboxState2.identifiers).toEqual([await signer.getIdentifier()]);
     expect(inboxState2.recoveryIdentifier).toEqual(
       await signer.getIdentifier(),
     );

--- a/sdks/browser-sdk/test/Utils.test.ts
+++ b/sdks/browser-sdk/test/Utils.test.ts
@@ -48,13 +48,29 @@ describe("Utils", () => {
     expect(installationIds).toContain(client3.installationId);
 
     const utils = new Utils();
-    await utils.revokeInstallations("local", signer, client.inboxId!, [
-      client2.installationIdBytes!,
-      client3.installationIdBytes!,
-    ]);
+    await utils.revokeInstallations(
+      signer,
+      client.inboxId!,
+      [client2.installationIdBytes!, client3.installationIdBytes!],
+      "local",
+    );
 
     const inboxState2 = await client.preferences.inboxState(true);
     expect(inboxState2.installations.length).toBe(1);
     expect(inboxState2.installations[0].id).toBe(client.installationId);
+  });
+
+  it("should get inbox state from inbox ids", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const client = await createRegisteredClient(signer);
+    const utils = new Utils();
+    const inboxState = await utils.inboxStateFromInboxIds(
+      [client.inboxId!],
+      "local",
+    );
+    expect(inboxState.length).toBe(1);
+    expect(inboxState[0].inboxId).toBe(client.inboxId);
+    expect(inboxState[0].identifiers).toEqual([await signer.getIdentifier()]);
   });
 });

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -52,7 +52,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.2.3"
+    "@xmtp/node-bindings": "1.2.4"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -11,6 +11,7 @@ import { TextCodec } from "@xmtp/content-type-text";
 import {
   applySignatureRequest,
   GroupMessageKind,
+  inboxStateFromInboxIds,
   isAddressAuthorized as isAddressAuthorizedBinding,
   isInstallationAuthorized as isInstallationAuthorizedBinding,
   revokeInstallationsSignatureRequest,
@@ -598,6 +599,18 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     }
 
     await applySignatureRequest(host, signatureRequest);
+  }
+
+  /**
+   * Gets the inbox state for the specified inbox IDs without a client
+   *
+   * @param env - The environment to use
+   * @param inboxIds - The inbox IDs to get the state for
+   * @returns The inbox state for the specified inbox IDs
+   */
+  static async inboxStateFromInboxIds(env: XmtpEnv, inboxIds: string[]) {
+    const host = ApiUrls[env];
+    return inboxStateFromInboxIds(host, inboxIds);
   }
 
   /**

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -25,7 +25,7 @@ import { ApiUrls } from "@/constants";
 import { Conversations } from "@/Conversations";
 import { DebugInformation } from "@/DebugInformation";
 import { Preferences } from "@/Preferences";
-import type { ClientOptions, NetworkOptions, XmtpEnv } from "@/types";
+import type { ClientOptions, XmtpEnv } from "@/types";
 import { createClient } from "@/utils/createClient";
 import {
   AccountAlreadyAssociatedError,
@@ -568,12 +568,12 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * @param installationIds - The installation IDs to revoke
    */
   static async revokeInstallations(
-    env: XmtpEnv,
     signer: Signer,
     inboxId: string,
     installationIds: Uint8Array[],
+    env?: XmtpEnv,
   ) {
-    const host = ApiUrls[env];
+    const host = ApiUrls[env ?? "dev"];
     const identifier = await signer.getIdentifier();
     const signatureRequest = await revokeInstallationsSignatureRequest(
       host,
@@ -608,8 +608,8 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * @param inboxIds - The inbox IDs to get the state for
    * @returns The inbox state for the specified inbox IDs
    */
-  static async inboxStateFromInboxIds(env: XmtpEnv, inboxIds: string[]) {
-    const host = ApiUrls[env];
+  static async inboxStateFromInboxIds(inboxIds: string[], env?: XmtpEnv) {
+    const host = ApiUrls[env ?? "dev"];
     return inboxStateFromInboxIds(host, inboxIds);
   }
 
@@ -834,9 +834,9 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   static async isAddressAuthorized(
     inboxId: string,
     address: string,
-    options?: NetworkOptions,
+    env?: XmtpEnv,
   ): Promise<boolean> {
-    const host = options?.apiUrl || ApiUrls[options?.env || "dev"];
+    const host = ApiUrls[env ?? "dev"];
     return await isAddressAuthorizedBinding(host, inboxId, address);
   }
 
@@ -851,9 +851,9 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   static async isInstallationAuthorized(
     inboxId: string,
     installation: Uint8Array,
-    options?: NetworkOptions,
+    env?: XmtpEnv,
   ): Promise<boolean> {
-    const host = options?.apiUrl || ApiUrls[options?.env || "dev"];
+    const host = ApiUrls[env ?? "dev"];
     return await isInstallationAuthorizedBinding(host, inboxId, installation);
   }
 

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -16,7 +16,7 @@ import {
   createUser,
 } from "@test/helpers";
 
-describe.concurrent("Client", () => {
+describe("Client", () => {
   it("should create a client", async () => {
     const user = createUser();
     const signer = createSigner(user);
@@ -469,5 +469,29 @@ describe.concurrent("Client", () => {
       new ClientNotInitializedError(),
     );
     expect(() => client.isRegistered).toThrow(new ClientNotInitializedError());
+  });
+
+  it("should get inbox states from inbox IDs without a client", async () => {
+    const user = createUser();
+    const user2 = createUser();
+    const signer = createSigner(user);
+    const signer2 = createSigner(user2);
+    const client = await createRegisteredClient(signer);
+    const client2 = await createRegisteredClient(signer2);
+    const inboxStates = await Client.inboxStateFromInboxIds("local", [
+      client.inboxId,
+    ]);
+    expect(inboxStates.length).toBe(1);
+    expect(inboxStates[0].inboxId).toBe(client.inboxId);
+    expect(inboxStates[0].identifiers).toEqual([await signer.getIdentifier()]);
+
+    const inboxStates2 = await Client.inboxStateFromInboxIds("local", [
+      client2.inboxId,
+    ]);
+    expect(inboxStates2.length).toBe(1);
+    expect(inboxStates2[0].inboxId).toBe(client2.inboxId);
+    expect(inboxStates2[0].identifiers).toEqual([
+      await signer2.getIdentifier(),
+    ]);
   });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -183,9 +183,12 @@ describe("Client", () => {
     expect(installationIds).toContain(client2.installationId);
     expect(installationIds).toContain(client3.installationId);
 
-    await Client.revokeInstallations("local", signer, client3.inboxId, [
-      client.installationIdBytes,
-    ]);
+    await Client.revokeInstallations(
+      signer,
+      client3.inboxId,
+      [client.installationIdBytes],
+      "local",
+    );
 
     const inboxState2 = await client3.preferences.inboxState(true);
 
@@ -291,14 +294,14 @@ describe("Client", () => {
     const authorized = await Client.isAddressAuthorized(
       client.inboxId,
       user.account.address.toLowerCase(),
-      { env: "local" },
+      "local",
     );
     expect(authorized).toBe(true);
 
     const notAuthorized = await Client.isAddressAuthorized(
       client.inboxId,
       "0x1234567890123456789012345678901234567890",
-      { env: "local" },
+      "local",
     );
     expect(notAuthorized).toBe(false);
   });
@@ -310,14 +313,14 @@ describe("Client", () => {
     const authorized = await Client.isInstallationAuthorized(
       client.inboxId,
       client.installationIdBytes,
-      { env: "local" },
+      "local",
     );
     expect(authorized).toBe(true);
 
     const notAuthorized = await Client.isInstallationAuthorized(
       client.inboxId,
       new Uint8Array(32),
-      { env: "local" },
+      "local",
     );
     expect(notAuthorized).toBe(false);
   });
@@ -478,16 +481,18 @@ describe("Client", () => {
     const signer2 = createSigner(user2);
     const client = await createRegisteredClient(signer);
     const client2 = await createRegisteredClient(signer2);
-    const inboxStates = await Client.inboxStateFromInboxIds("local", [
-      client.inboxId,
-    ]);
+    const inboxStates = await Client.inboxStateFromInboxIds(
+      [client.inboxId],
+      "local",
+    );
     expect(inboxStates.length).toBe(1);
     expect(inboxStates[0].inboxId).toBe(client.inboxId);
     expect(inboxStates[0].identifiers).toEqual([await signer.getIdentifier()]);
 
-    const inboxStates2 = await Client.inboxStateFromInboxIds("local", [
-      client2.inboxId,
-    ]);
+    const inboxStates2 = await Client.inboxStateFromInboxIds(
+      [client2.inboxId],
+      "local",
+    );
     expect(inboxStates2.length).toBe(1);
     expect(inboxStates2[0].inboxId).toBe(client2.inboxId);
     expect(inboxStates2[0].identifiers).toEqual([

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -16,7 +16,7 @@ import {
   TestCodec,
 } from "@test/helpers";
 
-describe.concurrent("Conversation", () => {
+describe("Conversation", () => {
   it("should update conversation name", async () => {
     const user1 = createUser();
     const user2 = createUser();

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -7,7 +7,7 @@ import {
   createUser,
 } from "@test/helpers";
 
-describe.concurrent("Conversations", () => {
+describe("Conversations", () => {
   it("should not have initial conversations", async () => {
     const user = createUser();
     const signer = createSigner(user);

--- a/sdks/node-sdk/test/DebugInformation.test.ts
+++ b/sdks/node-sdk/test/DebugInformation.test.ts
@@ -5,7 +5,7 @@ import {
   createUser,
 } from "@test/helpers";
 
-describe.concurrent("DebugInformation", () => {
+describe("DebugInformation", () => {
   it("should return network API statistics", async () => {
     const user = createUser();
     const signer = createSigner(user);

--- a/sdks/node-sdk/test/Preferences.test.ts
+++ b/sdks/node-sdk/test/Preferences.test.ts
@@ -9,7 +9,7 @@ import {
   sleep,
 } from "@test/helpers";
 
-describe.concurrent("Preferences", () => {
+describe("Preferences", () => {
   it("should return the correct inbox state", async () => {
     const user = createUser();
     const signer = createSigner(user);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/wasm-bindings": "npm:1.2.3"
+    "@xmtp/wasm-bindings": "npm:1.2.4"
     playwright: "npm:^1.52.0"
     rollup: "npm:^4.41.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3829,10 +3829,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@xmtp/node-bindings@npm:1.2.3"
-  checksum: 10/3e058aa3257ffbb0c94f4c1dfac8794bce76a057e11777a077c039a8fe5049c64396a3d0582a3609f6f04c04eb61de7c696e94396f5cdbd0f2b6724f2e87e4fe
+"@xmtp/node-bindings@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@xmtp/node-bindings@npm:1.2.4"
+  checksum: 10/a2a06f5c8a520a63935395481a88f2d205ea3a5054b6a2fa3345c292287f3fe6129086c0e719783d3ef0ed98e7695eb9ef773bd21fb4e471076dd207313edc89
   languageName: node
   linkType: hard
 
@@ -3847,7 +3847,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.2.3"
+    "@xmtp/node-bindings": "npm:1.2.4"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.41.1"
@@ -3889,10 +3889,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@xmtp/wasm-bindings@npm:1.2.3"
-  checksum: 10/ecfa97e36c7be1d9752d9aacfcf14e803e36b18b1c6dc11dea101b4a85472888c999cfced238b058ae4e49cea06bb19be2f575fcf50add85d6e40b4db32b6c35
+"@xmtp/wasm-bindings@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@xmtp/wasm-bindings@npm:1.2.4"
+  checksum: 10/e75ae1cb765fe155416a97837e2d95ad64fb420b68c1429efb3f094d3b89be373e656e8ffe3872765651b12c062bfde169f52a283df9a2008ef638054e197596
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Added `Client.inboxStateFromInboxIds` static method for retrieving inbox state without a client
- Refactored some method signatures and outputs for consistency across SDKs