### PR TITLE
Add path alias resolution

### DIFF
--- a/.changeset/thirty-maps-begin.md
+++ b/.changeset/thirty-maps-begin.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Added path alias resolution

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -7,6 +7,57 @@ To keep up with the latest SDK developments, see the [Issues tab](https://githu
 > [!CAUTION]
 > This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
 
+## Documentation
+
+You can learn how to build an [agent for XMTP here](https://docs.xmtp.org/agents/get-started/build-an-agent).
+
+## Install
+
+**NPM**
+
+```bash
+npm install @xmtp/node-sdk
+```
+
+**PNPM**
+
+```bash
+pnpm install @xmtp/node-sdk
+```
+
+**Yarn**
+
+```bash
+yarn add @xmtp/node-sdk
+```
+
+## Usage
+
+```ts
+import { Agent, createSigner, createUser } from "@xmtp/agent-sdk";
+
+const user = createUser();
+const signer = createSigner(user);
+
+const agent = await Agent.create(signer, {
+  dbPath: null,
+  env: "dev",
+});
+
+agent.on("message", async (ctx) => {
+  await ctx.conversation.send("Hello!");
+});
+
+agent.on("start", () => {
+  const address = agent.client.accountIdentifier?.identifier;
+  const env = agent.client.options?.env;
+  const url = `http://xmtp.chat/dm/${address}?env=${env}`;
+  console.log(`We are online: ${url}`);
+});
+
+await agent.start();
+```
+
 ## Features
 
 ### Event-driven architecture

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -13,6 +13,7 @@
     "@arethetypeswrong/cli": "^0.18.2",
     "@types/node": "^22.16.3",
     "@vitest/coverage-v8": "^3.2.4",
+    "tsc-alias": "^1.8.16",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "vite": "^7.0.4",
@@ -53,7 +54,7 @@
     "url": "git+https://git@github.com/xmtp/xmtp-js.git"
   },
   "scripts": {
-    "build": "yarn clean:dist && tsc -p tsconfig.build.json && attw --pack . --ignore-rules cjs-resolves-to-esm",
+    "build": "yarn clean:dist && tsc -p tsconfig.build.json && tsc-alias && attw --pack . --ignore-rules cjs-resolves-to-esm",
     "clean": "rm -rf .turbo && rm -rf node_modules && yarn clean:dist",
     "clean:dist": "rm -rf dist",
     "dev": "tsx --watch src/main.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3816,6 +3816,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^3.2.4"
     "@xmtp/content-type-reply": "npm:^2.0.2"
     "@xmtp/node-sdk": "npm:^4.0.3"
+    tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
     viem: "npm:^2.31.7"
@@ -4777,7 +4778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.6.0":
+"chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -4952,6 +4953,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10/90c5b6898610cd075984c58c4f88418a4fb44af08c1b1415e9854c03171bec31b336b7f3e4cefe33de994b3f12b03c5e2d638da4316df83593b9e82554e7e95b
+  languageName: node
+  linkType: hard
+
+"commander@npm:^9.0.0":
+  version: 9.5.0
+  resolution: "commander@npm:9.5.0"
+  checksum: 10/41c49b3d0f94a1fbeb0463c85b13f15aa15a9e0b4d5e10a49c0a1d58d4489b549d62262b052ae0aa6cfda53299bee487bfe337825df15e342114dde543f82906
   languageName: node
   linkType: hard
 
@@ -6433,6 +6441,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-tsconfig@npm:^4.10.0":
+  version: 4.10.1
+  resolution: "get-tsconfig@npm:4.10.1"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10/04d63f47fdecaefbd1f73ec02949be4ec4db7d6d9fbc8d4e81f9a4bb1c6f876e48943712f2f9236643d3e4d61d9a7b06da08564d08b034631ebe3f5605bef237
+  languageName: node
+  linkType: hard
+
 "get-tsconfig@npm:^4.7.5":
   version: 4.10.0
   resolution: "get-tsconfig@npm:4.10.0"
@@ -6520,7 +6537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.0":
+"globby@npm:^11.0.0, globby@npm:^11.0.4":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -7800,6 +7817,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mylas@npm:^2.1.9":
+  version: 2.1.13
+  resolution: "mylas@npm:2.1.13"
+  checksum: 10/37f335424463c422f48d50317aa0a34fe410fabb146cbf27b453a0aa743732b5626f56deaa190bca2ce29836f809d88759007976dc78d5d22b75918a00586577
+  languageName: node
+  linkType: hard
+
 "mz@npm:^2.4.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -8483,6 +8507,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plimit-lit@npm:^1.2.6":
+  version: 1.6.1
+  resolution: "plimit-lit@npm:1.6.1"
+  dependencies:
+    queue-lit: "npm:^1.5.1"
+  checksum: 10/e4eaf018dc311fd4d452954c10992cd8a9eb72d168ec2274bb831d86558422703e1405a8978ffdd5c418654e6a25e10a0765a39bf3ce3a84dc799fe6268e0ea4
+  languageName: node
+  linkType: hard
+
 "pngjs@npm:^5.0.0":
   version: 5.0.0
   resolution: "pngjs@npm:5.0.0"
@@ -8791,6 +8824,13 @@ __metadata:
     split-on-first: "npm:^1.0.0"
     strict-uri-encode: "npm:^2.0.0"
   checksum: 10/3b6f2c167e76ca4094c5f1a9eb276efcbb9ebfd8b1a28c413f3c4e4e7d6428c8187bf46c8cbc9f92a229369dd0015de10a7fd712c8cee98d5d84c2ac6140357e
+  languageName: node
+  linkType: hard
+
+"queue-lit@npm:^1.5.1":
+  version: 1.5.2
+  resolution: "queue-lit@npm:1.5.2"
+  checksum: 10/8dd45c79bd25b33b0c7d587391eb0b4acc4deb797bf92fef62b2d8e7c03b64083f5304f09d52a18267d34d020cc67ccde97a88185b67590eeccb194938ff1f98
   languageName: node
   linkType: hard
 
@@ -10217,6 +10257,23 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10/02e55b49d9617c6eebf8aadfa08d3ca03ca0cd2f0586ad34117fdfc7aa3cd25d95051843fde9df86665ad907f99baed179e7a117b11021417f379e4d2614eacd
+  languageName: node
+  linkType: hard
+
+"tsc-alias@npm:^1.8.16":
+  version: 1.8.16
+  resolution: "tsc-alias@npm:1.8.16"
+  dependencies:
+    chokidar: "npm:^3.5.3"
+    commander: "npm:^9.0.0"
+    get-tsconfig: "npm:^4.10.0"
+    globby: "npm:^11.0.4"
+    mylas: "npm:^2.1.9"
+    normalize-path: "npm:^3.0.0"
+    plimit-lit: "npm:^1.2.6"
+  bin:
+    tsc-alias: dist/bin/index.js
+  checksum: 10/a4c1988e645c0bbb993629f1cde79189549db35c2aeff7aa23bbf0864437f6dd15f91de3b51fe05cbd53e56ed32529710cc22855a8925c637357ab4c5e4f862a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Add path alias resolution to the Agent SDK build by running `tsc-alias` after `tsc -p tsconfig.build.json` and before packaging in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1155/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Update the Agent SDK build to rewrite TypeScript path aliases by adding `tsc-alias` to the build pipeline in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1155/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Rewrite and expand the Agent SDK documentation in [sdks/agent-sdk/README.md](https://github.com/xmtp/xmtp-js/pull/1155/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a)
- Refresh dependency lockfile in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1155/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to include `tsc-alias` and its dependencies

#### 📍Where to Start
Start with the `scripts.build` entry in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1155/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3) to review where `tsc-alias` is invoked between `tsc -p tsconfig.build.json` and `attw --pack`.



#### Changes since #1155 opened

- Added path alias resolution functionality to `@xmtp/agent-sdk` [a8b7d31]
----

_[Macroscope](https://app.macroscope.com) summarized a8b7d31._