### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -38,7 +38,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -63,7 +63,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/content-types.yml
+++ b/.github/workflows/content-types.yml
@@ -21,7 +21,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -39,7 +39,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -61,7 +61,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -20,7 +20,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -38,7 +38,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
@@ -60,7 +60,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,7 +12,7 @@ jobs:
     name: Prettier
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/sync-documentation.yml
+++ b/.github/workflows/sync-documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout XMTP-JS SDK
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           path: xmtp-js
@@ -42,7 +42,7 @@ jobs:
         run: corepack enable
 
       - name: Checkout Documentation Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ env.DOCS_REPO }}
           token: ${{ secrets.DOCS_SYNC_TOKEN }}

--- a/.github/workflows/xmtp-chat.yml
+++ b/.github/workflows/xmtp-chat.yml
@@ -21,7 +21,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.

Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0