### PR TITLE
Browser SDK updates

### DIFF
--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -63,7 +63,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/wasm-bindings": "1.2.5",
+    "@xmtp/wasm-bindings": "1.2.6",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/browser-sdk/test/Conversations.test.ts
+++ b/sdks/browser-sdk/test/Conversations.test.ts
@@ -447,8 +447,8 @@ describe("Conversations", () => {
 
     const group = await client.conversations.newGroup([client2.inboxId!]);
 
-    await client.conversations.syncAll();
-    await client2.conversations.syncAll();
+    await client.conversations.sync();
+    await client2.conversations.sync();
 
     const convos = await client2.conversations.list();
     expect(convos.length).toBe(1);
@@ -456,8 +456,8 @@ describe("Conversations", () => {
 
     const group2 = await client.conversations.newDm(client2.inboxId!);
 
-    await client.conversations.syncAll();
-    await client2.conversations.syncAll();
+    await client.conversations.sync();
+    await client2.conversations.sync();
 
     const convos2 = await client2.conversations.list();
     expect(convos2.length).toBe(2);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,7 +3648,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/wasm-bindings": "npm:1.2.5"
+    "@xmtp/wasm-bindings": "npm:1.2.6"
     playwright: "npm:^1.52.0"
     rollup: "npm:^4.41.1"
     rollup-plugin-dts: "npm:^6.1.1"
@@ -3906,10 +3906,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.2.5":
-  version: 1.2.5
-  resolution: "@xmtp/wasm-bindings@npm:1.2.5"
-  checksum: 10/b7806bf44e36b6ac47207baa9dec4b2a2162bf3f2954801442ddf75849813bed88e304227677cd8fe09f3fca6066c7efc38dc8afdd2464a5e12a6fcf6b08c223
+"@xmtp/wasm-bindings@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@xmtp/wasm-bindings@npm:1.2.6"
+  checksum: 10/24758772a19f0704a9c02beb31cdf94869a4d02bfda25a494dc3d05e488fc645e99d04fa7d7a9d882e7206b93f7348676e1b7cca7397ec83e5198fce98eb6b1d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- Increased max payload size to `25MB`
- Improved `syncAll` performance