### PR TITLE
Lock dependency versions

### DIFF
--- a/.changeset/six-donkeys-watch.md
+++ b/.changeset/six-donkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Locked dependency versions

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -5,11 +5,11 @@
   },
   "dependencies": {
     "@noble/curves": "^2.0.0",
-    "@xmtp/content-type-reaction": "workspace:^",
-    "@xmtp/content-type-remote-attachment": "workspace:^",
-    "@xmtp/content-type-reply": "workspace:^",
-    "@xmtp/content-type-text": "workspace:^",
-    "@xmtp/node-sdk": "workspace:^",
+    "@xmtp/content-type-reaction": "^2.0.2",
+    "@xmtp/content-type-remote-attachment": "^2.0.2",
+    "@xmtp/content-type-reply": "^2.0.2",
+    "@xmtp/content-type-text": "^2.0.2",
+    "@xmtp/node-sdk": "^4.1.0",
     "uint8arrays": "^5.1.0",
     "viem": "^2.31.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,11 +3831,11 @@ __metadata:
     "@noble/curves": "npm:^2.0.0"
     "@types/node": "npm:^22.16.3"
     "@vitest/coverage-v8": "npm:^3.2.4"
-    "@xmtp/content-type-reaction": "workspace:^"
-    "@xmtp/content-type-remote-attachment": "workspace:^"
-    "@xmtp/content-type-reply": "workspace:^"
-    "@xmtp/content-type-text": "workspace:^"
-    "@xmtp/node-sdk": "workspace:^"
+    "@xmtp/content-type-reaction": "npm:^2.0.2"
+    "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
+    "@xmtp/content-type-reply": "npm:^2.0.2"
+    "@xmtp/content-type-text": "npm:^2.0.2"
+    "@xmtp/node-sdk": "npm:^4.1.0"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.3"
     typescript: "npm:^5.8.3"
@@ -3928,7 +3928,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/content-type-reaction@workspace:^, @xmtp/content-type-reaction@workspace:content-types/content-type-reaction":
+"@xmtp/content-type-reaction@npm:^2.0.2, @xmtp/content-type-reaction@workspace:^, @xmtp/content-type-reaction@workspace:content-types/content-type-reaction":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-reaction@workspace:content-types/content-type-reaction"
   dependencies:
@@ -3965,7 +3965,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/content-type-remote-attachment@workspace:^, @xmtp/content-type-remote-attachment@workspace:content-types/content-type-remote-attachment":
+"@xmtp/content-type-remote-attachment@npm:^2.0.2, @xmtp/content-type-remote-attachment@workspace:^, @xmtp/content-type-remote-attachment@workspace:content-types/content-type-remote-attachment":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-remote-attachment@workspace:content-types/content-type-remote-attachment"
   dependencies:
@@ -3986,7 +3986,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/content-type-reply@workspace:^, @xmtp/content-type-reply@workspace:content-types/content-type-reply":
+"@xmtp/content-type-reply@npm:^2.0.2, @xmtp/content-type-reply@workspace:^, @xmtp/content-type-reply@workspace:content-types/content-type-reply":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-reply@workspace:content-types/content-type-reply"
   dependencies:
@@ -4067,7 +4067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:^4.1.0, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
### Lock dependency versions for `@xmtp/agent-sdk` by pinning content-type dependencies to `^2.0.2` and `@xmtp/node-sdk` to `^4.1.0` in [package.json](https://github.com/xmtp/xmtp-js/pull/1160/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Replace `workspace:^` specifiers with caret-pinned semver ranges in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1160/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3) for `@xmtp/content-type-*` and `@xmtp/node-sdk`.
- Update [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1160/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect the pinned versions.
- Add a patch release changeset for `@xmtp/agent-sdk` in [.changeset/six-donkeys-watch.md](https://github.com/xmtp/xmtp-js/pull/1160/files#diff-a9ee2b1bc966d11ce6e023f6b928b2440166558c50c56d6728d0b95437e4827e).

#### 📍Where to Start
Start with the dependency declarations in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1160/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3), focusing on the replaced `workspace:^` specifiers.

----

_[Macroscope](https://app.macroscope.com) summarized ff26aa9._