### PR TITLE
Expose debug utils

### DIFF
--- a/.changeset/eighty-birds-stare.md
+++ b/.changeset/eighty-birds-stare.md
@@ -3,5 +3,5 @@
 ---
 
 - Exposed default middleware
-- Exposed debug uitls
+- Exposed debug utils
 - Added default Reaction schema

--- a/.changeset/eighty-birds-stare.md
+++ b/.changeset/eighty-birds-stare.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+- Exposed default middleware
+- Exposed debug uitls
+- Added default Reaction schema

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -26,7 +26,7 @@ yarn add @xmtp/agent-sdk
 ## Quick Start
 
 ```ts
-import { Agent, createSigner, createUser } from "@xmtp/agent-sdk";
+import { createUser, createSigner, Agent, getTestUrl } from "@xmtp/agent-sdk";
 
 // 1. Create a local user + signer (you can plug in your own wallet signer)
 const user = createUser();
@@ -45,9 +45,7 @@ agent.on("message", async (ctx) => {
 
 // 4. Log when we're ready
 agent.on("start", () => {
-  const address = agent.client.accountIdentifier?.identifier;
-  const env = agent.client.options?.env;
-  console.log(`Agent online: http://xmtp.chat/dm/${address}?env=${env}`);
+  console.log(`We are online: ${getTestUrl(agent)}`);
 });
 
 await agent.start();

--- a/sdks/agent-sdk/src/core/AgentContext.ts
+++ b/sdks/agent-sdk/src/core/AgentContext.ts
@@ -21,7 +21,7 @@ export class AgentContext<ContentTypes = unknown> {
     this.#client = client;
   }
 
-  async sendReaction(content: string, schema: Reaction["schema"]) {
+  async sendReaction(content: string, schema: Reaction["schema"] = "unicode") {
     const reaction: Reaction = {
       action: "added",
       reference: this.#message.id,

--- a/sdks/agent-sdk/src/index.ts
+++ b/sdks/agent-sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./core/index.js";
+export * from "./middleware/index.js";
 export * from "./utils/index.js";

--- a/sdks/agent-sdk/src/utils/index.ts
+++ b/sdks/agent-sdk/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./crypto.js";
+export * from "./debug.js";
 export * from "./filter.js";
 export * from "./message.js";
 export * from "./user.js";


### PR DESCRIPTION
### Expose debug utilities from the `sdks/agent-sdk` utils barrel by re-exporting `./debug.js` in [utils/index.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-4f1d49c347c8b27e9bb311fc3811de8fb42ef2ea0e21ef1ea5d265094ac59b0a)
- Set the default reaction schema to "unicode" in the `AgentContext.sendReaction` method in [AgentContext.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-a59513a36778566268e9d2786fafe2bda627b8ff9e28c4f38d62d9dc54674957).
- Add a package root re-export for middleware in [index.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-178c237e09d69cc3f77d1162ab595541301b70d86679d03f69b8cc912f0872ca) via `export * from "./middleware/index.js"`.
- Update the Quick Start in [README.md](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a) to use `getTestUrl` for constructing the console URL.
- Add a changeset entry in [eighty-birds-stare.md](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-7c61e15ae2ece7828fe74629c5783fbf00b2c432f0089406a14a9ecce853b4e0).

#### 📍Where to Start
Start with the `AgentContext.sendReaction` implementation in [AgentContext.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-a59513a36778566268e9d2786fafe2bda627b8ff9e28c4f38d62d9dc54674957), then review the export surfaces in [index.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-178c237e09d69cc3f77d1162ab595541301b70d86679d03f69b8cc912f0872ca) and [utils/index.ts](https://github.com/xmtp/xmtp-js/pull/1162/files#diff-4f1d49c347c8b27e9bb311fc3811de8fb42ef2ea0e21ef1ea5d265094ac59b0a).

----

_[Macroscope](https://app.macroscope.com) summarized efa45dc._