### PR TITLE
Fix remote attachments URL

### DIFF
--- a/apps/xmtp.chat/src/helpers/attachment.ts
+++ b/apps/xmtp.chat/src/helpers/attachment.ts
@@ -101,7 +101,7 @@ export const uploadAttachment = async (
   const upload = await pinata.upload.public
     .file(encryptedFile)
     .url(presignedUrl);
-  const url = await pinata.gateways.public.convert(upload.cid);
+  const url = `https://${import.meta.env.VITE_PINATA_GATEWAY}/ipfs/${upload.cid}`;
 
   // Return the RemoteAttachment with encryption metadata
   return {


### PR DESCRIPTION
### Set RemoteAttachment.url in `apps/xmtp.chat/src/helpers/attachment.ts::uploadAttachment` to `https://${import.meta.env.VITE_PINATA_GATEWAY}/ipfs/{cid}` to fix remote attachments URL
Update the URL construction after upload in `uploadAttachment` to build the IPFS URL using the `VITE_PINATA_GATEWAY` environment value and the returned CID, removing the await on `pinata.gateways.public.convert`. The change is contained in [attachment.ts](https://github.com/xmtp/xmtp-js/pull/1212/files#diff-da0649e08605a22e5c3713229ccd313a14202d14f7bc15172b86c2a7058a0fb2).

#### 📍Where to Start
Start with the `uploadAttachment` helper in [attachment.ts](https://github.com/xmtp/xmtp-js/pull/1212/files#diff-da0649e08605a22e5c3713229ccd313a14202d14f7bc15172b86c2a7058a0fb2).

----

_[Macroscope](https://app.macroscope.com) summarized 5ca189b._