### PR TITLE
[WIP] Create db path if it doesn't exist

### DIFF
--- a/sdks/node-sdk/src/types.ts
+++ b/sdks/node-sdk/src/types.ts
@@ -34,7 +34,7 @@ export type StorageOptions = {
   /**
    * Path to the local DB
    *
-   * There are 3 value types that can be used to specify the database path:
+   * There are 4 value types that can be used to specify the database path:
    *
    * - `undefined` (or excluded from the client options)
    *    The database will be created in the current working directory and is based on
@@ -47,8 +47,12 @@ export type StorageOptions = {
    * - `string`
    *    The given path will be used to create the database.
    *    Example: `./my-db.db3`
+   *
+   * - `function`
+   *    A callback function that receives the inbox ID and returns a string path.
+   *    Example: `(inboxId) => string`
    */
-  dbPath?: string | null;
+  dbPath?: string | null | ((inboxId: string) => string);
   /**
    * Encryption key for the local DB
    */

--- a/sdks/node-sdk/src/utils/createClient.ts
+++ b/sdks/node-sdk/src/utils/createClient.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import process from "node:process";
 import {
@@ -25,6 +26,10 @@ export const createClient = async (
     options?.dbPath === undefined
       ? join(process.cwd(), `xmtp-${env}-${inboxId}.db3`)
       : options.dbPath;
+
+  if (dbPath !== null) {
+    mkdirSync(dbPath, { recursive: true });
+  }
 
   const logOptions: LogOptions = {
     structured: options?.structuredLogging ?? false,

--- a/sdks/node-sdk/src/utils/createClient.ts
+++ b/sdks/node-sdk/src/utils/createClient.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import {
   createClient as createNodeClient,
@@ -28,7 +28,7 @@ export const createClient = async (
       : options.dbPath;
 
   if (typeof dbPath === "string") {
-    mkdirSync(dbPath, { recursive: true });
+    mkdirSync(dirname(dbPath), { recursive: true });
   }
 
   const logOptions: LogOptions = {

--- a/sdks/node-sdk/src/utils/createClient.ts
+++ b/sdks/node-sdk/src/utils/createClient.ts
@@ -27,7 +27,7 @@ export const createClient = async (
       ? join(process.cwd(), `xmtp-${env}-${inboxId}.db3`)
       : options.dbPath;
 
-  if (dbPath !== null) {
+  if (typeof dbPath === "string") {
     mkdirSync(dbPath, { recursive: true });
   }
 

--- a/sdks/node-sdk/src/utils/createClient.ts
+++ b/sdks/node-sdk/src/utils/createClient.ts
@@ -22,10 +22,18 @@ export const createClient = async (
   const inboxId =
     (await getInboxIdForIdentifier(identifier, env)) ||
     generateInboxId(identifier);
-  const dbPath =
-    options?.dbPath === undefined
-      ? join(process.cwd(), `xmtp-${env}-${inboxId}.db3`)
-      : options.dbPath;
+
+  let dbPath: string | null;
+  if (options?.dbPath === undefined) {
+    // Default: auto-generated path
+    dbPath = join(process.cwd(), `xmtp-${env}-${inboxId}.db3`);
+  } else if (typeof options.dbPath === "function") {
+    // Callback function: call with inboxId
+    dbPath = options.dbPath(inboxId);
+  } else {
+    // String or null: use as-is
+    dbPath = options.dbPath;
+  }
 
   if (typeof dbPath === "string") {
     mkdirSync(dirname(dbPath), { recursive: true });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { IdentifierKind } from "@xmtp/node-bindings";
@@ -525,10 +526,11 @@ describe("Client", () => {
   it("should create database directory if it doesn't exist", async () => {
     const user = createUser();
     const signer = createSigner(user);
-    const directory = path.join(os.tmpdir(), v4(), v4(), "local.db3");
-    const client = await createRegisteredClient(signer, {
-      dbPath: directory,
+    const database = path.join(os.tmpdir(), v4(), v4(), "local.db3");
+    const client = await Client.create(signer, {
+      dbPath: database,
     });
     expect(client).toBeDefined();
+    expect(fs.existsSync(database)).toBe(true);
   });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -533,4 +533,20 @@ describe("Client", () => {
     expect(client).toBeDefined();
     expect(fs.existsSync(database)).toBe(true);
   });
+
+  it("should support callback function for dynamic database creation", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const baseDir = path.join(os.tmpdir(), v4());
+
+    const client = await createRegisteredClient(signer, {
+      dbPath: (inboxId: string) => path.join(baseDir, `user-${inboxId}.db3`),
+    });
+
+    expect(client).toBeDefined();
+    expect(client.inboxId).toBeDefined();
+
+    const database = path.join(baseDir, `user-${client.inboxId}.db3`);
+    expect(fs.existsSync(database)).toBe(true);
+  });
 });

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { IdentifierKind } from "@xmtp/node-bindings";
 import { uint8ArrayToHex } from "uint8array-extras";
 import { v4 } from "uuid";
@@ -518,5 +520,15 @@ describe("Client", () => {
     expect(inboxStates2[0].identifiers).toEqual([
       await signer2.getIdentifier(),
     ]);
+  });
+
+  it("should create database directory if it doesn't exist", async () => {
+    const user = createUser();
+    const signer = createSigner(user);
+    const directory = path.join(os.tmpdir(), v4(), v4(), "local.db3");
+    const client = await createRegisteredClient(signer, {
+      dbPath: directory,
+    });
+    expect(client).toBeDefined();
   });
 });

--- a/sdks/node-sdk/test/helpers.ts
+++ b/sdks/node-sdk/test/helpers.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   ContentTypeId,
@@ -85,10 +85,20 @@ export const createClient = async <ContentCodecs extends ContentCodec[] = []>(
     env: options?.env ?? "local",
   };
   const inboxId = generateInboxId(await signer.getIdentifier());
+
+  let dbPath: string;
+  if (typeof opts.dbPath === "function") {
+    dbPath = opts.dbPath(inboxId);
+  } else {
+    dbPath = opts.dbPath ?? `./test-${inboxId}.db3`;
+  }
+
+  const finalDbPath = isAbsolute(dbPath) ? dbPath : join(__dirname, dbPath);
+
   const client = await Client.create<ContentCodecs>(signer, {
     ...opts,
     disableAutoRegister: true,
-    dbPath: join(__dirname, opts.dbPath ?? `./test-${inboxId}.db3`),
+    dbPath: finalDbPath,
     historySyncUrl: HistorySyncUrls.local,
   });
   return client;
@@ -107,9 +117,19 @@ export const createRegisteredClient = async <
     env: options?.env ?? "local",
   };
   const inboxId = generateInboxId(await signer.getIdentifier());
+
+  let dbPath: string;
+  if (typeof opts.dbPath === "function") {
+    dbPath = opts.dbPath(inboxId);
+  } else {
+    dbPath = opts.dbPath ?? `./test-${inboxId}.db3`;
+  }
+
+  const finalDbPath = isAbsolute(dbPath) ? dbPath : join(__dirname, dbPath);
+
   return Client.create<ContentCodecs>(signer, {
     ...opts,
-    dbPath: join(__dirname, opts.dbPath ?? `./test-${inboxId}.db3`),
+    dbPath: finalDbPath,
     historySyncUrl: HistorySyncUrls.local,
   });
 };


### PR DESCRIPTION
### Add automatic parent directory creation for string `dbPath` values and support function-based `StorageOptions.dbPath` resolution in `createClient` to create the DB path if it doesn't exist
- Extend `StorageOptions` in [sdks/node-sdk/src/types.ts](https://github.com/xmtp/xmtp-js/pull/1208/files#diff-5ab8d64966cdd3ef2296dd75417e657434be92abe4cd0072322fa40832ab5485) to allow `dbPath` as a callback `(inboxId) => string`, with updated JSDoc.
- Update `createClient` in [sdks/node-sdk/src/utils/createClient.ts](https://github.com/xmtp/xmtp-js/pull/1208/files#diff-384c4dfe50aecc407db2a90b34a4b35e41ddbafca70ca720f757f920439f76a3) to accept a function `dbPath`, preserve default when `undefined`, allow `null` to disable DB, and create parent directories for string paths via `mkdirSync(dirname(path), { recursive: true })`.
- Add tests in [sdks/node-sdk/test/Client.test.ts](https://github.com/xmtp/xmtp-js/pull/1208/files#diff-c00658c71eee5bdefef8b17b8d65ffb08e066b43f77200db2e049e2e6f137442) covering nested path creation and function-based `dbPath` resolution.
- Modify test helpers in [sdks/node-sdk/test/helpers.ts](https://github.com/xmtp/xmtp-js/pull/1208/files#diff-37feebcc9d42f385088026f4ef1ff4570a9e8788a1995800a398c311b0f17543) to resolve function-based `dbPath`, compute defaults, and handle absolute vs relative paths using `isAbsolute`.

#### 📍Where to Start
Start with `createClient` in [sdks/node-sdk/src/utils/createClient.ts](https://github.com/xmtp/xmtp-js/pull/1208/files#diff-384c4dfe50aecc407db2a90b34a4b35e41ddbafca70ca720f757f920439f76a3) to see `dbPath` handling and directory creation logic.

----

_[Macroscope](https://app.macroscope.com) summarized 2d671e2._