### PR TITLE
Remove Beta label

### DIFF
--- a/.changeset/afraid-camels-drum.md
+++ b/.changeset/afraid-camels-drum.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": major
+---
+
+Removed Beta label

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -2,9 +2,6 @@
 
 Build event‑driven, middleware‑powered messaging agents on the XMTP network. 🚀
 
-> [!CAUTION]
-> This SDK is in beta status and ready for you to build with in production. Software in this status may change based on feedback.
-
 ## Documentation
 
 Full agent building guide: **[Build an XMTP Agent](https://docs.xmtp.org/agents/get-started/build-an-agent)**
@@ -275,6 +272,21 @@ Every message event handler receives a `MessageContext` with:
 agent.on("text", async (ctx) => {
   await ctx.sendTextReply("Reply using helper ✨");
 });
+```
+
+### 5. Starting Conversations
+
+These functionalities let you start a conversation:
+
+```ts
+// Direct Message
+const dm = await agent.createDmWithAddress("0x123");
+await dm.send("Hello!");
+
+// Group Conversation
+const group = await agent.createGroupWithAddresses(["0x123", "0x456"]);
+await group.addMembers(["0x789"]);
+await group.send("Hello group!");
 ```
 
 ## Adding Custom Content Types

--- a/sdks/agent-sdk/src/demo.ts
+++ b/sdks/agent-sdk/src/demo.ts
@@ -66,3 +66,7 @@ agent.on("stop", (ctx) => {
 
 await agent.start();
 console.log("Agent has started.");
+
+const group = await agent.createGroupWithAddresses(["0x123", "0x456"]);
+await group.addMembers(["0x789"]);
+await group.send("Hello group!");


### PR DESCRIPTION
### Remove the Beta label from @xmtp/agent-sdk and update documentation and demo to show starting direct and group conversations
- Add a changeset marking a major release for `@xmtp/agent-sdk` in [afraid-camels-drum.md](https://github.com/xmtp/xmtp-js/pull/1240/files#diff-08dc4cfcccd5e5e933c0754371445536a85c6806ae59aba555194d4566e737db)
- Update [README.md](https://github.com/xmtp/xmtp-js/pull/1240/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a) to remove the beta notice and add a "Starting Conversations" section with examples for starting a direct message and a group conversation, adding members, and sending a message
- Extend the demo sequence in [demo.ts](https://github.com/xmtp/xmtp-js/pull/1240/files#diff-3b064fdd3f4f695a10826e6b00730cabce1abc76ff576338c80e97c3575d1872) to create a group with two addresses, add an additional member, and send "Hello group!" after starting the agent

#### 📍Where to Start
Start with the new demo flow in [demo.ts](https://github.com/xmtp/xmtp-js/pull/1240/files#diff-3b064fdd3f4f695a10826e6b00730cabce1abc76ff576338c80e97c3575d1872), then review the usage examples in [README.md](https://github.com/xmtp/xmtp-js/pull/1240/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a).

----

_[Macroscope](https://app.macroscope.com) summarized 7626d42._