### PR TITLE
Add support for actions and intent content types

### DIFF
--- a/apps/xmtp.chat/package.json
+++ b/apps/xmtp.chat/package.json
@@ -42,7 +42,8 @@
     "react-virtuoso": "^4.14.0",
     "uint8array-extras": "^1.5.0",
     "viem": "^2.37.6",
-    "wagmi": "^2.16.9"
+    "wagmi": "^2.16.9",
+    "zod": "^4.1.9"
   },
   "devDependencies": {
     "@types/react": "^19.1.13",

--- a/apps/xmtp.chat/src/components/DateLabel.tsx
+++ b/apps/xmtp.chat/src/components/DateLabel.tsx
@@ -60,6 +60,7 @@ export const DateLabel: React.FC<DateLabelProps> = ({
       events={{ hover: true, focus: true, touch: true }}>
       <Text
         p={padding}
+        pt={0}
         size={size}
         ta={align}
         onKeyDown={handleKeyboardCopy}

--- a/apps/xmtp.chat/src/components/Messages/ActionsContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ActionsContent.tsx
@@ -1,0 +1,54 @@
+import { Button, Paper, Stack, type ButtonVariant } from "@mantine/core";
+import { useCallback } from "react";
+import BreakableText from "@/components/Messages/BreakableText";
+import type { Action, Actions } from "@/content-types/Actions";
+import { ContentTypeIntent, type Intent } from "@/content-types/Intent";
+import { useConversationContext } from "@/contexts/ConversationContext";
+
+export type ActionsContentProps = {
+  content: Actions;
+};
+
+const styleToVariantMap: Record<Required<Action>["style"], ButtonVariant> = {
+  primary: "filled",
+  secondary: "default",
+  danger: "filled",
+};
+
+const styleToColorMap: Record<Required<Action>["style"], string | undefined> = {
+  primary: undefined,
+  secondary: undefined,
+  danger: "red",
+};
+
+export const ActionsContent: React.FC<ActionsContentProps> = ({ content }) => {
+  const { conversation } = useConversationContext();
+  const handleActionClick = useCallback(
+    (actionId: string) => {
+      const intent: Intent = {
+        id: content.id,
+        actionId,
+      };
+      void conversation.send(intent, ContentTypeIntent);
+    },
+    [conversation, content],
+  );
+  return (
+    <Paper p="sm" radius="md" withBorder>
+      <Stack gap="xxs">
+        <BreakableText>{content.description}</BreakableText>
+        {content.actions.map((action) => (
+          <Button
+            key={action.id}
+            variant={action.style ? styleToVariantMap[action.style] : "filled"}
+            color={action.style ? styleToColorMap[action.style] : undefined}
+            onClick={() => {
+              handleActionClick(action.id);
+            }}>
+            {action.label}
+          </Button>
+        ))}
+      </Stack>
+    </Paper>
+  );
+};

--- a/apps/xmtp.chat/src/components/Messages/IntentContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/IntentContent.tsx
@@ -1,0 +1,39 @@
+import { Badge, Group, Text } from "@mantine/core";
+import { AddressBadge } from "@/components/AddressBadge";
+import { DateLabel } from "@/components/DateLabel";
+import type { Intent } from "@/content-types/Intent";
+import { nsToDate } from "@/helpers/date";
+
+export type IntentContentProps = {
+  content: Intent;
+  sentAtNs: bigint;
+  senderInboxId: string;
+};
+
+export const IntentContent: React.FC<IntentContentProps> = ({
+  senderInboxId,
+  content,
+  sentAtNs,
+}) => {
+  return (
+    <>
+      <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+      <Group gap="4" wrap="wrap" justify="center">
+        <AddressBadge address={senderInboxId} size="lg" />
+        <Text size="sm">selected the</Text>
+        <Badge
+          radius="md"
+          variant="default"
+          size="lg"
+          styles={{
+            label: {
+              textTransform: "none",
+            },
+          }}>
+          {content.actionId}
+        </Badge>
+        <Text size="sm">action</Text>
+      </Group>
+    </>
+  );
+};

--- a/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContent.tsx
@@ -14,6 +14,7 @@ import {
   ContentTypeWalletSendCalls,
   type WalletSendCallsParams,
 } from "@xmtp/content-type-wallet-send-calls";
+import { ActionsContent } from "@/components/Messages/ActionsContent";
 import { FallbackContent } from "@/components/Messages/FallbackContent";
 import { type MessageContentAlign } from "@/components/Messages/MessageContentWrapper";
 import { ReadReceiptContent } from "@/components/Messages/ReadReceiptContent";
@@ -22,6 +23,7 @@ import { ReplyContent } from "@/components/Messages/ReplyContent";
 import { TextContent } from "@/components/Messages/TextContent";
 import { TransactionReferenceContent } from "@/components/Messages/TransactionReferenceContent";
 import { WalletSendCallsContent } from "@/components/Messages/WalletSendCallsContent";
+import { ContentTypeActions, type Actions } from "@/content-types/Actions";
 
 export type MessageContentProps = {
   align: MessageContentAlign;
@@ -78,6 +80,10 @@ export const MessageContent: React.FC<MessageContentProps> = ({
         content={content as RemoteAttachment}
       />
     );
+  }
+
+  if (contentType.sameAs(ContentTypeActions)) {
+    return <ActionsContent content={content as Actions} />;
   }
 
   if (typeof content === "string") {

--- a/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
@@ -4,11 +4,13 @@ import {
   type GroupUpdated,
 } from "@xmtp/content-type-group-updated";
 import { GroupUpdatedContent } from "@/components/Messages/GroupUpdatedContent";
+import { IntentContent } from "@/components/Messages/IntentContent";
 import { MessageContent } from "@/components/Messages/MessageContent";
 import {
   MessageContentWrapper,
   type MessageContentAlign,
 } from "@/components/Messages/MessageContentWrapper";
+import { ContentTypeIntent, type Intent } from "@/content-types/Intent";
 
 export type MessageContentWithWrapperProps = {
   align: MessageContentAlign;
@@ -25,6 +27,16 @@ export const MessageContentWithWrapper: React.FC<
       <GroupUpdatedContent
         content={message.content as GroupUpdated}
         sentAtNs={message.sentAtNs}
+      />
+    );
+  }
+
+  if (message.contentType.sameAs(ContentTypeIntent)) {
+    return (
+      <IntentContent
+        content={message.content as Intent}
+        sentAtNs={message.sentAtNs}
+        senderInboxId={senderInboxId}
       />
     );
   }

--- a/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
@@ -68,8 +68,8 @@ export const WalletSendCallsContent: React.FC<WalletSendCallsContentProps> = ({
     <Box flex="flex">
       <Text size="sm">Review the following transactions:</Text>
       <List size="sm">
-        {content.calls.map((call) => (
-          <List.Item>{call.metadata?.description}</List.Item>
+        {content.calls.map((call, idx) => (
+          <List.Item key={idx}>{call.metadata?.description}</List.Item>
         ))}
       </List>
       <Space h="md" />

--- a/apps/xmtp.chat/src/content-types/Actions.ts
+++ b/apps/xmtp.chat/src/content-types/Actions.ts
@@ -1,0 +1,179 @@
+import {
+  ContentTypeId,
+  type ContentCodec,
+  type EncodedContent,
+} from "@xmtp/content-type-primitives";
+
+/**
+ * Content Type ID for Actions messages
+ * Following XIP-67 specification for inline actions
+ */
+export const ContentTypeActions = new ContentTypeId({
+  authorityId: "coinbase.com",
+  typeId: "actions",
+  versionMajor: 1,
+  versionMinor: 0,
+});
+
+/**
+ * Individual action definition
+ */
+export type Action = {
+  /** Unique identifier for this action */
+  id: string;
+  /** Display text for the button */
+  label: string;
+  /** Optional image URL */
+  imageUrl?: string;
+  /** Optional visual style (primary|secondary|danger) */
+  style?: "primary" | "secondary" | "danger";
+  /** Optional ISO-8601 expiration timestamp */
+  expiresAt?: string;
+};
+
+/**
+ * Actions content structure
+ * Agents use this to present interactive button options to users
+ */
+export type Actions = {
+  /** Unique identifier for these actions */
+  id: string;
+  /** Descriptive text explaining the actions */
+  description: string;
+  /** Array of action definitions */
+  actions: Action[];
+  /** Optional ISO-8601 expiration timestamp */
+  expiresAt?: string;
+};
+
+/**
+ * Actions codec for encoding/decoding Actions messages
+ * Implements XMTP ContentCodec interface for Actions content type
+ */
+export class ActionsCodec implements ContentCodec<Actions> {
+  get contentType(): ContentTypeId {
+    return ContentTypeActions;
+  }
+
+  encode(content: Actions): EncodedContent {
+    // Validate content before encoding
+    this.#validateContent(content);
+
+    return {
+      type: ContentTypeActions,
+      parameters: { encoding: "UTF-8" },
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    };
+  }
+
+  decode(content: EncodedContent): Actions {
+    const encoding = content.parameters.encoding;
+    if (encoding && encoding !== "UTF-8") {
+      throw new Error(`unrecognized encoding ${encoding}`);
+    }
+
+    const decodedContent = new TextDecoder().decode(content.content);
+    try {
+      const parsed = JSON.parse(decodedContent) as Actions;
+      this.#validateContent(parsed);
+      return parsed;
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to decode Actions content: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  fallback(content: Actions): string {
+    const actionList = content.actions
+      .map((action, index) => `[${index + 1}] ${action.label}`)
+      .join("\n");
+    return `${content.description}\n\n${actionList}\n\nReply with the number to select`;
+  }
+
+  shouldPush(): boolean {
+    return true;
+  }
+
+  /**
+   * Validates Actions content according to XIP-67 specification
+   */
+  #validateContent(content: Actions): void {
+    if (!content.id || typeof content.id !== "string") {
+      throw new Error("Actions.id is required and must be a string");
+    }
+
+    if (!content.description || typeof content.description !== "string") {
+      throw new Error("Actions.description is required and must be a string");
+    }
+
+    if (!Array.isArray(content.actions) || content.actions.length === 0) {
+      throw new Error(
+        "Actions.actions is required and must be a non-empty array",
+      );
+    }
+
+    if (content.actions.length > 10) {
+      throw new Error(
+        "Actions.actions cannot exceed 10 actions for UX reasons",
+      );
+    }
+
+    // Validate each action
+    content.actions.forEach((action, index) => {
+      if (!action.id || typeof action.id !== "string") {
+        throw new Error(`Action[${index}].id is required and must be a string`);
+      }
+
+      if (!action.label || typeof action.label !== "string") {
+        throw new Error(
+          `Action[${index}].label is required and must be a string`,
+        );
+      }
+
+      if (action.label.length > 50) {
+        throw new Error(`Action[${index}].label cannot exceed 50 characters`);
+      }
+
+      if (
+        action.style &&
+        !["primary", "secondary", "danger"].includes(action.style)
+      ) {
+        throw new Error(
+          `Action[${index}].style must be one of: primary, secondary, danger`,
+        );
+      }
+
+      if (action.expiresAt && !this.#isValidISO8601(action.expiresAt)) {
+        throw new Error(
+          `Action[${index}].expiresAt must be a valid ISO-8601 timestamp`,
+        );
+      }
+    });
+
+    // Check for duplicate action IDs
+    const actionIds = content.actions.map((action) => action.id);
+    const uniqueActionIds = new Set(actionIds);
+    if (actionIds.length !== uniqueActionIds.size) {
+      throw new Error(
+        "Action.id values must be unique within Actions.actions array",
+      );
+    }
+
+    if (content.expiresAt && !this.#isValidISO8601(content.expiresAt)) {
+      throw new Error("Actions.expiresAt must be a valid ISO-8601 timestamp");
+    }
+  }
+
+  /**
+   * Basic ISO-8601 timestamp validation
+   */
+  #isValidISO8601(timestamp: string): boolean {
+    try {
+      const date = new Date(timestamp);
+      return date.toISOString() === timestamp;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/xmtp.chat/src/content-types/Actions.ts
+++ b/apps/xmtp.chat/src/content-types/Actions.ts
@@ -69,7 +69,6 @@ export class ActionsCodec implements ContentCodec<Actions> {
   }
 
   encode(content: Actions): EncodedContent {
-    // Validate content before encoding
     this.#validateContent(content);
 
     return {
@@ -83,8 +82,6 @@ export class ActionsCodec implements ContentCodec<Actions> {
     const decodedContent = new TextDecoder().decode(content.content);
     try {
       const parsed = JSON.parse(decodedContent) as Actions;
-
-      // Validate decoded content
       this.#validateContent(parsed);
 
       return parsed;

--- a/apps/xmtp.chat/src/content-types/Actions.ts
+++ b/apps/xmtp.chat/src/content-types/Actions.ts
@@ -61,17 +61,12 @@ export class ActionsCodec implements ContentCodec<Actions> {
 
     return {
       type: ContentTypeActions,
-      parameters: { encoding: "UTF-8" },
+      parameters: {},
       content: new TextEncoder().encode(JSON.stringify(content)),
     };
   }
 
   decode(content: EncodedContent): Actions {
-    const encoding = content.parameters.encoding;
-    if (encoding && encoding !== "UTF-8") {
-      throw new Error(`unrecognized encoding ${encoding}`);
-    }
-
     const decodedContent = new TextDecoder().decode(content.content);
     try {
       const parsed = JSON.parse(decodedContent) as Actions;

--- a/apps/xmtp.chat/src/content-types/Intent.ts
+++ b/apps/xmtp.chat/src/content-types/Intent.ts
@@ -51,17 +51,12 @@ export class IntentCodec implements ContentCodec<Intent> {
 
     return {
       type: ContentTypeIntent,
-      parameters: { encoding: "UTF-8" },
+      parameters: {},
       content: new TextEncoder().encode(JSON.stringify(content)),
     };
   }
 
   decode(content: EncodedContent): Intent {
-    const encoding = content.parameters.encoding;
-    if (encoding && encoding !== "UTF-8") {
-      throw new Error(`unrecognized encoding ${encoding}`);
-    }
-
     const decodedContent = new TextDecoder().decode(content.content);
     try {
       const parsed = JSON.parse(decodedContent) as Intent;

--- a/apps/xmtp.chat/src/content-types/Intent.ts
+++ b/apps/xmtp.chat/src/content-types/Intent.ts
@@ -1,0 +1,133 @@
+import {
+  ContentTypeId,
+  type ContentCodec,
+  type EncodedContent,
+} from "@xmtp/content-type-primitives";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Object.prototype.toString.call(value) !== "[object Object]"
+  ) {
+    return false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const proto = Object.getPrototypeOf(value);
+
+  if (!proto) {
+    return true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const ctor =
+    Object.prototype.hasOwnProperty.call(proto, "constructor") &&
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    proto.constructor;
+
+  return (
+    typeof ctor == "function" &&
+    ctor instanceof ctor &&
+    Function.prototype.toString.call(ctor) ==
+      Function.prototype.toString.call(Object)
+  );
+};
+
+/**
+ * Content Type ID for Intent messages
+ * Following XIP-67 specification for inline actions
+ */
+export const ContentTypeIntent = new ContentTypeId({
+  authorityId: "coinbase.com",
+  typeId: "intent",
+  versionMajor: 1,
+  versionMinor: 0,
+});
+
+/**
+ * Intent content structure
+ * Users express their selection by sending Intent messages when they tap action buttons
+ */
+export type Intent = {
+  /** References Actions.id - provides strong coupling with Actions message */
+  id: string;
+  /** References specific Action.id - indicates which action was selected */
+  actionId: string;
+  /** Optional context data for the selection */
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+/**
+ * Intent codec for encoding/decoding Intent messages
+ * Implements XMTP ContentCodec interface for Intent content type
+ */
+export class IntentCodec implements ContentCodec<Intent> {
+  get contentType(): ContentTypeId {
+    return ContentTypeIntent;
+  }
+
+  encode(content: Intent): EncodedContent {
+    // Validate content before encoding
+    this.#validateContent(content);
+
+    return {
+      type: ContentTypeIntent,
+      parameters: { encoding: "UTF-8" },
+      content: new TextEncoder().encode(JSON.stringify(content)),
+    };
+  }
+
+  decode(content: EncodedContent): Intent {
+    const encoding = content.parameters.encoding;
+    if (encoding && encoding !== "UTF-8") {
+      throw new Error(`unrecognized encoding ${encoding}`);
+    }
+
+    const decodedContent = new TextDecoder().decode(content.content);
+    try {
+      const parsed = JSON.parse(decodedContent) as Intent;
+      this.#validateContent(parsed);
+      return parsed;
+    } catch (error: unknown) {
+      throw new Error(
+        `Failed to decode Intent content: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  fallback(content: Intent): string {
+    return `User selected action: ${content.actionId}`;
+  }
+
+  shouldPush(): boolean {
+    return true;
+  }
+
+  /**
+   * Validates Intent content according to XIP-67 specification
+   */
+  #validateContent(content: Intent): void {
+    if (!content.id || typeof content.id !== "string") {
+      throw new Error("Intent.id is required and must be a string");
+    }
+
+    if (!content.actionId || typeof content.actionId !== "string") {
+      throw new Error("Intent.actionId is required and must be a string");
+    }
+
+    // Validate metadata if provided
+    if (content.metadata !== undefined) {
+      if (!isPlainObject(content.metadata)) {
+        throw new Error("Intent.metadata must be a plain object if provided");
+      }
+
+      // Check for reasonable metadata size to avoid XMTP content limits
+      const metadataString = JSON.stringify(content.metadata);
+      if (metadataString.length > 10000) {
+        // 10KB limit for metadata
+        throw new Error("Intent.metadata is too large (exceeds 10KB limit)");
+      }
+    }
+  }
+}

--- a/apps/xmtp.chat/src/content-types/Intent.ts
+++ b/apps/xmtp.chat/src/content-types/Intent.ts
@@ -5,6 +5,9 @@ import {
 } from "@xmtp/content-type-primitives";
 import { z } from "zod";
 
+// 10KB limit for intent metadata
+const INTENT_METADATA_LIMIT = 10 * 1024;
+
 /**
  * Intent content structure
  * Users express their selection by sending Intent messages when they tap action buttons
@@ -46,7 +49,6 @@ export class IntentCodec implements ContentCodec<Intent> {
   }
 
   encode(content: Intent): EncodedContent {
-    // Validate content before encoding
     this.#validateContent(content);
 
     return {
@@ -90,9 +92,11 @@ export class IntentCodec implements ContentCodec<Intent> {
     if (content.metadata !== undefined) {
       // Check for reasonable metadata size to avoid XMTP content limits
       const metadataString = JSON.stringify(content.metadata);
-      if (metadataString.length > 10000) {
+      if (metadataString.length > INTENT_METADATA_LIMIT) {
         // 10KB limit for metadata
-        throw new Error("Intent.metadata is too large (exceeds 10KB limit)");
+        throw new Error(
+          `Intent.metadata is too large (exceeds ${(INTENT_METADATA_LIMIT / 1024).toFixed(0)}KB limit)`,
+        );
       }
     }
   }

--- a/apps/xmtp.chat/src/contexts/XMTPContext.tsx
+++ b/apps/xmtp.chat/src/contexts/XMTPContext.tsx
@@ -18,6 +18,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { ActionsCodec } from "@/content-types/Actions";
+import { IntentCodec } from "@/content-types/Intent";
 
 export type ContentTypes = ExtractCodecContentTypes<
   [
@@ -27,6 +29,8 @@ export type ContentTypes = ExtractCodecContentTypes<
     TransactionReferenceCodec,
     WalletSendCallsCodec,
     ReadReceiptCodec,
+    ActionsCodec,
+    IntentCodec,
   ]
 >;
 
@@ -125,6 +129,8 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
               new TransactionReferenceCodec(),
               new WalletSendCallsCodec(),
               new ReadReceiptCodec(),
+              new ActionsCodec(),
+              new IntentCodec(),
             ],
           });
           setClient(xmtpClient);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4294,6 +4294,7 @@ __metadata:
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^3.2.4"
     wagmi: "npm:^2.16.9"
+    zod: "npm:^4.1.9"
   languageName: unknown
   linkType: soft
 
@@ -11870,6 +11871,13 @@ __metadata:
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 10/73622ca36a916f785cf528fe612a884b3e0f183dbe6b33365a7d0fc92abdbedf7804c5e2bd8df0a278e1472106d46674281397a3dd800fa9031dc3429758c6ac
+  languageName: node
+  linkType: hard
+
+"zod@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "zod@npm:4.1.9"
+  checksum: 10/e9197869b65c858132f85ab877b3c6e7477d9782b8693fb7bff25a69b5fbfa6781cc0c98d465d543cc428c34a5aa370af8652cbf1842d4a67ab2139cfc99b408
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Add Actions and Intent content type support to XMTP client and message rendering to handle interactive actions and user intents
- Introduce `ActionsCodec` and `IntentCodec` with `ContentTypeId` values `coinbase.com/actions` v1.0 and `coinbase.com/intent` v1.0, including `encode`, `decode`, `fallback`, `shouldPush`, and `zod`-based validation in [Actions.ts](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-c8afbb69754abc38eed124b089145e31d2bae025684d36c34705e2ce07482e67) and [Intent.ts](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-debf8d3c42c9c360fb482631f4ed8172afc96ff63ecb96197024df47fd3b5c24).
- Register the new codecs in the XMTP client provider and extend the `ContentTypes` union in [XMTPContext.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-3f85f8bbcc919a25261978a5ef34f53d1929bda0d4019a04ce8629ed0d7b494e).
- Render Actions messages as interactive buttons and send Intent messages on selection via [ActionsContent.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-5f0147badc896d644f1bd25eaf1ba850dabad56e276b2c5ddd216af253f9a49d); render Intent summaries in [IntentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-489aca3e2462fd4497a97773e7c6623b52ff8126e34e12256ce2f174c8008c61).
- Route messages by content type in [MessageContent.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-f06fa629658413c5ba584e63a5629af927c7d804258e50885a0b856ade70c87f) and [MessageContentWithWrapper.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-a53ff22661ac52ca32c409869af09dad7b31d4083caaafcc78f488ee250ed9b2).
- Add `zod` dependency in [package.json](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-0b676dbdc3fa949b9bfafb55bb5fbfb04054a499b5490d6d853830ee6b69a4d8) and update [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de); minor UI fixes in [DateLabel.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-f14bd2987f91e2dfcdf6aec23bea6aa21067d6e56b17e47b3304d30aded22761) and key props in [WalletSendCallsContent.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-7a5e7aeaa095719baa8b7b21cf36ad9571137eb5b016132138e51b41f08d9063).

#### 📍Where to Start
Start with codec definitions and validation in `ActionsCodec` and `IntentCodec` to understand schemas and fallbacks in [Actions.ts](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-c8afbb69754abc38eed124b089145e31d2bae025684d36c34705e2ce07482e67) and [Intent.ts](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-debf8d3c42c9c360fb482631f4ed8172afc96ff63ecb96197024df47fd3b5c24), then review codec registration in [XMTPContext.tsx](https://github.com/xmtp/xmtp-js/pull/1219/files#diff-3f85f8bbcc919a25261978a5ef34f53d1929bda0d4019a04ce8629ed0d7b494e).



#### Changes since #1219 opened

- Modified `IntentCodec` validation logic to use a named constant and increase metadata size limit [c136804]
- Removed inline comments from codec methods without functional changes [c136804]
----

_[Macroscope](https://app.macroscope.com) summarized c136804._