### PR TITLE
Update READMEs to point to SDK-specific docs

### DIFF
--- a/sdks/browser-sdk/README.md
+++ b/sdks/browser-sdk/README.md
@@ -9,7 +9,7 @@ To keep up with the latest SDK developments, see the [Issues tab](https://githu
 
 ## Documentation
 
-To learn how to use the XMTP client SDK for browsers and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
+To learn how to use the XMTP client SDK for browsers, see [Get started with the XMTP Browser SDK](https://docs.xmtp.org/sdks/browser).
 
 ## SDK reference
 

--- a/sdks/node-sdk/README.md
+++ b/sdks/node-sdk/README.md
@@ -9,7 +9,7 @@ To keep up with the latest SDK developments, see the [Issues tab](https://githu
 
 ## Documentation
 
-To learn how to use the XMTP client SDK for Node and get answers to frequently asked questions, see the [XMTP documentation](https://docs.xmtp.org/).
+To learn how to use the XMTP client SDK for Node, see [Get started with the XMTP Node SDK](https://docs.xmtp.org/sdks/node).
 
 ## SDK reference
 


### PR DESCRIPTION
### Update README documentation links to point to SDK-specific documentation pages for browser and node SDKs
Updates documentation links in README files to point to SDK-specific documentation pages instead of generic XMTP documentation. The changes modify links in [sdks/browser-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/1111/files#diff-a561646e4e333b5b6e55b5f396496c268bfb99bd7623dc14e4a1ed183b0cf263) to point to `https://docs.xmtp.org/sdks/browser` and [sdks/node-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/1111/files#diff-132170c207fc917bdd7a4b6acb196aa1d4c1a43c609375ba625fbd9d1e2a135c) to point to `https://docs.xmtp.org/sdks/node`, replacing the previous generic `https://docs.xmtp.org/` links.

#### 📍Where to Start
Start with the README file changes in [sdks/browser-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/1111/files#diff-a561646e4e333b5b6e55b5f396496c268bfb99bd7623dc14e4a1ed183b0cf263) to see the documentation link updates.

----

_[Macroscope](https://app.macroscope.com) summarized b2b9913._