### PR TITLE
Upgrade browser SDK for xmtp.chat

### DIFF
--- a/apps/xmtp.chat/package.json
+++ b/apps/xmtp.chat/package.json
@@ -21,7 +21,7 @@
     "@mantine/modals": "^8.0.2",
     "@mantine/notifications": "^8.0.2",
     "@tanstack/react-query": "^5.77.2",
-    "@xmtp/browser-sdk": "workspace:^",
+    "@xmtp/browser-sdk": "3.1.0-rc1",
     "@xmtp/content-type-group-updated": "workspace:^",
     "@xmtp/content-type-primitives": "workspace:^",
     "@xmtp/content-type-reaction": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3633,7 +3633,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/browser-sdk@workspace:^, @xmtp/browser-sdk@workspace:sdks/browser-sdk":
+"@xmtp/browser-sdk@npm:3.1.0-rc1":
+  version: 3.1.0-rc1
+  resolution: "@xmtp/browser-sdk@npm:3.1.0-rc1"
+  dependencies:
+    "@xmtp/content-type-group-updated": "npm:^2.0.2"
+    "@xmtp/content-type-primitives": "npm:^2.0.2"
+    "@xmtp/content-type-text": "npm:^2.0.2"
+    "@xmtp/wasm-bindings": "npm:1.3.0-rc1"
+    uuid: "npm:^11.1.0"
+  checksum: 10/585143b2fa48d7d25a007738045a204f204bde915202cefe9c22be65c30b18dd4f0dd20c81e2ee5cb33ea49e6d7471e9bc42f78181e70a74f966552dd7ea030c
+  languageName: node
+  linkType: hard
+
+"@xmtp/browser-sdk@workspace:sdks/browser-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/browser-sdk@workspace:sdks/browser-sdk"
   dependencies:
@@ -3913,6 +3926,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmtp/wasm-bindings@npm:1.3.0-rc1":
+  version: 1.3.0-rc1
+  resolution: "@xmtp/wasm-bindings@npm:1.3.0-rc1"
+  checksum: 10/0748327643d648ba44d86850191e069b64d3372ee9a48294ec656de9eec6011a96e802e55c2c3d5430a4418f3ee1a567d3828b0464321761c0d66fe305a09746
+  languageName: node
+  linkType: hard
+
 "@xmtp/xmtp.chat@workspace:apps/xmtp.chat":
   version: 0.0.0-use.local
   resolution: "@xmtp/xmtp.chat@workspace:apps/xmtp.chat"
@@ -3926,7 +3946,7 @@ __metadata:
     "@types/react": "npm:^19.1.6"
     "@types/react-dom": "npm:^19.1.5"
     "@vitejs/plugin-react": "npm:^4.5.0"
-    "@xmtp/browser-sdk": "workspace:^"
+    "@xmtp/browser-sdk": "npm:3.1.0-rc1"
     "@xmtp/content-type-group-updated": "workspace:^"
     "@xmtp/content-type-primitives": "workspace:^"
     "@xmtp/content-type-reaction": "workspace:^"


### PR DESCRIPTION
### Upgrade browser SDK dependency for xmtp.chat from workspace reference to version 3.1.0-rc1
Changes the `@xmtp/browser-sdk` dependency in [apps/xmtp.chat/package.json](https://github.com/xmtp/xmtp-js/pull/1096/files#diff-0b676dbdc3fa949b9bfafb55bb5fbfb04054a499b5490d6d853830ee6b69a4d8) from a workspace reference to a specific release candidate version and updates the corresponding lock file entries in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1096/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

#### 📍Where to Start
Start with the dependency changes in [apps/xmtp.chat/package.json](https://github.com/xmtp/xmtp-js/pull/1096/files#diff-0b676dbdc3fa949b9bfafb55bb5fbfb04054a499b5490d6d853830ee6b69a4d8) to see how the `@xmtp/browser-sdk` reference has been modified.

----

_[Macroscope](https://app.macroscope.com) summarized 3abd7f0._