### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api-service.yml
+++ b/.github/workflows/api-service.yml
@@ -39,6 +39,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - run: echo "Nothing to test"
 


### PR DESCRIPTION
Potential fix for [https://github.com/xmtp/xmtp-js/security/code-scanning/19](https://github.com/xmtp/xmtp-js/security/code-scanning/19)

To fix the problem, add a minimal `permissions` block to the `test` job, just as in `typecheck` and `build`. The minimal permissions recommended for most jobs that do not need write privileges is `permissions: contents: read`. To implement this, manually edit the `.github/workflows/api-service.yml` file and insert a `permissions:` block with `contents: read` at the same indentation level as `runs-on` under the `test` job (after line 41, before line 42). This will ensure that the `test` job cannot escalate permissions, following the principle of least privilege and satisfying best practices and CodeQL security checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
