### PR TITLE
Static installation revocation

### DIFF
--- a/apps/xmtp.chat/src/components/App/App.tsx
+++ b/apps/xmtp.chat/src/components/App/App.tsx
@@ -17,6 +17,7 @@ import { CreateGroupModal } from "@/components/Conversations/CreateGroupModal";
 import { IdentityModal } from "@/components/Identity/IdentityModal";
 import { MessageModal } from "@/components/Messages/MessageModal";
 import { useAnalytics } from "@/hooks/useAnalytics";
+import RevokeInstallations from "./RevokeInstallations";
 
 export const App: React.FC = () => {
   useAnalytics();
@@ -29,6 +30,9 @@ export const App: React.FC = () => {
           <Route path="" element={<Welcome />}>
             <Route path="connect" element={<ConnectModal />} />
           </Route>
+        </Route>
+        <Route path="revoke-installations/*" element={<RevokeInstallations />}>
+          <Route path="connect" element={<ConnectModal />} />
         </Route>
         <Route path="/*" element={<AppLayout />}>
           <Route index element={<Navigate to="/conversations" />} />

--- a/apps/xmtp.chat/src/components/App/Connect.tsx
+++ b/apps/xmtp.chat/src/components/App/Connect.tsx
@@ -1,12 +1,12 @@
 import { Button, Group } from "@mantine/core";
-import { useCallback } from "react";
+import { useCallback, type FC } from "react";
 import { useNavigate } from "react-router";
 
-export const Connect = () => {
+export const Connect: FC<{ url?: string }> = ({ url = "/welcome/connect" }) => {
   const navigate = useNavigate();
 
   const handleClick = useCallback(() => {
-    void navigate("/welcome/connect");
+    void navigate(url);
   }, [navigate]);
 
   return (

--- a/apps/xmtp.chat/src/components/App/RevokeInstallations.tsx
+++ b/apps/xmtp.chat/src/components/App/RevokeInstallations.tsx
@@ -1,0 +1,389 @@
+import {
+  Anchor,
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  Group,
+  Stack,
+  Table,
+  Text,
+  Title,
+  useMatches,
+} from "@mantine/core";
+import { useMediaQuery } from "@mantine/hooks";
+import { Utils } from "@xmtp/browser-sdk";
+import { formatDistanceToNow } from "date-fns";
+import { Fragment, useEffect, useState } from "react";
+import { Outlet, useNavigate, useParams } from "react-router";
+import { useAccount } from "wagmi";
+import { nsToDate } from "@/helpers/date";
+import { useSettings } from "@/hooks/useSettings";
+import useStaticRevokeInstallations from "@/hooks/useStaticRevokeInstallations";
+import { BadgeWithCopy } from "../BadgeWithCopy";
+import { Connect } from "./Connect";
+
+const RevokeInstallations = () => {
+  const [selectedInstallationsIndexes, setSelectedInstallationsIndexes] =
+    useState<number[]>([]);
+  const px = useMatches({
+    base: "5%",
+    sm: "10%",
+  });
+  const { address } = useAccount();
+  const params = useParams();
+  const splatValue = params["*"];
+  const inboxId =
+    splatValue && splatValue !== "connect" ? splatValue : undefined;
+  const navigate = useNavigate();
+  const { environment } = useSettings();
+
+  const { handleRevokeInstallations, installations, isRevoking } =
+    useStaticRevokeInstallations(inboxId);
+
+  useEffect(() => {
+    if (address && !inboxId) {
+      const utils = new Utils();
+      void utils
+        .getInboxIdForIdentifier(
+          {
+            identifier: address,
+            identifierKind: "Ethereum",
+          },
+          environment,
+        )
+        .then((inboxId) => {
+          if (inboxId) {
+            void navigate("/revoke-installations/" + inboxId);
+          } else {
+            throw new Error(
+              "Inbox ID not found for the provided address. Please ensure you have an XMTP account.",
+            );
+          }
+        });
+    }
+  }, [address, inboxId, environment, navigate]);
+
+  useEffect(() => {
+    if (!address && inboxId) {
+      // if wallet is disconnected but inboxId exist remove the inboxId from the URL
+      void navigate("/revoke-installations");
+    }
+  }, [inboxId, address, navigate]);
+
+  const toggleAllInstallations = (checked: boolean) => {
+    setSelectedInstallationsIndexes(
+      checked ? [...Array(installations.length).keys()] : [],
+    );
+  };
+
+  const toggleInstallation = (installationIndex: number) => {
+    setSelectedInstallationsIndexes((prev) =>
+      prev.some((i) => i === installationIndex)
+        ? prev.filter((i) => i !== installationIndex)
+        : [...prev, installationIndex],
+    );
+  };
+
+  const isInstallationSelected = (installationIndex: number) =>
+    selectedInstallationsIndexes.some((i) => i === installationIndex);
+
+  const handleRevoke = () => {
+    if (!inboxId) return;
+    void handleRevokeInstallations(
+      inboxId,
+      selectedInstallationsIndexes.map(
+        (_, indexValue) => installations[indexValue].bytes,
+      ),
+    ).then(() => {
+      // Clear selected installations indexes after revocation
+      setSelectedInstallationsIndexes([]);
+    });
+  };
+
+  const isMobile = useMediaQuery("(max-width: 600px)");
+
+  return (
+    <Fragment>
+      <Stack
+        gap="xl"
+        py={isMobile ? 16 : 40}
+        px={isMobile ? 12 : px}
+        align="center"
+        style={{
+          minHeight: "100vh",
+          width: "100vw",
+          background: "#18181b",
+          overflowX: "hidden",
+        }}>
+        <Stack
+          gap="md"
+          align="center"
+          style={{ maxWidth: 600, width: "100%", margin: isMobile ? 0 : "xl" }}>
+          <Title order={1} ta="center" style={{ fontSize: isMobile ? 28 : 36 }}>
+            Revoke Installations
+          </Title>
+          <Text
+            fs="italic"
+            size={isMobile ? "md" : "xl"}
+            style={{ textAlign: "center" }}>
+            Revoke installations for your XMTP inbox ID.
+          </Text>
+        </Stack>
+        <Stack gap="md" align="center" style={{ maxWidth: 600, width: "100%" }}>
+          {inboxId && (
+            <Text size="md" c="red" style={{ textAlign: "center" }}>
+              Note that is a disruptive action as it will remove all the
+              selected installations form your inbox, which will result in the
+              loss of all your convesation history associated with them. Please
+              proceed with caution as this action cannot undone.
+            </Text>
+          )}
+          {!inboxId ? (
+            <Connect url="/revoke-installations/connect" />
+          ) : (
+            <Box
+              p={isMobile ? 0 : "md"}
+              style={{
+                textAlign: "center",
+                width: "100%",
+                background: isMobile ? "none" : "#232326",
+                borderRadius: isMobile ? 0 : 12,
+                boxShadow: isMobile ? "none" : "0 2px 16px 0 rgba(0,0,0,0.10)",
+                border: isMobile ? "none" : "1px solid #232326",
+                maxWidth: 600,
+                margin: isMobile ? 0 : "auto",
+              }}>
+              <Flex direction="column" gap="sm" mb={isMobile ? 16 : 40}>
+                <Text
+                  size="lg"
+                  fw={700}
+                  style={{
+                    maxWidth: isMobile ? 320 : 720,
+                    textAlign: "left",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    marginRight: 8,
+                    flex: 1,
+                    display: "block",
+                  }}
+                  title={inboxId}>
+                  Inbox ID: {inboxId}
+                </Text>
+                <Text
+                  size="lg"
+                  fw={700}
+                  style={{
+                    maxWidth: isMobile ? 320 : 720,
+                    textAlign: "left",
+                    whiteSpace: "nowrap",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    marginRight: 8,
+                    flex: 1,
+                    display: "block",
+                  }}
+                  title={address}>
+                  Wallet Address: {address}
+                </Text>
+              </Flex>
+              <Box mt={10}>
+                {installations.length > 0 ? (
+                  <Stack gap="sm">
+                    <Group justify="space-between" px={isMobile ? 0 : "md"}>
+                      <Text size="md">Select installations to revoke:</Text>
+                      <Checkbox
+                        label="Select All"
+                        checked={
+                          selectedInstallationsIndexes.length ===
+                          installations.length
+                        }
+                        indeterminate={
+                          selectedInstallationsIndexes.length > 0 &&
+                          selectedInstallationsIndexes.length <
+                            installations.length
+                        }
+                        onChange={(event) => {
+                          toggleAllInstallations(event.currentTarget.checked);
+                        }}
+                      />
+                    </Group>
+                    <Box
+                      style={{
+                        maxHeight: isMobile ? 220 : 320,
+                        overflowY: "auto",
+                        background: isMobile ? "none" : "#18181b",
+                        borderRadius: 8,
+                        border: isMobile ? "none" : "1px solid #232326",
+                        padding: isMobile ? 0 : 8,
+                        marginBottom: isMobile ? 8 : 16,
+                        width: "100%",
+                      }}>
+                      <Table
+                        style={{
+                          width: "100%",
+                          tableLayout: "fixed",
+                          background: isMobile ? "none" : "#18181b",
+                          borderRadius: 8,
+                          overflow: "hidden",
+                          border: "none",
+                        }}>
+                        <Table.Thead>
+                          <Table.Tr>
+                            <Table.Th
+                              style={{
+                                width: "60%",
+                                border: "none",
+                                textAlign: "left",
+                                padding: isMobile ? "8px 0" : "8px 16px",
+                                fontWeight: 600,
+                                fontSize: isMobile ? 14 : 16,
+                                color: "#fff",
+                                background: "none",
+                              }}>
+                              Installation ID
+                            </Table.Th>
+                            <Table.Th
+                              style={{
+                                width: "30%",
+                                border: "none",
+                                textAlign: "left",
+                                padding: isMobile ? "8px 0" : "8px 16px",
+                                fontWeight: 600,
+                                fontSize: isMobile ? 14 : 16,
+                                color: "#fff",
+                                background: "none",
+                              }}>
+                              Created
+                            </Table.Th>
+                            <Table.Th
+                              style={{
+                                width: "10%",
+                                border: "none",
+                                background: "none",
+                              }}></Table.Th>
+                          </Table.Tr>
+                        </Table.Thead>
+                        <Table.Tbody>
+                          {installations.map((installation, index) => {
+                            const createdAt = nsToDate(
+                              installation.clientTimestampNs ?? 0n,
+                            );
+                            return (
+                              <Table.Tr
+                                key={index}
+                                style={{
+                                  background: isMobile
+                                    ? "none"
+                                    : "rgba(0,0,0,0.05)",
+                                  borderRadius: 6,
+                                }}>
+                                <Table.Td
+                                  style={{
+                                    padding: isMobile ? "8px 0" : "8px 16px",
+                                    textAlign: "left",
+                                    border: "none",
+                                    verticalAlign: "middle",
+                                    width: "60%",
+                                    minWidth: 120,
+                                    maxWidth: 0,
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                  }}>
+                                  <BadgeWithCopy
+                                    maxWidth={isMobile ? "140" : "220"}
+                                    value={installation.id}
+                                  />
+                                </Table.Td>
+                                <Table.Td
+                                  style={{
+                                    padding: isMobile ? "8px 0" : "8px 16px",
+                                    textAlign: "left",
+                                    border: "none",
+                                    verticalAlign: "middle",
+                                    width: "30%",
+                                    minWidth: 80,
+                                    maxWidth: 120,
+                                  }}>
+                                  <Text
+                                    size="xs"
+                                    c="dimmed"
+                                    style={{
+                                      minWidth: 80,
+                                      marginRight: 8,
+                                      whiteSpace: "nowrap",
+                                      textAlign: "left",
+                                    }}
+                                    title={createdAt.toISOString()}>
+                                    {formatDistanceToNow(createdAt, {
+                                      addSuffix: true,
+                                    })}
+                                  </Text>
+                                </Table.Td>
+                                <Table.Td
+                                  style={{
+                                    textAlign: "right",
+                                    border: "none",
+                                    verticalAlign: "middle",
+                                    width: "10%",
+                                    background: "none",
+                                  }}>
+                                  <Checkbox
+                                    checked={isInstallationSelected(index)}
+                                    onChange={() => {
+                                      toggleInstallation(index);
+                                    }}
+                                  />
+                                </Table.Td>
+                              </Table.Tr>
+                            );
+                          })}
+                        </Table.Tbody>
+                      </Table>
+                    </Box>
+                  </Stack>
+                ) : (
+                  <Text size="md" c="text.primary">
+                    No installations found for this inbox ID.
+                  </Text>
+                )}
+              </Box>
+              <Button
+                mt={isMobile ? 12 : 20}
+                w={"100%"}
+                size={isMobile ? "md" : "lg"}
+                disabled={
+                  selectedInstallationsIndexes.length === 0 || isRevoking
+                }
+                loading={isRevoking}
+                onClick={handleRevoke}
+                style={{
+                  fontSize: isMobile ? 16 : 18,
+                  marginTop: isMobile ? 8 : 20,
+                }}>
+                {`Revoke ${
+                  selectedInstallationsIndexes.length > 0
+                    ? `(${selectedInstallationsIndexes.length})`
+                    : ""
+                }`}
+              </Button>
+            </Box>
+          )}
+          <Text style={{ textAlign: "center" }}>
+            To Learn more about static installations revocation, see{" "}
+            <Anchor
+              href="https://docs.xmtp.org/inboxes/manage-inboxes#revoke-installations-for-a-user-who-cant-log-in"
+              target="_blank">
+              documentation
+            </Anchor>
+            .
+          </Text>
+        </Stack>
+      </Stack>
+      <Outlet />
+    </Fragment>
+  );
+};
+
+export default RevokeInstallations;

--- a/apps/xmtp.chat/src/components/App/Welcome.tsx
+++ b/apps/xmtp.chat/src/components/App/Welcome.tsx
@@ -1,5 +1,7 @@
 import {
   Anchor,
+  Button,
+  Flex,
   LoadingOverlay,
   Stack,
   Text,
@@ -19,6 +21,7 @@ import {
   createEphemeralSigner,
   createSCWSigner,
 } from "@/helpers/createSigner";
+import { extractIboxIdFromMaxInstallationsError } from "@/helpers/strings";
 import { useRedirect } from "@/hooks/useRedirect";
 import { useSettings } from "@/hooks/useSettings";
 
@@ -102,6 +105,18 @@ export const Welcome = () => {
         : createEOASigner(account.address, (message: string) =>
             signMessageAsync({ message }),
           ),
+    }).catch((error: unknown) => {
+      const err = error as Error;
+      if (err.message.includes("Cannot register a new installation")) {
+        const inboxId = extractIboxIdFromMaxInstallationsError(err);
+        if (inboxId) {
+          void navigate(`/revoke-installations/${inboxId}`);
+        } else {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
     });
   }, [account.address, account.chainId, useSCW, signMessageAsync]);
 
@@ -122,7 +137,18 @@ export const Welcome = () => {
             Settings
           </Title>
           <Settings />
-          <Connect />
+          <Flex gap="xs" columnGap={4} align="center" justify="center">
+            <Connect />
+            <Button
+              size="md"
+              variant="filled"
+              color="red"
+              onClick={() => {
+                void navigate("/revoke-installations");
+              }}>
+              Revoke Installations
+            </Button>
+          </Flex>
           <Title order={3}>Feedback</Title>
           <Stack gap="md">
             <Text>

--- a/apps/xmtp.chat/src/components/BadgeWithCopy.tsx
+++ b/apps/xmtp.chat/src/components/BadgeWithCopy.tsx
@@ -48,14 +48,19 @@ const CopyIcon: React.FC<CopyIconProps> = ({ value }) => {
 
 export type BadgeWithCopyProps = {
   value: string;
+  maxWidth?: string | number;
 };
 
-export const BadgeWithCopy: React.FC<BadgeWithCopyProps> = ({ value }) => {
+export const BadgeWithCopy: React.FC<BadgeWithCopyProps> = ({
+  value,
+  maxWidth,
+}) => {
   return (
     <Badge
       variant="filled"
       className={classes.badge}
       w="100%"
+      maw={maxWidth}
       size="xl"
       styles={{
         label: {

--- a/apps/xmtp.chat/src/helpers/strings.ts
+++ b/apps/xmtp.chat/src/helpers/strings.ts
@@ -7,3 +7,18 @@ export const isValidInboxId = (inboxId: string): inboxId is string =>
 
 export const shortAddress = (address: string): string =>
   `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
+
+export const extractIboxIdFromMaxInstallationsError = (
+  error: Error,
+): string | null => {
+  if (error.message.includes("Cannot register a new installation")) {
+    const regex = /InboxID ([a-f0-9]+)/;
+    const match = error.message.match(regex);
+    if (match && match[1]) {
+      return match[1];
+    } else {
+      console.log("InboxID not found.");
+    }
+  }
+  return null;
+};

--- a/apps/xmtp.chat/src/hooks/useStaticRevokeInstallations.ts
+++ b/apps/xmtp.chat/src/hooks/useStaticRevokeInstallations.ts
@@ -1,0 +1,101 @@
+import { Client, type SafeInstallation, type Signer } from "@xmtp/browser-sdk";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAccount, useSignMessage } from "wagmi";
+import {
+  createEOASigner,
+  createEphemeralSigner,
+  createSCWSigner,
+} from "@/helpers/createSigner";
+import { useSettings } from "./useSettings";
+
+const useStaticRevokeInstallations = (inboxId?: string) => {
+  const account = useAccount();
+  const { signMessageAsync } = useSignMessage();
+  const [installations, setInstallations] = useState<Array<SafeInstallation>>(
+    [],
+  );
+  const [isRevoking, setIsRevoking] = useState<boolean>(false);
+  const { environment, ephemeralAccountEnabled, ephemeralAccountKey, useSCW } =
+    useSettings();
+
+  const isFetchingRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!inboxId || !/^[0-9a-zA-Z]{64}$/.test(inboxId)) return;
+    if (isFetchingRef.current) return; // Prevent multiple fetches
+    isFetchingRef.current = true;
+    void Client.inboxStateFromInboxIds([inboxId], environment)
+      .then((state) => {
+        setInstallations(state[0].installations.map((item) => item));
+      })
+      .finally(() => {
+        isFetchingRef.current = false;
+      });
+  }, [inboxId]);
+
+  const handleRevokeInstallations = useCallback(
+    async (
+      inboxId: string,
+      installations: Array<Uint8Array>,
+    ): Promise<void> => {
+      try {
+        if (!inboxId || !/^[0-9a-zA-Z]{64}$/.test(inboxId)) {
+          throw new Error("Invalid inbox ID format");
+        }
+        if (!installations.length) {
+          throw new Error("No installations provided to revoke.");
+        }
+        let signer: Signer;
+        if (ephemeralAccountEnabled) {
+          if (!ephemeralAccountKey) {
+            throw new Error("Ephemeral account key is not set");
+          }
+          signer = createEphemeralSigner(ephemeralAccountKey);
+        } else {
+          if (!account.address || (useSCW && !account.chainId)) {
+            return void 0;
+          }
+          signer = useSCW
+            ? createSCWSigner(
+                account.address,
+                (message: string) => signMessageAsync({ message }),
+                account.chainId,
+              )
+            : createEOASigner(account.address, (message: string) =>
+                signMessageAsync({ message }),
+              );
+        }
+        setIsRevoking(true);
+        await Client.revokeInstallations(
+          signer,
+          inboxId,
+          installations,
+          environment,
+        );
+        setInstallations((prev) =>
+          prev.filter(
+            (item) =>
+              !installations.some((i) => i.valueOf() === item.bytes.valueOf()),
+          ),
+        );
+      } finally {
+        setIsRevoking(false);
+      }
+    },
+    [
+      account.address,
+      account.chainId,
+      ephemeralAccountEnabled,
+      ephemeralAccountKey,
+      useSCW,
+      signMessageAsync,
+    ],
+  );
+  return {
+    handleRevokeInstallations,
+    installations,
+    isRevoking,
+  };
+};
+
+export default useStaticRevokeInstallations;


### PR DESCRIPTION
# Add static installation revocation flow for XMTP inbox IDs

## Problem

XMTP V3 enforces a maximum of 5 installations per inbox ID. If a user reaches this limit and is logged out of all devices, they are unable to sign in to any XMTP app with that identity/inbox ID. There was previously no way for users to manage or revoke installations in this scenario, resulting in permanent lockout.

## Issues
#Closes #1077

## Solution

This PR introduces a static installation revocation feature to xmtp.chat. With this feature, users can:

- Connect their wallet or are redirect the the /revoke-installations/inboxId route from the /welcome page after they are unable to login as a result of reaching maximum installation.
- View all installations associated with their inbox.
- Select and revoke one or more installations to free up slots.
- Regain access to XMTP apps afterwards.

The UI is user-friendly and mobile-responsive, with clear warnings about the consequences of revocation (such as loss of conversation history for revoked installations). There is also a direct link to documentation for further guidance.

## Use Cases

- Users who are locked out due to the installation limit can recover access to their XMTP inbox.
- Other XMTP app developers can redirect users to xmtp.chat for installation management when they hit the limit.
- The implementation serves as a reference for other developers to add similar functionality to their own apps.

## Demo

A walkthrough of the feature is available here:  
[Loom video demo](https://www.loom.com/share/27247f45f5a448fb8413ae20896b54d6?sid=eb0cea53-de14-4d3a-8d1c-96f6ef45eeeb)

## Additional Notes

- The feature is accessible via the `/revoke-installations` route.
- Error handling is improved: if a user hits the installation limit during login, they are redirected to the revocation flow.
- The code is modular and reusable, with a custom hook for managing installation state and