### PR TITLE
Add Lens Chain support (mainnet 232, testnet 37111)

### DIFF
--- a/apps/xmtp.chat/src/main.tsx
+++ b/apps/xmtp.chat/src/main.tsx
@@ -10,6 +10,8 @@ import {
   arbitrumSepolia,
   base,
   baseSepolia,
+  lens,
+  lensTestnet,
   linea,
   lineaSepolia,
   mainnet,
@@ -60,6 +62,8 @@ export const config = createConfig({
     worldchainSepolia,
     zksync,
     zksyncSepoliaTestnet,
+    lens,
+    lensTestnet,
   ],
   transports: {
     [arbitrum.id]: http(),
@@ -78,6 +82,8 @@ export const config = createConfig({
     [worldchainSepolia.id]: http(),
     [zksync.id]: http(),
     [zksyncSepoliaTestnet.id]: http(),
+    [lens.id]: http(),
+    [lensTestnet.id]: http(),
   },
 });
 


### PR DESCRIPTION
**What**
Adds Lens Chain Mainnet (232) and Lens Testnet (37111) to the supported chain list in xmtp-js.

**Changes**
`apps/xmtp.chat/src/main.tsx`
Added LC mainnet 232 and testnet 37111

**Why**
Lens Protocol v3 uses smart accounts on Lens Chain. XMTP must support verifying EIP-1271 signatures on these networks to enable per-profile inboxes.