### PR TITLE
Add support for read receipts

### DIFF
--- a/apps/xmtp.chat/package.json
+++ b/apps/xmtp.chat/package.json
@@ -25,6 +25,7 @@
     "@xmtp/content-type-group-updated": "workspace:^",
     "@xmtp/content-type-primitives": "workspace:^",
     "@xmtp/content-type-reaction": "workspace:^",
+    "@xmtp/content-type-read-receipt": "workspace:^",
     "@xmtp/content-type-remote-attachment": "workspace:^",
     "@xmtp/content-type-reply": "workspace:^",
     "@xmtp/content-type-text": "workspace:^",

--- a/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
@@ -1,5 +1,6 @@
 import { Code } from "@mantine/core";
 import type { ContentTypeId } from "@xmtp/content-type-primitives";
+import { ContentTypeReadReceipt } from "@xmtp/content-type-read-receipt";
 import { ContentTypeReply, type Reply } from "@xmtp/content-type-reply";
 import {
   ContentTypeTransactionReference,
@@ -11,6 +12,7 @@ import {
 } from "@xmtp/content-type-wallet-send-calls";
 import { FallbackContent } from "@/components/Messages/FallbackContent";
 import { type MessageContentAlign } from "@/components/Messages/MessageContentWrapper";
+import { ReadReceiptContent } from "@/components/Messages/ReadReceiptContent";
 import { ReplyContent } from "@/components/Messages/ReplyContent";
 import { TextContent } from "@/components/Messages/TextContent";
 import { TransactionReferenceContent } from "@/components/Messages/TransactionReferenceContent";
@@ -58,6 +60,10 @@ export const MessageContent: React.FC<MessageContentProps> = ({
         scrollToMessage={scrollToMessage}
       />
     );
+  }
+
+  if (contentType.sameAs(ContentTypeReadReceipt)) {
+    return <ReadReceiptContent />;
   }
 
   if (typeof content === "string") {

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,0 +1,5 @@
+import { Text } from "@mantine/core";
+
+export const ReadReceiptContent: React.FC = () => {
+  return <Text size="sm">Read receipt received</Text>;
+};

--- a/apps/xmtp.chat/src/contexts/XMTPContext.tsx
+++ b/apps/xmtp.chat/src/contexts/XMTPContext.tsx
@@ -5,6 +5,7 @@ import {
   type Signer,
 } from "@xmtp/browser-sdk";
 import { ReactionCodec } from "@xmtp/content-type-reaction";
+import { ReadReceiptCodec } from "@xmtp/content-type-read-receipt";
 import { RemoteAttachmentCodec } from "@xmtp/content-type-remote-attachment";
 import { ReplyCodec } from "@xmtp/content-type-reply";
 import { TransactionReferenceCodec } from "@xmtp/content-type-transaction-reference";
@@ -25,6 +26,7 @@ export type ContentTypes = ExtractCodecContentTypes<
     RemoteAttachmentCodec,
     TransactionReferenceCodec,
     WalletSendCallsCodec,
+    ReadReceiptCodec,
   ]
 >;
 
@@ -121,6 +123,7 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
               new RemoteAttachmentCodec(),
               new TransactionReferenceCodec(),
               new WalletSendCallsCodec(),
+              new ReadReceiptCodec(),
             ],
           });
           setClient(xmtpClient);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,7 +3588,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/content-type-read-receipt@workspace:content-types/content-type-read-receipt":
+"@xmtp/content-type-read-receipt@workspace:^, @xmtp/content-type-read-receipt@workspace:content-types/content-type-read-receipt":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-read-receipt@workspace:content-types/content-type-read-receipt"
   dependencies:
@@ -3785,6 +3785,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "workspace:^"
     "@xmtp/content-type-primitives": "workspace:^"
     "@xmtp/content-type-reaction": "workspace:^"
+    "@xmtp/content-type-read-receipt": "workspace:^"
     "@xmtp/content-type-remote-attachment": "workspace:^"
     "@xmtp/content-type-reply": "workspace:^"
     "@xmtp/content-type-text": "workspace:^"


### PR DESCRIPTION
# Summary

Added official support for read receipts on `xmtp.chat`.

Resolves #1053 