### PR TITLE
Stabilize conversation stream test

### DIFF
--- a/sdks/node-sdk/test/Conversations.test.ts
+++ b/sdks/node-sdk/test/Conversations.test.ts
@@ -417,8 +417,8 @@ describe("Conversations", () => {
       client3.inboxId,
     ]);
 
-    const expectedIds = new Set([conversation1.id, conversation2.id]);
-    const receivedIds = new Set<string>();
+    const expectedIds = [conversation1.id, conversation2.id];
+    const receivedIds: string[] = [];
 
     setTimeout(() => {
       void stream.end();
@@ -429,14 +429,10 @@ describe("Conversations", () => {
         break;
       }
       expect(convo).toBeDefined();
-      receivedIds.add(convo.id);
-      if (receivedIds.size === 2) {
-        void stream.end();
-        break;
-      }
+      receivedIds.push(convo.id);
     }
 
-    expect(receivedIds.size).toBe(2);
+    expect(receivedIds.length).toBe(2);
     expect(receivedIds).toEqual(expectedIds);
     expect(
       (await client3.conversations.getConversationById(conversation1.id))?.id,


### PR DESCRIPTION
### Stabilize the jest "should stream group conversations" test in [Conversations.test.ts](https://github.com/xmtp/xmtp-js/pull/1200/files#diff-66116d04f0b220afaee5094ae02adcc0c5fb2635d790dacc13e8a4f8181ba8d0)
Replace order-dependent assertions with set-based assertions in the jest "should stream group conversations" test. Introduce `expectedIds` and `receivedIds` sets to collect streamed conversation IDs, terminate the stream once both expected IDs are received, and compare set contents and size after the loop. Remove the `count` variable and related conditional checks in [Conversations.test.ts](https://github.com/xmtp/xmtp-js/pull/1200/files#diff-66116d04f0b220afaee5094ae02adcc0c5fb2635d790dacc13e8a4f8181ba8d0).

#### 📍Where to Start
Start with the jest test case "should stream group conversations" in [Conversations.test.ts](https://github.com/xmtp/xmtp-js/pull/1200/files#diff-66116d04f0b220afaee5094ae02adcc0c5fb2635d790dacc13e8a4f8181ba8d0).



#### Changes since #1200 opened

- Modified conversation stream test data handling and termination logic [9b611ef]
----

_[Macroscope](https://app.macroscope.com) summarized 9b611ef._