### PR TITLE
Refactor streaming methods (Node SDK)

### DIFF
--- a/.changeset/nine-colts-think.md
+++ b/.changeset/nine-colts-think.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": major
+---
+
+Refactor streaming methods (Node SDK)

--- a/content-types/content-type-reaction/src/Reaction.test.ts
+++ b/content-types/content-type-reaction/src/Reaction.test.ts
@@ -120,9 +120,9 @@ describe("ReactionContentType", () => {
 
     await dms[0].sync();
     const messages = await dms[0].messages();
-    expect(messages.length).toBe(2);
+    expect(messages.length).toBe(3);
 
-    const reactionMessage = messages[1];
+    const reactionMessage = messages[2];
     const messageContent = reactionMessage.content as Reaction;
     expect(messageContent.action).toBe("added");
     expect(messageContent.content).toBe("smile");

--- a/content-types/content-type-read-receipt/src/ReadReceipt.test.ts
+++ b/content-types/content-type-read-receipt/src/ReadReceipt.test.ts
@@ -64,9 +64,9 @@ describe("ReadReceiptContentType", () => {
 
     await dms[0].sync();
     const messages = await dms[0].messages();
-    expect(messages.length).toBe(1);
+    expect(messages.length).toBe(2);
 
-    const readReceiptMessage = messages[0];
+    const readReceiptMessage = messages[1];
     expect(readReceiptMessage.contentType?.typeId).toBe("readReceipt");
   });
 

--- a/content-types/content-type-remote-attachment/src/Attachment.test.ts
+++ b/content-types/content-type-remote-attachment/src/Attachment.test.ts
@@ -67,9 +67,9 @@ test("can send an attachment", async () => {
 
   await dms[0].sync();
   const messages = await dms[0].messages();
-  expect(messages.length).toBe(1);
+  expect(messages.length).toBe(2);
 
-  const message = messages[0];
+  const message = messages[1];
   const messageContent = message.content as Attachment;
   expect(messageContent.filename).toBe("test.png");
   expect(messageContent.mimeType).toBe("image/png");

--- a/content-types/content-type-remote-attachment/src/RemoteAttachment.test.ts
+++ b/content-types/content-type-remote-attachment/src/RemoteAttachment.test.ts
@@ -95,9 +95,9 @@ test("can create a remote attachment", async () => {
 
   await dms[0].sync();
   const messages = await dms[0].messages();
-  expect(messages.length).toBe(1);
+  expect(messages.length).toBe(2);
 
-  const message = messages[0];
+  const message = messages[1];
   const messageContent = message.content as RemoteAttachment;
   expect(messageContent.url).toBe("https://localhost:3000/test");
   expect(messageContent.filename).toBe("test.txt");
@@ -210,9 +210,9 @@ test("fails if content digest does not match", async () => {
 
   await dms[0].sync();
   const messages = await dms[0].messages();
-  expect(messages.length).toBe(1);
+  expect(messages.length).toBe(2);
 
-  const message = messages[0];
+  const message = messages[1];
 
   const encryptedEncoded2 = await RemoteAttachmentCodec.encodeEncrypted(
     attachment,

--- a/content-types/content-type-reply/src/Reply.test.ts
+++ b/content-types/content-type-reply/src/Reply.test.ts
@@ -72,9 +72,9 @@ describe("ReplyContentType", () => {
 
     await dms[0].sync();
     const messages = await dms[0].messages();
-    expect(messages.length).toBe(2);
+    expect(messages.length).toBe(3);
 
-    const replyMessage = messages[1];
+    const replyMessage = messages[2];
     const messageContent = replyMessage.content as Reply;
     expect(messageContent.content).toBe("LGTM");
     expect(messageContent.reference).toBe(originalMessage);
@@ -118,9 +118,9 @@ describe("ReplyContentType", () => {
 
     await dms[0].sync();
     const messages = await dms[0].messages();
-    expect(messages.length).toBe(2);
+    expect(messages.length).toBe(3);
 
-    const replyMessage = messages[1];
+    const replyMessage = messages[2];
     const messageContent = replyMessage.content as Reply;
     expect(ContentTypeAttachment.sameAs(messageContent.contentType)).toBe(true);
     expect(messageContent.content).toEqual({

--- a/content-types/content-type-transaction-reference/src/TransactionReference.test.ts
+++ b/content-types/content-type-transaction-reference/src/TransactionReference.test.ts
@@ -76,9 +76,9 @@ test("should successfully send and receive a TransactionReference message", asyn
 
   await dms[0].sync();
   const messages = await dms[0].messages();
-  expect(messages.length).toBe(1);
+  expect(messages.length).toBe(2);
 
-  const message = messages[0];
+  const message = messages[1];
   const messageContent = message.content as TransactionReference;
 
   expect(messageContent.namespace).toBe(transactionRefToSend.namespace);

--- a/content-types/content-type-wallet-send-calls/src/WalletSendCalls.test.ts
+++ b/content-types/content-type-wallet-send-calls/src/WalletSendCalls.test.ts
@@ -94,9 +94,9 @@ test("should successfully send and receive a WalletSendCalls message", async () 
 
   await dms[0].sync();
   const messages = await dms[0].messages();
-  expect(messages.length).toBe(1);
+  expect(messages.length).toBe(2);
 
-  const message = messages[0];
+  const message = messages[1];
   const messageContent = message.content as WalletSendCallsParams;
 
   expect(messageContent.version).toBe(walletSendCalls.version);

--- a/sdks/node-sdk/rollup.config.js
+++ b/sdks/node-sdk/rollup.config.js
@@ -7,6 +7,7 @@ import tsConfigPaths from "rollup-plugin-tsconfig-paths";
 const external = [
   "node:path",
   "node:process",
+  "node:util/types",
   "@xmtp/content-type-group-updated",
   "@xmtp/content-type-primitives",
   "@xmtp/content-type-text",

--- a/sdks/node-sdk/src/AsyncStream.ts
+++ b/sdks/node-sdk/src/AsyncStream.ts
@@ -84,7 +84,7 @@ export class AsyncStream<T> {
   }
 }
 
-interface AsyncStreamProxy<T> extends AsyncIterable<T> {
+export interface AsyncStreamProxy<T> extends AsyncIterable<T> {
   next(): Promise<ResolveValue<T>>;
   return(): Promise<ResolveValue<undefined>>;
   end(): Promise<ResolveValue<undefined>>;
@@ -106,7 +106,7 @@ const isUsableProperty = <T>(
 
 /**
  * Creates a proxy for AsyncStream instances that only exposes the next, end,
- * and return methods, the isDone property, and the async iterator.
+ * return, isDone, and the async iterator.
  */
 export function createAsyncStreamProxy<T>(stream: AsyncStream<T>) {
   return new Proxy(stream, {

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -10,7 +10,11 @@ import type { Client } from "@/Client";
 import { DecodedMessage } from "@/DecodedMessage";
 import { nsToDate } from "@/utils/date";
 import { MissingContentTypeError } from "@/utils/errors";
-import { createStream, type StreamOptions } from "@/utils/streams";
+import {
+  createStream,
+  type StreamCallback,
+  type StreamOptions,
+} from "@/utils/streams";
 
 /**
  * Represents a conversation
@@ -114,7 +118,13 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Stream instance for new messages
    */
   stream(options?: StreamOptions<Message, DecodedMessage<ContentTypes>>) {
-    const stream = this.#conversation.stream.bind(this.#conversation);
+    const stream = async (
+      callback: StreamCallback<Message>,
+      onFail: () => void,
+    ) => {
+      await this.sync();
+      return this.#conversation.stream(callback, onFail);
+    };
     const convertMessage = (value: Message) => {
       return new DecodedMessage(this.#client, value);
     };

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -6,11 +6,11 @@ import type {
   Message,
   Conversation as XmtpConversation,
 } from "@xmtp/node-bindings";
-import { AsyncStream, type StreamCallback } from "@/AsyncStream";
 import type { Client } from "@/Client";
 import { DecodedMessage } from "@/DecodedMessage";
 import { nsToDate } from "@/utils/date";
 import { MissingContentTypeError } from "@/utils/errors";
+import { createStream, type StreamOptions } from "@/utils/streams";
 
 /**
  * Represents a conversation
@@ -113,36 +113,13 @@ export class Conversation<ContentTypes = unknown> {
    * @param callback - Optional callback function for handling new stream values
    * @returns Stream instance for new messages
    */
-  stream(
-    callback?: StreamCallback<DecodedMessage<ContentTypes>>,
-    onFail?: () => void,
-  ) {
-    const asyncStream = new AsyncStream<DecodedMessage<ContentTypes>>();
-
-    const stream = this.#conversation.stream(
-      (error, value) => {
-        let err: Error | null = error;
-        let message: DecodedMessage<ContentTypes> | undefined;
-
-        if (value) {
-          try {
-            message = new DecodedMessage(this.#client, value);
-          } catch (error) {
-            err = error as Error;
-          }
-        }
-
-        asyncStream.callback(err, message);
-        callback?.(err, message);
-      },
-      onFail ?? (() => {}),
-    );
-
-    asyncStream.onDone = () => {
-      stream.end();
+  stream(options?: StreamOptions<Message, DecodedMessage<ContentTypes>>) {
+    const stream = this.#conversation.stream.bind(this.#conversation);
+    const convertMessage = (value: Message) => {
+      return new DecodedMessage(this.#client, value);
     };
 
-    return asyncStream;
+    return createStream(stream, convertMessage, options);
   }
 
   /**

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -114,7 +114,7 @@ export class Conversation<ContentTypes = unknown> {
   /**
    * Creates a stream for new messages in this conversation
    *
-   * @param callback - Optional callback function for handling new stream values
+   * @param options - Optional stream options
    * @returns Stream instance for new messages
    */
   stream(options?: StreamOptions<Message, DecodedMessage<ContentTypes>>) {

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -117,7 +117,7 @@ export class Conversation<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @returns Stream instance for new messages
    */
-  stream(options?: StreamOptions<Message, DecodedMessage<ContentTypes>>) {
+  async stream(options?: StreamOptions<Message, DecodedMessage<ContentTypes>>) {
     const stream = async (
       callback: StreamCallback<Message>,
       onFail: () => void,

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -250,7 +250,7 @@ export class Conversations<ContentTypes = unknown> {
    * Creates a stream for new conversations
    *
    * @param options - Optional stream options
-   * @param conversationType - Optional conversation type to filter by
+   * @param options.conversationType - Optional conversation type to filter by
    * @returns Stream instance for new conversations
    */
   async stream(
@@ -342,8 +342,8 @@ export class Conversations<ContentTypes = unknown> {
    * Creates a stream for all new messages
    *
    * @param options - Optional stream options
-   * @param conversationType - Optional conversation type to filter by
-   * @param consentStates - Optional consent states to filter by
+   * @param options.conversationType - Optional conversation type to filter by
+   * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new messages
    */
   async streamAllMessages(
@@ -375,7 +375,7 @@ export class Conversations<ContentTypes = unknown> {
    * Creates a stream for all new group messages
    *
    * @param options - Optional stream options
-   * @param consentStates - Optional consent states to filter by
+   * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new group messages
    */
   async streamAllGroupMessages(
@@ -394,7 +394,7 @@ export class Conversations<ContentTypes = unknown> {
    * Creates a stream for all new DM messages
    *
    * @param options - Optional stream options
-   * @param consentStates - Optional consent states to filter by
+   * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new DM messages
    */
   async streamAllDmMessages(

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -384,7 +384,7 @@ export class Conversations<ContentTypes = unknown> {
     },
   ) {
     return this.streamAllMessages({
-      ...options,
+      ...(options ?? {}),
       conversationType: ConversationType.Group,
       consentStates: options?.consentStates,
     });
@@ -403,7 +403,7 @@ export class Conversations<ContentTypes = unknown> {
     },
   ) {
     return this.streamAllMessages({
-      ...options,
+      ...(options ?? {}),
       conversationType: ConversationType.Dm,
       consentStates: options?.consentStates,
     });

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -249,7 +249,8 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for new conversations
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
+   * @param conversationType - Optional conversation type to filter by
    * @returns Stream instance for new conversations
    */
   stream(
@@ -287,7 +288,7 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for new group conversations
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
    * @returns Stream instance for new group conversations
    */
   streamGroups(options?: StreamOptions<Conversation, Group<ContentTypes>>) {
@@ -312,7 +313,7 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for new DM conversations
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
    * @returns Stream instance for new DM conversations
    */
   streamDms(options?: StreamOptions<Conversation, Dm<ContentTypes>>) {
@@ -333,7 +334,9 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for all new messages
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
+   * @param conversationType - Optional conversation type to filter by
+   * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new messages
    */
   streamAllMessages(
@@ -363,7 +366,8 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for all new group messages
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
+   * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new group messages
    */
   streamAllGroupMessages(
@@ -380,7 +384,8 @@ export class Conversations<ContentTypes = unknown> {
   /**
    * Creates a stream for all new DM messages
    *
-   * @param callback - Optional callback function for handling new stream value
+   * @param options - Optional stream options
+   * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new DM messages
    */
   streamAllDmMessages(

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -257,15 +257,20 @@ export class Conversations<ContentTypes = unknown> {
     options?: StreamOptions<
       Conversation,
       Group<ContentTypes> | Dm<ContentTypes> | undefined
-    >,
-    conversationType?: ConversationType,
+    > & {
+      conversationType?: ConversationType;
+    },
   ) {
     const stream = async (
       callback: StreamCallback<Conversation>,
       onFail: () => void,
     ) => {
       await this.sync();
-      return this.#conversations.stream(callback, onFail, conversationType);
+      return this.#conversations.stream(
+        callback,
+        onFail,
+        options?.conversationType,
+      );
     };
     const convertConversation = async (value: Conversation) => {
       const metadata = await value.groupMetadata();
@@ -342,9 +347,10 @@ export class Conversations<ContentTypes = unknown> {
    * @returns Stream instance for new messages
    */
   async streamAllMessages(
-    options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
-    conversationType?: ConversationType,
-    consentStates?: ConsentState[],
+    options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
+      conversationType?: ConversationType;
+      consentStates?: ConsentState[];
+    },
   ) {
     const streamAllMessages = async (
       callback: StreamCallback<Message>,
@@ -354,8 +360,8 @@ export class Conversations<ContentTypes = unknown> {
       return this.#conversations.streamAllMessages(
         callback,
         onFail,
-        conversationType,
-        consentStates,
+        options?.conversationType,
+        options?.consentStates,
       );
     };
     const convertMessage = (value: Message) => {
@@ -373,14 +379,15 @@ export class Conversations<ContentTypes = unknown> {
    * @returns Stream instance for new group messages
    */
   async streamAllGroupMessages(
-    options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
-    consentStates?: ConsentState[],
+    options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
+      consentStates?: ConsentState[];
+    },
   ) {
-    return this.streamAllMessages(
-      options,
-      ConversationType.Group,
-      consentStates,
-    );
+    return this.streamAllMessages({
+      ...options,
+      conversationType: ConversationType.Group,
+      consentStates: options?.consentStates,
+    });
   }
 
   /**
@@ -391,10 +398,15 @@ export class Conversations<ContentTypes = unknown> {
    * @returns Stream instance for new DM messages
    */
   async streamAllDmMessages(
-    options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
-    consentStates?: ConsentState[],
+    options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
+      consentStates?: ConsentState[];
+    },
   ) {
-    return this.streamAllMessages(options, ConversationType.Dm, consentStates);
+    return this.streamAllMessages({
+      ...options,
+      conversationType: ConversationType.Dm,
+      consentStates: options?.consentStates,
+    });
   }
 
   /**

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -253,7 +253,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param conversationType - Optional conversation type to filter by
    * @returns Stream instance for new conversations
    */
-  stream(
+  async stream(
     options?: StreamOptions<
       Conversation,
       Group<ContentTypes> | Dm<ContentTypes> | undefined
@@ -291,7 +291,9 @@ export class Conversations<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @returns Stream instance for new group conversations
    */
-  streamGroups(options?: StreamOptions<Conversation, Group<ContentTypes>>) {
+  async streamGroups(
+    options?: StreamOptions<Conversation, Group<ContentTypes>>,
+  ) {
     const stream = async (
       callback: StreamCallback<Conversation>,
       onFail: () => void,
@@ -316,7 +318,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @returns Stream instance for new DM conversations
    */
-  streamDms(options?: StreamOptions<Conversation, Dm<ContentTypes>>) {
+  async streamDms(options?: StreamOptions<Conversation, Dm<ContentTypes>>) {
     const stream = async (
       callback: StreamCallback<Conversation>,
       onFail: () => void,
@@ -339,7 +341,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new messages
    */
-  streamAllMessages(
+  async streamAllMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
     conversationType?: ConversationType,
     consentStates?: ConsentState[],
@@ -370,7 +372,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new group messages
    */
-  streamAllGroupMessages(
+  async streamAllGroupMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
     consentStates?: ConsentState[],
   ) {
@@ -388,7 +390,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param consentStates - Optional consent states to filter by
    * @returns Stream instance for new DM messages
    */
-  streamAllDmMessages(
+  async streamAllDmMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>>,
     consentStates?: ConsentState[],
   ) {

--- a/sdks/node-sdk/src/Preferences.ts
+++ b/sdks/node-sdk/src/Preferences.ts
@@ -4,7 +4,11 @@ import type {
   ConsentEntityType,
   Conversations,
 } from "@xmtp/node-bindings";
-import { AsyncStream, type StreamCallback } from "@/AsyncStream";
+import {
+  createStream,
+  type StreamFunction,
+  type StreamOptions,
+} from "@/utils/streams";
 
 export type PreferenceUpdate = {
   type: string;
@@ -101,28 +105,11 @@ export class Preferences {
    * @param callback - Optional callback function for handling stream updates
    * @returns Stream instance for consent updates
    */
-  streamConsent(callback?: StreamCallback<Consent[]>, onFail?: () => void) {
-    const asyncStream = new AsyncStream<Consent[]>();
-
-    const stream = this.#conversations.streamConsent(
-      (err, value) => {
-        if (err) {
-          asyncStream.callback(err, undefined);
-          callback?.(err, undefined);
-          return;
-        }
-
-        asyncStream.callback(null, value);
-        callback?.(null, value);
-      },
-      onFail ?? (() => {}),
+  streamConsent(options?: StreamOptions<Consent[]>) {
+    const streamConsent = this.#conversations.streamConsent.bind(
+      this.#conversations,
     );
-
-    asyncStream.onDone = () => {
-      stream.end();
-    };
-
-    return asyncStream;
+    return createStream(streamConsent, undefined, options);
   }
 
   /**
@@ -131,31 +118,10 @@ export class Preferences {
    * @param callback - Optional callback function for handling stream updates
    * @returns Stream instance for preference updates
    */
-  streamPreferences(
-    callback?: StreamCallback<PreferenceUpdate>,
-    onFail?: () => void,
-  ) {
-    const asyncStream = new AsyncStream<PreferenceUpdate>();
-
-    const stream = this.#conversations.streamPreferences(
-      (err, value) => {
-        if (err) {
-          asyncStream.callback(err, undefined);
-          callback?.(err, undefined);
-          return;
-        }
-
-        // TODO: remove this once the node bindings type is updated
-        asyncStream.callback(null, value as unknown as PreferenceUpdate);
-        callback?.(null, value as unknown as PreferenceUpdate);
-      },
-      onFail ?? (() => {}),
-    );
-
-    asyncStream.onDone = () => {
-      stream.end();
-    };
-
-    return asyncStream;
+  streamPreferences(options?: StreamOptions<PreferenceUpdate>) {
+    const streamPreferences = this.#conversations.streamPreferences.bind(
+      this.#conversations,
+    ) as StreamFunction<PreferenceUpdate>;
+    return createStream(streamPreferences, undefined, options);
   }
 }

--- a/sdks/node-sdk/src/Preferences.ts
+++ b/sdks/node-sdk/src/Preferences.ts
@@ -119,7 +119,7 @@ export class Preferences {
   /**
    * Creates a stream of user preference updates
    *
-   * @param callback - Optional callback function for handling stream updates
+   * @param options - Optional stream options
    * @returns Stream instance for preference updates
    */
   streamPreferences(options?: StreamOptions<PreferenceUpdate>) {

--- a/sdks/node-sdk/src/Preferences.ts
+++ b/sdks/node-sdk/src/Preferences.ts
@@ -102,7 +102,7 @@ export class Preferences {
   /**
    * Creates a stream of consent state updates
    *
-   * @param callback - Optional callback function for handling stream updates
+   * @param options - Optional stream options
    * @returns Stream instance for consent updates
    */
   streamConsent(options?: StreamOptions<Consent[]>) {

--- a/sdks/node-sdk/src/Preferences.ts
+++ b/sdks/node-sdk/src/Preferences.ts
@@ -6,7 +6,7 @@ import type {
 } from "@xmtp/node-bindings";
 import {
   createStream,
-  type StreamFunction,
+  type StreamCallback,
   type StreamOptions,
 } from "@/utils/streams";
 
@@ -106,9 +106,13 @@ export class Preferences {
    * @returns Stream instance for consent updates
    */
   streamConsent(options?: StreamOptions<Consent[]>) {
-    const streamConsent = this.#conversations.streamConsent.bind(
-      this.#conversations,
-    );
+    const streamConsent = async (
+      callback: StreamCallback<Consent[]>,
+      onFail: () => void,
+    ) => {
+      await this.sync();
+      return this.#conversations.streamConsent(callback, onFail);
+    };
     return createStream(streamConsent, undefined, options);
   }
 
@@ -119,9 +123,13 @@ export class Preferences {
    * @returns Stream instance for preference updates
    */
   streamPreferences(options?: StreamOptions<PreferenceUpdate>) {
-    const streamPreferences = this.#conversations.streamPreferences.bind(
-      this.#conversations,
-    ) as StreamFunction<PreferenceUpdate>;
+    const streamPreferences = async (
+      callback: StreamCallback<PreferenceUpdate>,
+      onFail: () => void,
+    ) => {
+      await this.sync();
+      return this.#conversations.streamPreferences(callback, onFail);
+    };
     return createStream(streamPreferences, undefined, options);
   }
 }

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -59,4 +59,4 @@ export {
 export { generateInboxId, getInboxIdForIdentifier } from "./utils/inboxId";
 export type { Signer } from "./utils/signer";
 export * from "./utils/errors";
-export * from "./utils/streams";
+export type * from "./utils/streams";

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -14,7 +14,7 @@ export { Dm } from "./Dm";
 export { Group } from "./Group";
 export type { PreferenceUpdate } from "./Preferences";
 export { DecodedMessage } from "./DecodedMessage";
-export type { AsyncStream, StreamCallback } from "./AsyncStream";
+export type { AsyncStreamProxy } from "./AsyncStream";
 export type {
   Consent,
   ContentType,
@@ -59,3 +59,4 @@ export {
 export { generateInboxId, getInboxIdForIdentifier } from "./utils/inboxId";
 export type { Signer } from "./utils/signer";
 export * from "./utils/errors";
+export * from "./utils/streams";

--- a/sdks/node-sdk/src/utils/errors.ts
+++ b/sdks/node-sdk/src/utils/errors.ts
@@ -47,3 +47,16 @@ export class ClientNotInitializedError extends Error {
     );
   }
 }
+
+export class StreamFailedError extends Error {
+  constructor(retryAttempts: number) {
+    const times = `time${retryAttempts !== 1 ? "s" : ""}`;
+    super(`Stream failed, retried ${retryAttempts} ${times}`);
+  }
+}
+
+export class StreamInvalidRetryAttemptsError extends Error {
+  constructor() {
+    super("Stream retry attempts must be greater than 0");
+  }
+}

--- a/sdks/node-sdk/src/utils/streams.ts
+++ b/sdks/node-sdk/src/utils/streams.ts
@@ -107,16 +107,20 @@ export const createStream = async <T = unknown, V = T>(
       return;
     }
     // ensure the value is not undefined
-    if (value) {
+    if (value !== undefined) {
       try {
         // if a streamValueMutator is provided, mutate the value
         if (streamValueMutator) {
           const mutatedValue = streamValueMutator(value);
           if (isPromise(mutatedValue)) {
-            void mutatedValue.then((mutatedValue) => {
-              asyncStream.push(mutatedValue);
-              onValue?.(mutatedValue);
-            });
+            void mutatedValue
+              .then((mutatedValue) => {
+                asyncStream.push(mutatedValue);
+                onValue?.(mutatedValue);
+              })
+              .catch((error: unknown) => {
+                onError?.(error as Error);
+              });
           } else {
             asyncStream.push(mutatedValue);
             onValue?.(mutatedValue);

--- a/sdks/node-sdk/src/utils/streams.ts
+++ b/sdks/node-sdk/src/utils/streams.ts
@@ -3,8 +3,7 @@ import type { StreamCloser } from "@xmtp/node-bindings";
 import { AsyncStream, createAsyncStreamProxy } from "@/AsyncStream";
 import { StreamFailedError, StreamInvalidRetryAttemptsError } from "./errors";
 
-export const wait = (ms: number) =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const DEFAULT_RETRY_DELAY = 10000; // milliseconds
 export const DEFAULT_RETRY_ATTEMPTS = 6;

--- a/sdks/node-sdk/src/utils/streams.ts
+++ b/sdks/node-sdk/src/utils/streams.ts
@@ -14,7 +14,7 @@ export type StreamOptions<T = unknown, V = T> = {
    */
   onEnd?: () => void;
   /**
-   * Called when a streamerror occurs
+   * Called when a stream error occurs
    */
   onError?: (error: Error) => void;
   /**
@@ -35,14 +35,17 @@ export type StreamOptions<T = unknown, V = T> = {
   onValue?: (value: V) => void;
   /**
    * The number of times to retry the stream
+   * (default: 6)
    */
   retryAttempts?: number;
   /**
-   * The delay between retries
+   * The delay between retries (in milliseconds)
+   * (default: 10000)
    */
   retryDelay?: number;
   /**
    * Whether to retry the stream if it fails
+   * (default: true)
    */
   retryOnFail?: boolean;
 };

--- a/sdks/node-sdk/src/utils/streams.ts
+++ b/sdks/node-sdk/src/utils/streams.ts
@@ -1,0 +1,197 @@
+import { isPromise } from "node:util/types";
+import type { StreamCloser } from "@xmtp/node-bindings";
+import { AsyncStream, createAsyncStreamProxy } from "@/AsyncStream";
+import { StreamFailedError, StreamInvalidRetryAttemptsError } from "./errors";
+
+export const wait = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export const DEFAULT_RETRY_DELAY = 10000; // milliseconds
+export const DEFAULT_RETRY_ATTEMPTS = 6;
+
+export type StreamOptions<T = unknown, V = T> = {
+  /**
+   * Called when the stream ends
+   */
+  onEnd?: () => void;
+  /**
+   * Called when a streamerror occurs
+   */
+  onError?: (error: Error) => void;
+  /**
+   * Called when the stream fails
+   */
+  onFail?: () => void;
+  /**
+   * Called when the stream is restarted
+   */
+  onRestart?: () => void;
+  /**
+   * Called when the stream is retried
+   */
+  onRetry?: (attempts: number, maxAttempts: number) => void;
+  /**
+   * Called when a value is emitted from the stream
+   */
+  onValue?: (value: V) => void;
+  /**
+   * The number of times to retry the stream
+   */
+  retryAttempts?: number;
+  /**
+   * The delay between retries
+   */
+  retryDelay?: number;
+  /**
+   * Whether to retry the stream if it fails
+   */
+  retryOnFail?: boolean;
+};
+
+export type StreamCallback<T = unknown> = (
+  error: Error | null,
+  value: T | undefined,
+) => void;
+
+export type StreamFunction<T = unknown, A extends unknown[] = []> = (
+  callback: StreamCallback<T>,
+  onFail: () => void,
+  ...args: A
+) => StreamCloser;
+
+export type StreamValueMutator<T = unknown, V = T> = (
+  value: T,
+) => V | Promise<V>;
+
+/**
+ * Creates a stream from a stream function
+ *
+ * If the stream fails, an attempt will be made to restart it.
+ *
+ * @param streamFunction - The stream function to create a stream from
+ * @param streamValueMutator - An optional function to mutate the value emitted from the stream
+ * @param options - The options for the stream
+ * @param args - Additional arguments to pass to the stream function
+ * @returns An async iterable stream proxy
+ * @throws {StreamInvalidRetryAttemptsError} if the retryAttempts option is less than 0 and retryOnFail is true
+ * @throws {StreamFailedError} if the stream fails and can't be restarted
+ */
+export const createStream = <T = unknown, V = T, A extends unknown[] = []>(
+  streamFunction: StreamFunction<T, A>,
+  streamValueMutator?: StreamValueMutator<T, V>,
+  options?: StreamOptions<T, V>,
+  ...args: A
+) => {
+  const {
+    onError,
+    onFail,
+    onRestart,
+    onRetry,
+    onValue,
+    retryAttempts = DEFAULT_RETRY_ATTEMPTS,
+    retryDelay = DEFAULT_RETRY_DELAY,
+    retryOnFail = true,
+  } = options ?? {};
+  // retry attempts must be greater than 0
+  if (retryOnFail && retryAttempts < 0) {
+    throw new StreamInvalidRetryAttemptsError();
+  }
+
+  let streamCloser: StreamCloser | undefined;
+  const asyncStream = new AsyncStream<V>();
+  const streamCallback: StreamCallback<T> = (error, value) => {
+    // if a stream error occurs, call the onError callback
+    if (error) {
+      onError?.(error);
+      return;
+    }
+    // ensure the value is not undefined
+    if (value) {
+      try {
+        // if a streamValueMutator is provided, mutate the value
+        if (streamValueMutator) {
+          const mutatedValue = streamValueMutator(value);
+          if (isPromise(mutatedValue)) {
+            void mutatedValue.then((mutatedValue) => {
+              asyncStream.push(mutatedValue);
+              onValue?.(mutatedValue);
+            });
+          } else {
+            asyncStream.push(mutatedValue);
+            onValue?.(mutatedValue);
+          }
+        } else {
+          asyncStream.push(value as unknown as V);
+          onValue?.(value as unknown as V);
+        }
+      } catch (error) {
+        onError?.(error as Error);
+      }
+    }
+  };
+  const retry = (retries: number = retryAttempts) => {
+    // if the stream has been retried the maximum number of times without
+    // success, throw an error
+    if (retries === 0) {
+      throw new StreamFailedError(retryAttempts);
+    }
+
+    // wait for the retry delay before attempting to restart the stream
+    void wait(retryDelay).then(() => {
+      // call the onRetry callback
+      onRetry?.(retryAttempts - retries + 1, retryAttempts);
+      // attempt to restart the stream
+      try {
+        streamCloser = streamFunction(
+          streamCallback,
+          () => {
+            onFail?.();
+            if (retryOnFail) {
+              retry();
+            } else {
+              throw new StreamFailedError(0);
+            }
+          },
+          ...args,
+        );
+        asyncStream.onDone = () => {
+          streamCloser?.end();
+        };
+        onRestart?.();
+      } catch (error) {
+        onError?.(error as Error);
+        // restart failed, try again
+        retry(retries - 1);
+      }
+    });
+  };
+
+  // create the stream
+  streamCloser = streamFunction(
+    streamCallback,
+    () => {
+      // end the current stream
+      streamCloser?.end();
+
+      // call the onFail callback
+      onFail?.();
+
+      // if the stream should be retried, start the process
+      if (retryOnFail) {
+        retry();
+      } else {
+        // stream failed and should not be retried, throw an error
+        throw new StreamFailedError(0);
+      }
+    },
+    ...args,
+  );
+
+  // when the async stream is done, end the stream
+  asyncStream.onDone = () => {
+    streamCloser?.end();
+  };
+
+  // return a proxy for the async stream
+  return createAsyncStreamProxy(asyncStream);
+};

--- a/sdks/node-sdk/test/AsyncStream.test.ts
+++ b/sdks/node-sdk/test/AsyncStream.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { AsyncStream } from "@/AsyncStream";
+import { AsyncStream, createAsyncStreamProxy } from "@/AsyncStream";
 
 const testError = new Error("test");
 
@@ -338,5 +338,241 @@ describe("AsyncStream", () => {
 
     const finalResult = await stream.next();
     expect(finalResult).toEqual({ done: true, value: undefined });
+  });
+});
+
+describe("createAsyncStreamProxy", () => {
+  it("should only expose allowed methods and properties", () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    expect(typeof proxy.next).toBe("function");
+    expect(typeof proxy.end).toBe("function");
+    expect(typeof proxy.return).toBe("function");
+    expect(typeof proxy[Symbol.asyncIterator]).toBe("function");
+
+    const ownProperties = Object.getOwnPropertyNames(proxy);
+    expect(ownProperties).toHaveLength(4);
+    expect(ownProperties).toContain("end");
+    expect(ownProperties).toContain("isDone");
+    expect(ownProperties).toContain("next");
+    expect(ownProperties).toContain("return");
+  });
+
+  it("should prevent setting properties", () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    // this will fail silently
+    proxy.isDone = true;
+
+    expect(proxy.isDone).toBe(false);
+  });
+
+  it("should correctly forward next() calls to the underlying stream", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    stream.callback(null, 1);
+    stream.callback(null, 2);
+
+    const result1 = await proxy.next();
+    const result2 = await proxy.next();
+
+    expect(result1).toEqual({ done: false, value: 1 });
+    expect(result2).toEqual({ done: false, value: 2 });
+  });
+
+  it("should correctly forward end() calls to the underlying stream", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+    const onDoneSpy = vi.fn();
+
+    stream.onDone = onDoneSpy;
+
+    const result = await proxy.end();
+
+    expect(result).toEqual({ done: true, value: undefined });
+    expect(onDoneSpy).toHaveBeenCalledOnce();
+    expect(stream.isDone).toBe(true);
+    expect(proxy.isDone).toBe(true);
+  });
+
+  it("should correctly forward return() calls to the underlying stream", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+    const onReturnSpy = vi.fn();
+
+    stream.onReturn = onReturnSpy;
+
+    const result = await proxy.return(42);
+
+    expect(result).toEqual({ done: true, value: 42 });
+    expect(onReturnSpy).toHaveBeenCalledOnce();
+    expect(stream.isDone).toBe(true);
+    expect(proxy.isDone).toBe(true);
+  });
+
+  it("should maintain async iterator functionality", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    stream.callback(null, 1);
+    stream.callback(null, 2);
+    stream.callback(null, 3);
+
+    const values: (number | undefined)[] = [];
+    let iterationCount = 0;
+
+    for await (const value of proxy) {
+      values.push(value);
+      iterationCount++;
+
+      if (iterationCount === 3) {
+        break;
+      }
+    }
+
+    expect(values).toEqual([1, 2, 3]);
+    expect(stream.isDone).toBe(true);
+    expect(proxy.isDone).toBe(true);
+  });
+
+  it("should handle errors in async iteration", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    stream.callback(null, 1);
+    stream.callback(testError, 2);
+
+    const values: (number | undefined)[] = [];
+
+    try {
+      for await (const value of proxy) {
+        values.push(value);
+      }
+    } catch (error) {
+      expect(error).toBe(testError);
+    }
+
+    expect(values).toEqual([1]);
+    expect(stream.isDone).toBe(true);
+    expect(proxy.isDone).toBe(true);
+  });
+
+  it("should correctly implement has() trap", () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    expect("isDone" in proxy).toBe(true);
+    expect("next" in proxy).toBe(true);
+    expect("end" in proxy).toBe(true);
+    expect("return" in proxy).toBe(true);
+    expect(Symbol.asyncIterator in proxy).toBe(true);
+
+    expect("callback" in proxy).toBe(false);
+    expect("error" in proxy).toBe(false);
+    expect("onDone" in proxy).toBe(false);
+    expect("onError" in proxy).toBe(false);
+    expect("onReturn" in proxy).toBe(false);
+    expect("nonExistentProperty" in proxy).toBe(false);
+  });
+
+  it("should correctly implement ownKeys() trap", () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    const keys = Object.getOwnPropertyNames(proxy);
+    const symbols = Object.getOwnPropertySymbols(proxy);
+
+    expect(keys).toHaveLength(4);
+    expect(keys).toContain("next");
+    expect(keys).toContain("end");
+    expect(keys).toContain("return");
+    expect(keys).toContain("isDone");
+    expect(symbols).toHaveLength(1);
+    expect(symbols).toContain(Symbol.asyncIterator);
+  });
+
+  it("should correctly implement getOwnPropertyDescriptor() trap", () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    const nextDescriptor = Object.getOwnPropertyDescriptor(proxy, "next");
+    expect(nextDescriptor).toBeDefined();
+    expect(nextDescriptor?.enumerable).toBe(true);
+    expect(nextDescriptor?.configurable).toBe(true);
+    expect(typeof nextDescriptor?.value).toBe("function");
+
+    const endDescriptor = Object.getOwnPropertyDescriptor(proxy, "end");
+    expect(endDescriptor).toBeDefined();
+    expect(endDescriptor?.enumerable).toBe(true);
+    expect(endDescriptor?.configurable).toBe(true);
+    expect(typeof endDescriptor?.value).toBe("function");
+
+    const returnDescriptor = Object.getOwnPropertyDescriptor(proxy, "return");
+    expect(returnDescriptor).toBeDefined();
+    expect(returnDescriptor?.enumerable).toBe(true);
+    expect(returnDescriptor?.configurable).toBe(true);
+    expect(typeof returnDescriptor?.value).toBe("function");
+
+    const asyncIteratorDescriptor = Object.getOwnPropertyDescriptor(
+      proxy,
+      Symbol.asyncIterator,
+    );
+    expect(asyncIteratorDescriptor).toBeDefined();
+    expect(asyncIteratorDescriptor?.enumerable).toBe(true);
+    expect(asyncIteratorDescriptor?.configurable).toBe(true);
+    expect(typeof asyncIteratorDescriptor?.value).toBe("function");
+
+    // Non-exposed properties should return undefined
+    const callbackDescriptor = Object.getOwnPropertyDescriptor(
+      proxy,
+      "callback",
+    );
+    expect(callbackDescriptor).toBeUndefined();
+
+    const isDoneDescriptor = Object.getOwnPropertyDescriptor(proxy, "isDone");
+    expect(isDoneDescriptor).toBeDefined();
+    expect(isDoneDescriptor?.enumerable).toBe(true);
+    expect(isDoneDescriptor?.configurable).toBe(true);
+    expect(typeof isDoneDescriptor?.value).toBe("boolean");
+  });
+
+  it("should handle concurrent operations through proxy", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    const nextPromise1 = proxy.next();
+    const nextPromise2 = proxy.next();
+    const nextPromise3 = proxy.next();
+
+    stream.callback(null, 1);
+    stream.callback(null, 2);
+    stream.callback(null, 3);
+
+    const [result1, result2, result3] = await Promise.all([
+      nextPromise1,
+      nextPromise2,
+      nextPromise3,
+    ]);
+
+    expect(result1).toEqual({ done: false, value: 1 });
+    expect(result2).toEqual({ done: false, value: 2 });
+    expect(result3).toEqual({ done: false, value: 3 });
+  });
+
+  it("should work correctly when stream is already done", async () => {
+    const stream = new AsyncStream<number>();
+    const proxy = createAsyncStreamProxy(stream);
+
+    stream.callback(null, 1);
+    await proxy.end();
+
+    const result1 = await proxy.next();
+    const result2 = await proxy.next();
+
+    expect(result1).toEqual({ done: true, value: undefined });
+    expect(result2).toEqual({ done: true, value: undefined });
   });
 });

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -400,7 +400,7 @@ describe("Conversation", () => {
     expect(conversation2[0].id).toBe(conversation.id);
 
     const streamedMessages: unknown[] = [];
-    const stream = conversation2[0].stream({
+    const stream = await conversation2[0].stream({
       onValue: (message) => {
         streamedMessages.push(message.content);
       },

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -400,23 +400,28 @@ describe("Conversation", () => {
     expect(conversation2[0].id).toBe(conversation.id);
 
     const streamedMessages: unknown[] = [];
-    const stream = conversation2[0].stream((_, message) => {
-      streamedMessages.push(message!.content);
+    const stream = conversation2[0].stream({
+      onValue: (message) => {
+        streamedMessages.push(message.content);
+      },
     });
 
     await conversation.send("gm");
     await conversation.send("gm2");
+
+    setTimeout(() => {
+      void stream.end();
+    }, 100);
 
     let count = 0;
     for await (const message of stream) {
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
-        expect(message!.content).toBe("gm");
+        expect(message.content).toBe("gm");
       }
       if (count === 2) {
-        expect(message!.content).toBe("gm2");
-        break;
+        expect(message.content).toBe("gm2");
       }
     }
 

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -406,7 +406,7 @@ describe("Conversations", () => {
     const client1 = await createRegisteredClient(signer1);
     const client2 = await createRegisteredClient(signer2);
     const client3 = await createRegisteredClient(signer3);
-    const stream = client3.conversations.stream();
+    const stream = await client3.conversations.stream();
     const conversation1 = await client1.conversations.newGroup([
       client3.inboxId,
     ]);
@@ -454,7 +454,7 @@ describe("Conversations", () => {
     const client2 = await createRegisteredClient(signer2);
     const client3 = await createRegisteredClient(signer3);
     const client4 = await createRegisteredClient(signer4);
-    const stream = client3.conversations.streamGroups();
+    const stream = await client3.conversations.streamGroups();
     await client4.conversations.newDm(client3.inboxId);
     const group1 = await client1.conversations.newGroup([client3.inboxId]);
     const group2 = await client2.conversations.newGroup([client3.inboxId]);
@@ -490,7 +490,7 @@ describe("Conversations", () => {
     const client2 = await createRegisteredClient(signer2);
     const client3 = await createRegisteredClient(signer3);
     const client4 = await createRegisteredClient(signer4);
-    const stream = client3.conversations.streamDms();
+    const stream = await client3.conversations.streamDms();
     await client1.conversations.newGroup([client3.inboxId]);
     await client2.conversations.newGroup([client3.inboxId]);
     const group3 = await client4.conversations.newDm(client3.inboxId);

--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -415,7 +415,7 @@ describe("Conversations", () => {
     ]);
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
@@ -460,14 +460,11 @@ describe("Conversations", () => {
     const group2 = await client2.conversations.newGroup([client3.inboxId]);
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const convo of stream) {
-      if (convo === undefined) {
-        break;
-      }
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
@@ -499,14 +496,11 @@ describe("Conversations", () => {
     const group3 = await client4.conversations.newDm(client3.inboxId);
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const convo of stream) {
-      if (convo === undefined) {
-        break;
-      }
       count++;
       expect(convo).toBeDefined();
       if (count === 1) {
@@ -541,14 +535,11 @@ describe("Conversations", () => {
     await groups3[0].send("gm2!");
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const message of stream) {
-      if (message === undefined) {
-        break;
-      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
@@ -597,14 +588,11 @@ describe("Conversations", () => {
     await groupsList3[0].send("gm2!");
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const message of stream) {
-      if (message === undefined) {
-        break;
-      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {
@@ -653,14 +641,11 @@ describe("Conversations", () => {
     await groupsList4[0].send("gm3!");
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const message of stream) {
-      if (message === undefined) {
-        break;
-      }
       count++;
       expect(message).toBeDefined();
       if (count === 1) {

--- a/sdks/node-sdk/test/Preferences.test.ts
+++ b/sdks/node-sdk/test/Preferences.test.ts
@@ -149,14 +149,11 @@ describe("Preferences", () => {
     ]);
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const updates of stream) {
-      if (updates === undefined) {
-        break;
-      }
       count++;
       if (count === 1) {
         expect(updates.length).toBe(1);
@@ -205,14 +202,11 @@ describe("Preferences", () => {
     await sleep(2000);
 
     setTimeout(() => {
-      stream.callback(null, undefined);
+      void stream.end();
     }, 2000);
 
     let count = 0;
     for await (const preferences of stream) {
-      if (preferences === undefined) {
-        break;
-      }
       count++;
       expect(preferences).toBeDefined();
       expect(preferences.type).toBeDefined();

--- a/sdks/node-sdk/test/Preferences.test.ts
+++ b/sdks/node-sdk/test/Preferences.test.ts
@@ -120,7 +120,7 @@ describe("Preferences", () => {
     const client = await createRegisteredClient(signer);
     const client2 = await createRegisteredClient(signer2);
     const group = await client.conversations.newGroup([client2.inboxId]);
-    const stream = client.preferences.streamConsent();
+    const stream = await client.preferences.streamConsent();
 
     await sleep(1000);
     group.updateConsentState(ConsentState.Denied);
@@ -182,7 +182,7 @@ describe("Preferences", () => {
     const user = createUser();
     const signer = createSigner(user);
     const client = await createRegisteredClient(signer);
-    const stream = client.preferences.streamPreferences();
+    const stream = await client.preferences.streamPreferences();
 
     await sleep(2000);
 

--- a/sdks/node-sdk/test/Preferences.test.ts
+++ b/sdks/node-sdk/test/Preferences.test.ts
@@ -122,10 +122,10 @@ describe("Preferences", () => {
     const group = await client.conversations.newGroup([client2.inboxId]);
     const stream = client.preferences.streamConsent();
 
+    await sleep(1000);
     group.updateConsentState(ConsentState.Denied);
 
     await sleep(1000);
-
     await client.preferences.setConsentStates([
       {
         entity: group.id,


### PR DESCRIPTION
# Summary

This PR contains **BREAKING CHANGES** for all streaming methods in the Node SDK.

### Single parameter for streaming methods

All streaming methods now accept a single parameter that defines streaming options. These new options add more callbacks and options for retrying failed streams.

```ts
type StreamOptions<T = unknown, V = T> = {
  /**
   * Called when the stream ends
   */
  onEnd?: () => void;
  /**
   * Called when a stream error occurs
   */
  onError?: (error: Error) => void;
  /**
   * Called when the stream fails
   */
  onFail?: () => void;
  /**
   * Called when the stream is restarted
   */
  onRestart?: () => void;
  /**
   * Called when the stream is retried
   */
  onRetry?: (attempts: number, maxAttempts: number) => void;
  /**
   * Called when a value is emitted from the stream
   */
  onValue?: (value: V) => void;
  /**
   * The number of times to retry the stream
   * (default: 6)
   */
  retryAttempts?: number;
  /**
   * The delay between retries (in milliseconds)
   * (default: 10000)
   */
  retryDelay?: number;
  /**
   * Whether to retry the stream if it fails
   * (default: true)
   */
  retryOnFail?: boolean;
}
```

In addition to these options, some streaming methods have more options. See their respective types for more details.

### Streams no longer end on error

When a stream error occurs, it's passed to the `onError` callback only. The stream will remain active.

### Stream types have changed

When using the `for await..of` loop, the value will never be `undefined`.
