### PR TITLE
Emit group chats and dms

### DIFF
--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -156,7 +156,7 @@ You can find all available prebuilt filters [here](https://github.com/xmtp/xmtp-
 
 ### 4. Rich Context
 
-Every `message` handler receives an `AgentContext` with:
+Every `message` handler receives a `MessageContext` with:
 
 - `message` – decoded message
 - `conversation` – the active conversation object

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -4,7 +4,6 @@
     "url": "https://github.com/xmtp/xmtp-js/issues"
   },
   "dependencies": {
-    "@noble/curves": "^2.0.0",
     "@xmtp/content-type-reaction": "^2.0.2",
     "@xmtp/content-type-remote-attachment": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -6,7 +6,7 @@ import { ContentTypeText } from "@xmtp/content-type-text";
 import type { Client, Conversation, DecodedMessage } from "@xmtp/node-sdk";
 import { describe, expect, expectTypeOf, it, vi, type Mock } from "vitest";
 import { createSigner, createUser } from "@/utils/user.js";
-import { Agent, type AgentOptions } from "./Agent.js";
+import { Agent, type AgentMiddleware, type AgentOptions } from "./Agent.js";
 import { AgentContext } from "./AgentContext.js";
 
 describe("Agent", () => {
@@ -117,7 +117,7 @@ describe("Agent", () => {
     });
 
     it("should execute middleware when processing messages", async () => {
-      const middleware = vi.fn(async (_, next: () => Promise<void>) => {
+      const middleware = vi.fn<AgentMiddleware>(async (_, next) => {
         await next();
       });
       agent.use(middleware);
@@ -140,13 +140,13 @@ describe("Agent", () => {
     it("should execute multiple middleware in order", async () => {
       const calls: string[] = [];
 
-      const middleware1 = vi.fn(async (_, next: () => Promise<void>) => {
+      const middleware1 = vi.fn<AgentMiddleware>(async (_, next) => {
         calls.push("middleware1-start");
         await next();
         calls.push("middleware1-end");
       });
 
-      const middleware2 = vi.fn(async (_, next: () => Promise<void>) => {
+      const middleware2 = vi.fn<AgentMiddleware>(async (_, next) => {
         calls.push("middleware2-start");
         await next();
         calls.push("middleware2-end");

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -4,7 +4,7 @@ import type { RemoteAttachment } from "@xmtp/content-type-remote-attachment";
 import { ReplyCodec, type Reply } from "@xmtp/content-type-reply";
 import { ContentTypeText } from "@xmtp/content-type-text";
 import type { Client, Conversation, DecodedMessage } from "@xmtp/node-sdk";
-import { describe, expect, expectTypeOf, it, Mock, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi, type Mock } from "vitest";
 import { createSigner, createUser } from "@/utils/user.js";
 import { Agent, type AgentOptions } from "./Agent.js";
 import { AgentContext } from "./AgentContext.js";
@@ -249,7 +249,7 @@ describe("Agent", () => {
         await next();
       });
 
-      agent.use(async (ctx) => {
+      agent.use((ctx) => {
         expect(ctx).toBeInstanceOf(AgentContext);
         callOrder.push("B");
         throw new Error("Initial error");
@@ -286,7 +286,7 @@ describe("Agent", () => {
 
       // Stream yields one message then ends
       mockClient.conversations.streamAllMessages.mockResolvedValue(
-        (async function* () {
+        (function* () {
           yield mockMessage;
         })(),
       );

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -210,7 +210,7 @@ describe("Agent", () => {
     });
   });
 
-  describe("Error Handling middleware chain", () => {
+  describe("Error Handling", () => {
     const mockConversation = { send: vi.fn() };
     const mockMessage = {
       id: "msg-1",

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -12,7 +12,7 @@ import {
   type AgentMiddleware,
   type AgentOptions,
 } from "./Agent.js";
-import { AgentContext } from "./AgentContext.js";
+import { MessageContext } from "./MessageContext.js";
 
 describe("Agent", () => {
   const mockConversation = {
@@ -66,7 +66,7 @@ describe("Agent", () => {
     it("types the content in message event listener", () => {
       ephemeralAgent.on("message", (ctx) => {
         expectTypeOf(ctx).toEqualTypeOf<
-          AgentContext<
+          MessageContext<
             string | Reaction | Reply | RemoteAttachment | GroupUpdated
           >
         >();
@@ -137,7 +137,7 @@ describe("Agent", () => {
 
       expect(middleware).toHaveBeenCalledTimes(1);
       expect(middleware).toHaveBeenCalledWith(
-        expect.any(AgentContext),
+        expect.any(MessageContext),
         expect.any(Function),
       );
     });
@@ -180,14 +180,14 @@ describe("Agent", () => {
   describe("emit", () => {
     it("should emit 'message' and allow sending a reply via context", async () => {
       let contextSend: ((text: string) => Promise<void>) | undefined;
-      const handler = vi.fn((ctx: AgentContext) => {
+      const handler = vi.fn((ctx: MessageContext) => {
         contextSend = ctx.sendText.bind(ctx);
       });
       agent.on("message", handler);
 
       void agent.emit(
         "message",
-        new AgentContext(
+        new MessageContext(
           mockMessage,
           mockConversation as unknown as Conversation,
           agent.client,
@@ -249,25 +249,25 @@ describe("Agent", () => {
       agent.on("error", onError);
 
       const mw1: AgentMiddleware = async (ctx, next) => {
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("1");
         await next();
       };
 
       const mw2: AgentMiddleware = (ctx) => {
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("2");
         throw new Error("Initial error");
       };
 
       const mw3: AgentMiddleware = async (ctx, next) => {
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("3");
         await next();
       };
 
       const mw4: AgentMiddleware = async (ctx, next) => {
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("4");
         await next();
       };
@@ -275,7 +275,7 @@ describe("Agent", () => {
       const e1: AgentErrorMiddleware = async (err, ctx, next) => {
         expect(err).toBeInstanceOf(Error);
         expect((err as Error).message).toBe("Initial error");
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("E1");
         // Transform the initial error
         await next(new Error("Transformed error"));
@@ -283,7 +283,7 @@ describe("Agent", () => {
 
       const e2: AgentErrorMiddleware = async (err, ctx, next) => {
         expect((err as Error).message).toBe("Transformed error");
-        expect(ctx).toBeInstanceOf(AgentContext);
+        expect(ctx).toBeInstanceOf(MessageContext);
         callOrder.push("E2");
         // Resume middleware chain
         await next();

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -246,7 +246,6 @@ export class Agent<ContentTypes> extends EventEmitter<
     let resumeMain = false as boolean; // whether to continue the normal middleware chain
     let propagate = true; // whether an unhandled error should reach the default handler
 
-    // Manual index so handlers can advance the chain only when they call next(err)
     // If next(err) gets called, loop continues
     // If next() gets called, resumeMain is true which breaks the error loop
     for (let i = 0; i < chain.length && !resumeMain; ) {

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -117,13 +117,31 @@ export class Agent<ContentTypes> extends EventEmitter<
     return new Agent({ client });
   }
 
-  use(middleware: AgentMiddleware<ContentTypes>) {
-    this.#middleware.push(middleware);
+  use(middleware: AgentMiddleware<ContentTypes>): this;
+  use(middleware: AgentMiddleware<ContentTypes>[]): this;
+  use(
+    middleware: AgentMiddleware<ContentTypes> | AgentMiddleware<ContentTypes>[],
+  ): this {
+    if (Array.isArray(middleware)) {
+      this.#middleware.push(...middleware);
+    } else {
+      this.#middleware.push(middleware);
+    }
     return this;
   }
 
-  useError(errorMiddleware: AgentErrorMiddleware<ContentTypes>) {
-    this.#errorMiddleware.push(errorMiddleware);
+  useError(errorMiddleware: AgentErrorMiddleware<ContentTypes>): this;
+  useError(errorMiddleware: AgentErrorMiddleware<ContentTypes>[]): this;
+  useError(
+    errorMiddleware:
+      | AgentErrorMiddleware<ContentTypes>
+      | AgentErrorMiddleware<ContentTypes>[],
+  ): this {
+    if (Array.isArray(errorMiddleware)) {
+      this.#errorMiddleware.push(...errorMiddleware);
+    } else {
+      this.#errorMiddleware.push(errorMiddleware);
+    }
     return this;
   }
 

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -205,13 +205,13 @@ export class Agent<ContentTypes> extends EventEmitter<
   }
 
   async #runMiddlewareChain(context: AgentContext<ContentTypes>) {
-    const emit = () => {
+    const finalEmit = () => {
       if (filter.notFromSelf(context.message, this.#client)) {
         void this.emit("message", context);
       }
     };
 
-    const chain = this.#middleware.reduceRight<() => Promise<void> | void>(
+    const chain = this.#middleware.reduceRight<Parameters<AgentMiddleware>[1]>(
       (next, mw) => {
         return async () => {
           try {
@@ -221,11 +221,11 @@ export class Agent<ContentTypes> extends EventEmitter<
             if (resume) {
               await next();
             }
-            // If not resuming, swallow error here to stop the chain
+            // Chain is not resuming, error is being swallowed
           }
         };
       },
-      emit,
+      finalEmit,
     );
 
     await chain();

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -175,12 +175,12 @@ export class Agent<ContentTypes> extends EventEmitter<
         try {
           await this.#processMessage(message);
         } catch (error) {
-          this.#runErrorChain(error, null);
+          await this.#runErrorChain(error, null);
         }
       }
     } catch (error) {
       this.#isListening = false;
-      this.#runErrorChain(error, null);
+      await this.#runErrorChain(error, null);
     }
   }
 
@@ -205,13 +205,13 @@ export class Agent<ContentTypes> extends EventEmitter<
   }
 
   async #runMiddlewareChain(context: AgentContext<ContentTypes>) {
-    const emit = async () => {
+    const emit = () => {
       if (filter.notFromSelf(context.message, this.#client)) {
         void this.emit("message", context);
       }
     };
 
-    const chain = this.#middleware.reduceRight<() => Promise<void>>(
+    const chain = this.#middleware.reduceRight<() => Promise<void> | void>(
       (next, mw) => {
         return async () => {
           try {

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -22,9 +22,9 @@ import { ConversationContext } from "./ConversationContext.js";
 import { MessageContext } from "./MessageContext.js";
 
 interface EventHandlerMap<ContentTypes> {
-  dm: [ctx: ConversationContext<ContentTypes>];
+  dm: [ctx: ConversationContext<ContentTypes, Dm<ContentTypes>>];
   error: [error: Error];
-  group: [ctx: ConversationContext<ContentTypes>];
+  group: [ctx: ConversationContext<ContentTypes, Group<ContentTypes>>];
   message: [ctx: MessageContext<ContentTypes>];
   start: [];
   stop: [];
@@ -175,12 +175,18 @@ export class Agent<ContentTypes> extends EventEmitter<
           if (conversation instanceof Group) {
             this.emit(
               "group",
-              new ConversationContext(conversation, this.#client),
+              new ConversationContext<ContentTypes, Group<ContentTypes>>(
+                conversation,
+                this.#client,
+              ),
             );
           } else if (conversation instanceof Dm) {
             this.emit(
               "dm",
-              new ConversationContext(conversation, this.#client),
+              new ConversationContext<ContentTypes, Dm<ContentTypes>>(
+                conversation,
+                this.#client,
+              ),
             );
           }
         },

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -206,7 +206,7 @@ export class Agent<ContentTypes> extends EventEmitter<
   async #runMiddlewareChain(context: AgentContext<ContentTypes>) {
     const finalEmit = () => {
       if (filter.notFromSelf(context.message, this.#client)) {
-        void this.emit("message", context);
+        this.emit("message", context);
       }
     };
 

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -33,12 +33,12 @@ export type AgentMessageHandler<ContentTypes = unknown> = (
   ctx: AgentContext<ContentTypes>,
 ) => Promise<void> | void;
 
-export type AgentMiddleware<ContentTypes> = (
+export type AgentMiddleware<ContentTypes = unknown> = (
   ctx: AgentContext<ContentTypes>,
   next: () => Promise<void> | void,
 ) => Promise<void> | void;
 
-export type AgentErrorMiddleware<ContentTypes> = (
+export type AgentErrorMiddleware<ContentTypes = unknown> = (
   error: unknown,
   ctx: AgentContext<ContentTypes> | null,
   next: (err?: unknown) => Promise<void> | void,

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -29,7 +29,7 @@ export interface AgentOptions<ContentTypes> {
   client: Client<ContentTypes>;
 }
 
-export type AgentEventHandler<ContentTypes = unknown> = (
+export type AgentMessageHandler<ContentTypes = unknown> = (
   ctx: AgentContext<ContentTypes>,
 ) => Promise<void> | void;
 

--- a/sdks/agent-sdk/src/core/ConversationContext.ts
+++ b/sdks/agent-sdk/src/core/ConversationContext.ts
@@ -1,0 +1,28 @@
+import { ContentTypeText } from "@xmtp/content-type-text";
+import type { Client, Conversation } from "@xmtp/node-sdk";
+
+export class ConversationContext<ContentTypes = unknown> {
+  #client: Client<ContentTypes>;
+  #conversation: Conversation;
+
+  constructor(conversation: Conversation, client: Client<ContentTypes>) {
+    this.#conversation = conversation;
+    this.#client = client;
+  }
+
+  async sendText(text: string): Promise<void> {
+    await this.#conversation.send(text, ContentTypeText);
+  }
+
+  getOwnAddress() {
+    return this.#client.accountIdentifier?.identifier;
+  }
+
+  get conversation() {
+    return this.#conversation;
+  }
+
+  get client() {
+    return this.#client;
+  }
+}

--- a/sdks/agent-sdk/src/core/ConversationContext.ts
+++ b/sdks/agent-sdk/src/core/ConversationContext.ts
@@ -1,11 +1,14 @@
 import { ContentTypeText } from "@xmtp/content-type-text";
 import type { Client, Conversation } from "@xmtp/node-sdk";
 
-export class ConversationContext<ContentTypes = unknown> {
+export class ConversationContext<
+  ContentTypes = unknown,
+  TConversation extends Conversation = Conversation,
+> {
   #client: Client<ContentTypes>;
-  #conversation: Conversation;
+  #conversation: TConversation;
 
-  constructor(conversation: Conversation, client: Client<ContentTypes>) {
+  constructor(conversation: TConversation, client: Client<ContentTypes>) {
     this.#conversation = conversation;
     this.#client = client;
   }

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -1,0 +1,55 @@
+import {
+  ContentTypeReaction,
+  type Reaction,
+} from "@xmtp/content-type-reaction";
+import { ContentTypeReply, type Reply } from "@xmtp/content-type-reply";
+import { ContentTypeText } from "@xmtp/content-type-text";
+import type { Client, Conversation, DecodedMessage } from "@xmtp/node-sdk";
+import { ConversationContext } from "./ConversationContext.js";
+
+export class MessageContext<
+  ContentTypes = unknown,
+> extends ConversationContext<ContentTypes> {
+  #message: DecodedMessage<ContentTypes>;
+
+  constructor(
+    message: DecodedMessage<ContentTypes>,
+    conversation: Conversation,
+    client: Client<ContentTypes>,
+  ) {
+    super(conversation, client);
+    this.#message = message;
+  }
+
+  async sendReaction(content: string, schema: Reaction["schema"] = "unicode") {
+    const reaction: Reaction = {
+      action: "added",
+      reference: this.#message.id,
+      referenceInboxId: this.#message.senderInboxId,
+      schema,
+      content,
+    };
+    await this.conversation.send(reaction, ContentTypeReaction);
+  }
+
+  async sendTextReply(text: string) {
+    const reply: Reply = {
+      reference: this.#message.id,
+      referenceInboxId: this.#message.senderInboxId,
+      contentType: ContentTypeText,
+      content: text,
+    };
+    await this.conversation.send(reply, ContentTypeReply);
+  }
+
+  async getSenderAddress() {
+    const inboxState = await this.client.preferences.inboxStateFromInboxIds([
+      this.#message.senderInboxId,
+    ]);
+    return inboxState[0].identifiers[0].identifier;
+  }
+
+  get message() {
+    return this.#message;
+  }
+}

--- a/sdks/agent-sdk/src/core/index.ts
+++ b/sdks/agent-sdk/src/core/index.ts
@@ -1,2 +1,3 @@
 export * from "./Agent.js";
-export * from "./AgentContext.js";
+export * from "./ConversationContext.js";
+export * from "./MessageContext.js";

--- a/sdks/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/agent-sdk/src/middleware/CommandRouter.ts
@@ -1,12 +1,15 @@
-import { type AgentEventHandler, type AgentMiddleware } from "@/core/Agent.js";
+import {
+  type AgentMessageHandler,
+  type AgentMiddleware,
+} from "@/core/Agent.js";
 import type { AgentContext } from "@/core/AgentContext.js";
 import { isText } from "@/utils/message.js";
 
 export class CommandRouter<ContentTypes> {
-  private commandMap = new Map<string, AgentEventHandler>();
-  private defaultHandler: AgentEventHandler | null = null;
+  private commandMap = new Map<string, AgentMessageHandler>();
+  private defaultHandler: AgentMessageHandler | null = null;
 
-  command(command: string, handler: AgentEventHandler): this {
+  command(command: string, handler: AgentMessageHandler): this {
     if (!command.startsWith("/")) {
       throw new Error('Command must start with "/"');
     }
@@ -14,7 +17,7 @@ export class CommandRouter<ContentTypes> {
     return this;
   }
 
-  default(handler: AgentEventHandler): this {
+  default(handler: AgentMessageHandler): this {
     this.defaultHandler = handler;
     return this;
   }

--- a/sdks/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/agent-sdk/src/middleware/CommandRouter.ts
@@ -2,7 +2,7 @@ import {
   type AgentMessageHandler,
   type AgentMiddleware,
 } from "@/core/Agent.js";
-import type { AgentContext } from "@/core/AgentContext.js";
+import type { MessageContext } from "@/core/MessageContext.js";
 import { isText } from "@/utils/message.js";
 
 export class CommandRouter<ContentTypes> {
@@ -22,7 +22,7 @@ export class CommandRouter<ContentTypes> {
     return this;
   }
 
-  async handle(ctx: AgentContext): Promise<boolean> {
+  async handle(ctx: MessageContext): Promise<boolean> {
     if (!isText(ctx.message)) {
       return false;
     }

--- a/sdks/agent-sdk/src/utils/crypto.ts
+++ b/sdks/agent-sdk/src/utils/crypto.ts
@@ -1,7 +1,6 @@
 import { getRandomValues } from "node:crypto";
-import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { fromString, toString } from "uint8arrays";
-import { toHex } from "viem";
+import { generatePrivateKey } from "viem/accounts";
 
 /**
  * Convert a hex string to a Uint8Array encryption key.
@@ -11,18 +10,6 @@ import { toHex } from "viem";
 export const getEncryptionKeyFromHex = (hex: string): Uint8Array => {
   return fromString(hex, "hex");
 };
-
-/**
- * Generates a cryptographically secure random private key for wallet operations.
- *
- * Uses the secp256k1 elliptic curve to generate a private key suitable for
- * Ethereum-compatible wallets and XMTP client authentication.
- *
- * @returns A hex-encoded private key string (64 characters, prefixed with '0x')
- */
-function generatePrivateKey() {
-  return toHex(secp256k1.utils.randomSecretKey());
-}
 
 /**
  * Generates a cryptographically secure random encryption key for database encryption.

--- a/sdks/agent-sdk/src/utils/filter.ts
+++ b/sdks/agent-sdk/src/utils/filter.ts
@@ -1,6 +1,6 @@
 import { ContentTypeText } from "@xmtp/content-type-text";
 import type { Client, DecodedMessage } from "@xmtp/node-sdk";
-import type { AgentContext } from "@/core/AgentContext.js";
+import type { MessageContext } from "@/core/MessageContext.js";
 import { getTextContent } from "./message.js";
 
 /**
@@ -147,9 +147,9 @@ export const f = filter;
 export const withFilter =
   <ContentTypes>(
     filter: MessageFilter<ContentTypes>,
-    listener: (ctx: AgentContext<ContentTypes>) => void,
+    listener: (ctx: MessageContext<ContentTypes>) => void,
   ) =>
-  (ctx: AgentContext<ContentTypes>) => {
+  (ctx: MessageContext<ContentTypes>) => {
     if (filter(ctx.message, ctx.client)) {
       listener(ctx);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,15 +1731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@noble/curves@npm:2.0.0"
-  dependencies:
-    "@noble/hashes": "npm:2.0.0"
-  checksum: 10/f0c42bebbde529bdee7dcf39eb145343f7ba1194d1fd5cc89f51e9b9a67821b389297d259055a07981f6b9fa2b18be702fa5ececa953b5f1ff481ca49b88761f
-  languageName: node
-  linkType: hard
-
 "@noble/curves@npm:~1.7.0":
   version: 1.7.0
   resolution: "@noble/curves@npm:1.7.0"
@@ -1797,13 +1788,6 @@ __metadata:
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10/474b7f56bc6fb2d5b3a42132561e221b0ea4f91e590f4655312ca13667840896b34195e2b53b7f097ec080a1fdd3b58d902c2a8d0fbdf51d2e238b53808a177e
-  languageName: node
-  linkType: hard
-
-"@noble/hashes@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@noble/hashes@npm:2.0.0"
-  checksum: 10/cab9ec490c211a9baa54297d3f1ed4289408c54cd99d4a71bdce92038ef8c10f4a9b1230a72c92656e0ffdf9420d0d631d5f83d9f72883f77bd92214f5502c28
   languageName: node
   linkType: hard
 
@@ -3828,7 +3812,6 @@ __metadata:
   resolution: "@xmtp/agent-sdk@workspace:sdks/agent-sdk"
   dependencies:
     "@arethetypeswrong/cli": "npm:^0.18.2"
-    "@noble/curves": "npm:^2.0.0"
     "@types/node": "npm:^22.16.3"
     "@vitest/coverage-v8": "npm:^3.2.4"
     "@xmtp/content-type-reaction": "npm:^2.0.2"


### PR DESCRIPTION
### Emit group chats and DMs by adding 'dm' and 'group' conversation event emission in `sdks/agent-sdk/src/core/Agent.ts` and switching message handlers to `MessageContext`.
- Add an error middleware pipeline with `Agent.errors.use`, `#runErrorChain`, and `#defaultErrorHandler`, and integrate per-middleware `try/catch` via `#runMiddlewareChain` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).
- Introduce `ConversationContext` and `MessageContext` classes for conversation- and message-level operations in [ConversationContext.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-222fb690a0cd16d10170db9b4a7d4ac9935fbb19039150c2a6305d5035e05c59) and [MessageContext.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-2c7d0bcd16f1cefdfff785910d6ec26e62817ba275ba58d5490320842bb014de); export them from [index.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-217e72015f51493397889eb9a0e6babeb7d8271a82a0bb54ecd4df2958cbdfcf).
- Update middleware and router types to `MessageContext` in [CommandRouter.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-ac9129c00bbc8485b30821a60ec909785fdec42df3bcf2f7a9a3ec7978935f4c) and adjust tests in [Agent.test.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-10cd54ce8c0c7e2e1f12c9c832981c7e72c688df5930175a2838785a0d9e7d61).
- Replace the local key generation with `generatePrivateKey` from `viem/accounts` and remove `@noble/curves` usage in [crypto.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-07d37eb0fda0da9bb943e17cb79ffda0af31ac7a70de3e4c2486f0e38994d35b); update [package.json](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3).
- Update documentation to reference `MessageContext` in [README.md](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a).

#### 📍Where to Start
Start with `Agent.start` and the streaming/error flow in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1170/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4), then review `#runMiddlewareChain` and `#runErrorChain`.

----

_[Macroscope](https://app.macroscope.com) summarized e77050d._