### PR TITLE
Fix logic that breaks static revoke installations in some cases

### DIFF
--- a/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
+++ b/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
@@ -80,15 +80,22 @@ export const InboxTools: React.FC = () => {
 
   const handleRevokeInstallations = useCallback(
     async (installationIds: Uint8Array[]) => {
-      if (ephemeralAccountEnabled && !ephemeralAddress) {
-        return;
-      } else if (!address || (useSCW && !account.chainId)) {
-        return;
-      }
       let signer: Signer;
       if (ephemeralAccountEnabled) {
+        if (!ephemeralAddress) {
+          console.error("Ephemeral wallet not connected");
+          return;
+        }
         signer = ephemeralSigner;
       } else {
+        if (!address) {
+          console.error("Wallet not connected");
+          return;
+        }
+        if (useSCW && !account.chainId) {
+          console.error("Smart contract wallet chain ID not set");
+          return;
+        }
         signer = useSCW
           ? createSCWSigner(
               address,

--- a/apps/xmtp.chat/src/hooks/useMemberId.ts
+++ b/apps/xmtp.chat/src/hooks/useMemberId.ts
@@ -26,6 +26,9 @@ export const useMemberId = () => {
         return;
       }
 
+      setInboxId("");
+      setError(null);
+
       if (!isValidEthereumAddress(memberId) && !isValidInboxId(memberId)) {
         setError("Invalid address or inbox ID");
       } else if (isValidEthereumAddress(memberId) && utilsRef.current) {
@@ -44,16 +47,14 @@ export const useMemberId = () => {
             setError("Address not registered on XMTP");
           } else {
             setInboxId(inboxId);
-            setError(null);
           }
         } catch (error) {
           setError((error as Error).message);
         } finally {
           setLoading(false);
         }
-      } else {
+      } else if (isValidInboxId(memberId)) {
         setInboxId(memberId);
-        setError(null);
       }
     };
 


### PR DESCRIPTION
# Summary

In some cases, it was not possible to revoke installations of an inbox without a client.