### PR TITLE
Fix dist reference in Agent SDK

### DIFF
--- a/.changeset/sharp-dodos-rhyme.md
+++ b/.changeset/sharp-dodos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Fixed dist reference in Agent SDK

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -22,7 +22,7 @@
     "node": ">=20"
   },
   "files": [
-    "dist/src",
+    "dist",
     "!dist/**/*.test.*"
   ],
   "homepage": "https://github.com/xmtp/xmtp-js",


### PR DESCRIPTION
### Fix Agent SDK dist reference by configuring the `@xmtp/agent-sdk` npm package to publish the `dist` directory in `sdks/agent-sdk/package.json`
- Add a changeset marking a patch release in [sharp-dodos-rhyme.md](https://github.com/xmtp/xmtp-js/pull/1151/files#diff-3c79a5a45d3d74431fbb70ad7ea54fe0ab52998cd8cdb514bf6f4f9aa9f73fe2)
- Update the `files` entry in [package.json](https://github.com/xmtp/xmtp-js/pull/1151/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3) from `dist/src` to `dist`

#### 📍Where to Start
Start with the `files` field change in [package.json](https://github.com/xmtp/xmtp-js/pull/1151/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3).

----

_[Macroscope](https://app.macroscope.com) summarized 97ba45d._