### PR TITLE
Fix video width

### DIFF
--- a/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx
@@ -195,6 +195,7 @@ export const RemoteAttachmentContent: React.FC<
             src={decryptedUrl}
             controls
             style={{
+              width: "100%",
               height: "auto",
               borderRadius: "var(--mantine-radius-sm)",
               display: "block",


### PR DESCRIPTION
### Set media width to 100% in `RemoteAttachmentContent` to fix video width in [RemoteAttachmentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1213/files#diff-d7d40b72b8c21795b6b272d198b05219ffa531fe902ac513c10e21ea4f0772ab)
Add an explicit `style` on the rendered media element in `RemoteAttachmentContent` setting `width: 100%`, alongside existing styles for auto height, border radius, and block display in [RemoteAttachmentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1213/files#diff-d7d40b72b8c21795b6b272d198b05219ffa531fe902ac513c10e21ea4f0772ab).

#### 📍Where to Start
Start with the `RemoteAttachmentContent` component in [RemoteAttachmentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1213/files#diff-d7d40b72b8c21795b6b272d198b05219ffa531fe902ac513c10e21ea4f0772ab).

----

_[Macroscope](https://app.macroscope.com) summarized 539b0b6._