### PR TITLE
Update for Vercel compatibility

### DIFF
--- a/.github/workflows/api-service.yml
+++ b/.github/workflows/api-service.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Typecheck
         run: yarn turbo run typecheck --filter='./apps/xmtp.chat-api-service'
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Nothing to test"
+
   build:
     name: Build
     permissions:

--- a/apps/xmtp.chat-api-service/package.json
+++ b/apps/xmtp.chat-api-service/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "main": "dist/index.js",
   "scripts": {
     "build": "yarn clean:dist && rollup -c",
     "clean": "rimraf .turbo && yarn clean:dist && yarn clean:deps",

--- a/apps/xmtp.chat-api-service/rollup.config.js
+++ b/apps/xmtp.chat-api-service/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from "@rollup/plugin-typescript";
 import { defineConfig } from "rollup";
 import tsConfigPaths from "rollup-plugin-tsconfig-paths";
 
-const external = [];
+const external = ["cors", "express", "helmet", "express-rate-limit", "pinata"];
 
 const plugins = [
   tsConfigPaths(),

--- a/apps/xmtp.chat-api-service/src/index.ts
+++ b/apps/xmtp.chat-api-service/src/index.ts
@@ -76,3 +76,5 @@ process.on("SIGINT", () => {
     console.log("xmtp.chat API service closed");
   });
 });
+
+export default app;

--- a/apps/xmtp.chat-api-service/vercel.json
+++ b/apps/xmtp.chat-api-service/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "dist/index.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "dist/index.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Set the apps/xmtp.chat-api-service module entry to dist/index.js and default-export the app instance for Vercel compatibility
- Add the `"main": "dist/index.js"` field to [package.json](https://github.com/xmtp/xmtp-js/pull/1147/files#diff-a88f87896d3c4d2f71844b3d37090ff83868d0561c37d8a50f80e93392d20375).
- Declare the application instance as the module default export in [src/index.ts](https://github.com/xmtp/xmtp-js/pull/1147/files#diff-589d989d2e3a6457a59d32a9fcbb3f02ed22b1ac6a6c47202772109d0fcc7b5c).

#### 📍Where to Start
Start with the default export in [src/index.ts](https://github.com/xmtp/xmtp-js/pull/1147/files#diff-589d989d2e3a6457a59d32a9fcbb3f02ed22b1ac6a6c47202772109d0fcc7b5c).



#### Changes since #1147 opened

- Updated Rollup configuration to externalize dependencies for runtime resolution [4c28d00]
- Added Vercel deployment configuration [cb974a7]
- Added a placeholder test job to the GitHub Actions workflow [3e1593a]
----

_[Macroscope](https://app.macroscope.com) summarized 3e1593a._