### PR TITLE
Add changeset for browser SDK release

### DIFF
--- a/.changeset/loud-doodles-grow.md
+++ b/.changeset/loud-doodles-grow.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": major
+---
+
+This update introduces enhancements for managing installations without a client. It also contains breaking changes related to signature management and consistency across SDKs.


### PR DESCRIPTION
### Add changeset documentation for browser SDK major version release
Adds a changeset file [.changeset/loud-doodles-grow.md](https://github.com/xmtp/xmtp-js/pull/1064/files#diff-ef8ada9f1b1c023915458b1c84587ceb970f60278897f6b9aadf00f06893eac5) that documents a major version update for the `@xmtp/browser-sdk` package. The changeset describes breaking changes related to signature management and consistency across SDKs, along with enhancements for managing installations without a client.

#### 📍Where to Start
Start with the changeset file [.changeset/loud-doodles-grow.md](https://github.com/xmtp/xmtp-js/pull/1064/files#diff-ef8ada9f1b1c023915458b1c84587ceb970f60278897f6b9aadf00f06893eac5) to understand the documented changes for the browser SDK release.

----

_[Macroscope](https://app.macroscope.com) summarized f53d914._