### PR TITLE
Use GHCR docker image for node

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   node:
-    image: xmtp/node-go:latest
+    image: ghcr.io/xmtp/node-go:main
     platform: linux/amd64
     environment:
       - GOWAKU-NODEKEY=8a30dcb604b0b53627a5adc054dbf434b446628d4bd1eccc681d223f0550ce67


### PR DESCRIPTION
### Update node service Docker image to use GitHub Container Registry with main tag in docker-compose configuration
The Docker image reference for the `node` service in [dev/docker-compose.yml](https://github.com/xmtp/xmtp-js/pull/1082/files#diff-57a74176b16e85d7cf445d1f8871ffc8838f90769f44608b6587015a59309903) changes from `xmtp/node-go:latest` to `ghcr.io/xmtp/node-go:main`, switching the container registry from Docker Hub to GitHub Container Registry and updating the image tag from `latest` to `main`.

#### 📍Where to Start
Start with the `node` service configuration in [dev/docker-compose.yml](https://github.com/xmtp/xmtp-js/pull/1082/files#diff-57a74176b16e85d7cf445d1f8871ffc8838f90769f44608b6587015a59309903).

----

_[Macroscope](https://app.macroscope.com) summarized 5447543._