### PR TITLE
fix(components): Correct member type value in Members component

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Members.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Members.tsx
@@ -40,7 +40,7 @@ export const Members: React.FC<MembersProps> = ({
   const [members, setMembers] = useState<SafeGroupMember[]>([]);
   const [addedMembers, setAddedMembers] = useState<string[]>([]);
   const [removedMembers, setRemovedMembers] = useState<SafeGroupMember[]>([]);
-  const [memberType, setMemberType] = useState<MemberType>("inboxID");
+  const [memberType, setMemberType] = useState<MemberType>("inboxId");
   const { environment } = useSettings();
   const utilsRef = useRef<Utils | null>(null);
 
@@ -223,7 +223,7 @@ export const Members: React.FC<MembersProps> = ({
                 data={[
                   {
                     label: "Inbox ID",
-                    value: "inboxID",
+                    value: "inboxId",
                   },
                   {
                     label: "Address",


### PR DESCRIPTION
This pull request corrects a typo in the `Members.tsx` component that affects the state management for the member type selector.
Problem
The component was using the string literal "inboxID" for the memberType state and in the `SegmentedControl `data. This does not match the defined MemberType which expects "inboxId" (with a lowercase 'd').
This inconsistency could lead to incorrect behavior in the UI, particularly with the "Inbox ID" / "Address" toggle, as the component's state would not match the expected values.
