### PR TITLE
Skip messages from agent itself in middleware

### DIFF
--- a/.changeset/funny-ravens-grab.md
+++ b/.changeset/funny-ravens-grab.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Skipped messages from agent itself in middleware

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -142,7 +142,7 @@ Extend your agent with custom business logic using middlewares. Compose cross-cu
 
 Middlewares can be registered with `agent.use` either one at a time or as an array. They are executed in the order they were added.
 
-Middleware functions receive a `context` object and a `next` function. Normally, a middleware calls `next()` to hand off control to the next one in the chain. However, a middleware can also alter the flow in the following ways:
+Middleware functions receive a `ctx` (context) object and a `next` function. Normally, a middleware calls `next()` to hand off control to the next one in the chain. However, a middleware can also alter the flow in the following ways:
 
 1. Use `next()` to continue the chain and pass control to the next middleware
 2. Use `return` to stop the chain and prevent events from firing
@@ -153,8 +153,8 @@ Middleware functions receive a `context` object and a `next` function. Normally,
 ```ts
 import { Agent, AgentMiddleware } from "@xmtp/agent-sdk";
 
-const onlyText: AgentMiddleware = async (context, next) => {
-  if (typeof context.message.content === "string") {
+const onlyText: AgentMiddleware = async (ctx, next) => {
+  if (typeof ctx.message.content === "string") {
     // Continue to next middleware
     await next();
   }
@@ -170,7 +170,7 @@ agent.use(onlyText);
 
 Error middleware can be registered with `agent.errors.use` either one at a time or as an array. They are executed in the order they were added.
 
-Error middleware receives the `error`, `context`, and a `next` function. Just like regular middleware, the flow in error middleware depends on how to use `next`:
+Error middleware receives the `error`, `ctx`, and a `next` function. Just like regular middleware, the flow in error middleware depends on how to use `next`:
 
 1. Use `next()` to mark the error as handled and continue with the main middleware chain
 2. Use `next(error)` to forward the original (or transformed) error to the next error handler

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -223,7 +223,7 @@ describe("Agent", () => {
     });
   });
 
-  describe("Error Handling", () => {
+  describe("errors.use", () => {
     const mockConversation = { send: vi.fn() };
     const mockMessage = {
       id: "msg-1",

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -20,8 +20,8 @@ import {
   vi,
   type Mock,
 } from "vitest";
+import { isReply } from "@/utils/message.js";
 import { createSigner, createUser } from "@/utils/user.js";
-import { isReply } from "../utils/message.js";
 import {
   Agent,
   type AgentErrorMiddleware,
@@ -180,8 +180,8 @@ describe("Agent", () => {
         expect.objectContaining({
           message: expect.objectContaining({
             senderInboxId: "other-inbox-id",
-          }),
-        }),
+          }) as { senderInboxId: string },
+        } as unknown as AgentContext),
       );
     });
 
@@ -237,8 +237,8 @@ describe("Agent", () => {
         expect.objectContaining({
           message: expect.objectContaining({
             senderInboxId: "other-inbox-id",
-          }),
-        }),
+          }) as { senderInboxId: string },
+        } as unknown as AgentContext),
       );
     });
   });
@@ -311,8 +311,8 @@ describe("Agent", () => {
         expect.objectContaining({
           message: expect.objectContaining({
             senderInboxId: "other-user-inbox",
-          }),
-        }),
+          }) as { senderInboxId: string },
+        } as unknown as AgentContext),
         expect.any(Function),
       );
     });

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -281,6 +281,11 @@ export class Agent<ContentTypes> extends EventEmitter<
       return;
     }
 
+    // Skip messages from agent itself
+    if (filter.fromSelf(message, this.#client)) {
+      return;
+    }
+
     let context: AgentContext<ContentTypes> | null = null;
     const conversation = await this.#client.conversations.getConversationById(
       message.conversationId,
@@ -302,9 +307,7 @@ export class Agent<ContentTypes> extends EventEmitter<
   ) {
     const finalEmit = async () => {
       try {
-        if (filter.notFromSelf(context.message, this.#client)) {
-          this.emit(topic, context);
-        }
+        this.emit(topic, context);
       } catch (error) {
         await this.#runErrorChain(error, context);
       }


### PR DESCRIPTION
### Skip processing self-authored messages in `Agent.#processMessage` to avoid invoking middleware and events in sdks/agent-sdk
- Add an early-return filter in `Agent.#processMessage` to drop messages authored by the agent before context creation, middleware execution, and event emission in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).
- Remove the self-message guard from the final emit in `Agent.#runMiddlewareChain`, relying on earlier filtering in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).
- Expand middleware and error-handling documentation with usage and flow control examples in [README.md](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a).
- Add tests covering self-message filtering and middleware chain behavior, including `next()` ordering and early termination via `return`, in [Agent.test.ts](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-10cd54ce8c0c7e2e1f12c9c832981c7e72c688df5930175a2838785a0d9e7d61).

#### 📍Where to Start
Start with the early-return logic in `Agent.#processMessage` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4), then review related test expectations in [Agent.test.ts](https://github.com/xmtp/xmtp-js/pull/1183/files#diff-10cd54ce8c0c7e2e1f12c9c832981c7e72c688df5930175a2838785a0d9e7d61).



#### Changes since #1183 opened

- Implemented middleware filtering to skip messages from agent itself in `@xmtp/agent-sdk` [8c1c659]
----

_[Macroscope](https://app.macroscope.com) summarized 8c1c659._