### PR TITLE
1.3.3 Release

### DIFF
--- a/.changeset/ten-adults-cheer.md
+++ b/.changeset/ten-adults-cheer.md
@@ -1,0 +1,8 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+- Resolves issue with too many key package api requests
+- Fixes issue causing users with old installations to sometimes not be added to groups
+- Fixes a performance bottleneck that affects listing conversations while syncing

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -63,7 +63,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/wasm-bindings": "1.3.2",
+    "@xmtp/wasm-bindings": "1.3.3",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -52,7 +52,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.3.2"
+    "@xmtp/node-bindings": "1.3.3"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,7 +3503,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/wasm-bindings": "npm:1.3.2"
+    "@xmtp/wasm-bindings": "npm:1.3.3"
     playwright: "npm:^1.54.1"
     rollup: "npm:^4.45.0"
     rollup-plugin-dts: "npm:^6.2.1"
@@ -3701,10 +3701,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.3.2":
-  version: 1.3.2
-  resolution: "@xmtp/node-bindings@npm:1.3.2"
-  checksum: 10/d07ae9152783b32f3a5b68c736f813c851d4941852a76e4bd743265a735ecb77b30504611d481c655a9e6d86635aebfe19676c21c636315209be59104d806030
+"@xmtp/node-bindings@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@xmtp/node-bindings@npm:1.3.3"
+  checksum: 10/c9fecccc1adf6f79ac2cf5e884fa47b4157a8cc8121e04fbb24c9ada13869de78301c67670cb3e9450239659aaea25849af334ee6b11d761d1be5ad36bc0235b
   languageName: node
   linkType: hard
 
@@ -3719,7 +3719,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.3.2"
+    "@xmtp/node-bindings": "npm:1.3.3"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.45.0"
@@ -3761,10 +3761,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.3.2":
-  version: 1.3.2
-  resolution: "@xmtp/wasm-bindings@npm:1.3.2"
-  checksum: 10/0b085f331dbd49aa31ca623b6e89a69344ca8a1140415ee797ba1c0d18c9e0f746bb07086a7734e6eb521e78611ba05b094f837dd1db151b790f071b836c3d77
+"@xmtp/wasm-bindings@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@xmtp/wasm-bindings@npm:1.3.3"
+  checksum: 10/b17888608cc9a0d41070299d4c128091894749fecd2bef6426938f4ad77e36f3d4b166db1450982ac11e82f7cd62dcb8d008156d20c10f270121ee09476e247e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Release version 1.3.3 with dependency updates to `@xmtp/wasm-bindings` and `@xmtp/node-bindings` packages
This release updates dependency versions from 1.3.2 to 1.3.3 for both SDK packages and includes fixes for key package API requests, group membership issues with old installations, and conversation listing performance during syncing. The changes include:

- Updates `@xmtp/wasm-bindings` dependency to version 1.3.3 in [sdks/browser-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1116/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82)
- Updates `@xmtp/node-bindings` dependency to version 1.3.3 in [sdks/node-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1116/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
- Adds changeset documentation in [.changeset/ten-adults-cheer.md](https://github.com/xmtp/xmtp-js/pull/1116/files#diff-80844d1a42e19d75b58983b89b96ab55ad0dfbcd76fb9da154eb35d04078c6cc)
- Updates lock file dependencies in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1116/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)

#### 📍Where to Start
Start with the changeset documentation in [.changeset/ten-adults-cheer.md](https://github.com/xmtp/xmtp-js/pull/1116/files#diff-80844d1a42e19d75b58983b89b96ab55ad0dfbcd76fb9da154eb35d04078c6cc) to understand the specific fixes included in this release.

----

_[Macroscope](https://app.macroscope.com) summarized 8a0bc90._