### PR TITLE
Add filters for admins

### DIFF
--- a/sdks/agent-sdk/src/utils/filter.test.ts
+++ b/sdks/agent-sdk/src/utils/filter.test.ts
@@ -40,7 +40,6 @@ const createMockGroup = (
     ),
   };
 
-  // Make instanceof Group work by setting the prototype
   Object.setPrototypeOf(mockGroup, Group.prototype);
 
   return mockGroup as unknown as Group;

--- a/sdks/agent-sdk/src/utils/filter.ts
+++ b/sdks/agent-sdk/src/utils/filter.ts
@@ -44,21 +44,37 @@ function hasDefinedContent<ContentTypes>() {
   };
 }
 
-function isDM<ContentTypes>(): MessageFilter<ContentTypes> {
-  return (_message, _client, conversation) => {
+function isDM<ContentTypes>(): (
+  message: DecodedMessage,
+  client: Client<ContentTypes>,
+  conversation: Conversation,
+) => conversation is Dm<ContentTypes> {
+  return (
+    _message,
+    _client,
+    conversation,
+  ): conversation is Dm<ContentTypes> => {
     return conversation instanceof Dm;
   };
 }
 
-function isGroup<ContentTypes>(): MessageFilter<ContentTypes> {
-  return (_message, _client, conversation) => {
+function isGroup<ContentTypes>(): (
+  message: DecodedMessage,
+  client: Client<ContentTypes>,
+  conversation: Conversation,
+) => conversation is Group<ContentTypes> {
+  return (
+    _message,
+    _client,
+    conversation,
+  ): conversation is Group<ContentTypes> => {
     return conversation instanceof Group;
   };
 }
 
 function isGroupAdmin<ContentTypes>(): MessageFilter<ContentTypes> {
-  return (message, _client, conversation) => {
-    if (conversation instanceof Group) {
+  return (message, client, conversation) => {
+    if (isGroup()(message, client, conversation)) {
       return conversation.isAdmin(message.senderInboxId);
     }
     return false;
@@ -66,8 +82,8 @@ function isGroupAdmin<ContentTypes>(): MessageFilter<ContentTypes> {
 }
 
 function isGroupSuperAdmin<ContentTypes>(): MessageFilter<ContentTypes> {
-  return (message, _client, conversation) => {
-    if (conversation instanceof Group) {
+  return (message, client, conversation) => {
+    if (isGroup()(message, client, conversation)) {
       return conversation.isSuperAdmin(message.senderInboxId);
     }
     return false;


### PR DESCRIPTION
### Add admin filters to sdks/agent-sdk utils and switch `utils.filter.isDM` and `utils.filter.isGroup` to synchronous `instanceof` checks for DMs and Groups
This pull request adds admin-related filters and refactors existing conversation type checks in the agent SDK. It introduces `utils.filter.isGroupAdmin` and `utils.filter.isGroupSuperAdmin`, and updates `utils.filter.isDM` and `utils.filter.isGroup` to use synchronous `instanceof` checks against `Dm` and `Group`. Tests are updated to reflect the new behavior and to mock `Group` instances with admin role methods.

- Add `utils.filter.isGroupAdmin` and `utils.filter.isGroupSuperAdmin` in [filter.ts](https://github.com/xmtp/xmtp-js/pull/1201/files#diff-331d98ee1dd4a35f5b849e635a6778e9183ba0fb6beb25698a1fcfb45a13554e)
- Change `utils.filter.isDM` and `utils.filter.isGroup` to synchronous `instanceof` checks in [filter.ts](https://github.com/xmtp/xmtp-js/pull/1201/files#diff-331d98ee1dd4a35f5b849e635a6778e9183ba0fb6beb25698a1fcfb45a13554e)
- Update and expand tests, including mock factories and role checks, in [filter.test.ts](https://github.com/xmtp/xmtp-js/pull/1201/files#diff-d08c8c8dd7d43a02b3759f8e9de887f5aa11bb6275b2e192e357d297492dbe92)

#### 📍Where to Start
Start with the new and refactored filters in [filter.ts](https://github.com/xmtp/xmtp-js/pull/1201/files#diff-331d98ee1dd4a35f5b849e635a6778e9183ba0fb6beb25698a1fcfb45a13554e), then review the corresponding test coverage and mocks in [filter.test.ts](https://github.com/xmtp/xmtp-js/pull/1201/files#diff-d08c8c8dd7d43a02b3759f8e9de887f5aa11bb6275b2e192e357d297492dbe92).



#### Changes since #1201 opened

- Refactored conversation type checking functions to use TypeScript type guards [d3c79c0]
- Updated admin permission functions to use new type guards and renamed parameters [d3c79c0]
- Removed inline comment from test utility function [d3c79c0]
----

_[Macroscope](https://app.macroscope.com) summarized d3c79c0._