### PR TITLE
Refactor API schema and endpoints

### DIFF
--- a/apps/xmtp.chat-api-service/package.json
+++ b/apps/xmtp.chat-api-service/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "yarn clean:dist && rollup -c && yarn prisma:generate",
+    "build": "yarn prisma:generate && yarn clean:dist && rollup -c",
     "build:vercel": "yarn build && yarn migrate:deploy",
     "clean": "rimraf .turbo && yarn clean:dist && yarn clean:deps",
     "clean:deps": "rimraf node_modules",

--- a/apps/xmtp.chat-api-service/prisma/migrations/20250925203856_init/migration.sql
+++ b/apps/xmtp.chat-api-service/prisma/migrations/20250925203856_init/migration.sql
@@ -1,18 +1,15 @@
 -- CreateEnum
-CREATE TYPE "public"."Platform" AS ENUM ('ens', 'basenames', 'farcaster', 'unknown');
+CREATE TYPE "public"."Platform" AS ENUM ('ens', 'basenames', 'unknown');
 
 -- CreateTable
 CREATE TABLE "public"."Profile" (
     "id" TEXT NOT NULL,
     "address" TEXT NOT NULL,
-    "identity" TEXT NOT NULL,
-    "platform" "public"."Platform" NOT NULL,
-    "displayName" TEXT,
-    "email" TEXT,
-    "location" TEXT,
-    "status" TEXT,
     "avatar" TEXT,
     "description" TEXT,
+    "displayName" TEXT,
+    "identity" TEXT NOT NULL,
+    "platform" "public"."Platform" NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/apps/xmtp.chat-api-service/prisma/schema.prisma
+++ b/apps/xmtp.chat-api-service/prisma/schema.prisma
@@ -20,21 +20,17 @@ datasource db {
 enum Platform {
   ens
   basenames
-  farcaster
   unknown
 }
 
 model Profile {
   id          String   @id @default(uuid())
   address     String
-  identity    String   @unique
-  platform    Platform
-  displayName String?
-  email       String?
-  location    String?
-  status      String?
   avatar      String?
   description String?
+  displayName String?
+  identity    String   @unique
+  platform    Platform
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }

--- a/apps/xmtp.chat-api-service/rollup.config.js
+++ b/apps/xmtp.chat-api-service/rollup.config.js
@@ -3,7 +3,19 @@ import typescript from "@rollup/plugin-typescript";
 import { defineConfig } from "rollup";
 import tsConfigPaths from "rollup-plugin-tsconfig-paths";
 
-const external = ["cors", "express", "helmet", "express-rate-limit", "pinata"];
+const external = [
+  "cors",
+  "express",
+  "helmet",
+  "express-rate-limit",
+  "pinata",
+  "web3bio-profile-kit/types",
+  "web3bio-profile-kit/utils",
+  "zod",
+  "date-fns",
+  "@prisma/client",
+  "node:querystring",
+];
 
 const plugins = [
   tsConfigPaths(),

--- a/apps/xmtp.chat-api-service/src/api/v1/resolve.router.ts
+++ b/apps/xmtp.chat-api-service/src/api/v1/resolve.router.ts
@@ -1,4 +1,4 @@
-import type { Platform } from "@prisma/client";
+import type { Platform, Profile } from "@prisma/client";
 import { addDays, isAfter } from "date-fns";
 import { Router, type Request, type Response } from "express";
 import {
@@ -7,7 +7,15 @@ import {
 } from "web3bio-profile-kit/types";
 import { z } from "zod";
 import { prisma } from "../../helpers/prisma.js";
-import { batchFetchProfiles, fetchAddress } from "../../helpers/web3.bio.js";
+import {
+  batchFetchNames,
+  fetchProfilesFromName,
+} from "../../helpers/web3.bio.js";
+
+const hasIdentity = (identity: string, profiles: Profile[]) => {
+  const [platform, address] = identity.split(",");
+  return profiles.some((p) => p.platform === platform && p.address === address);
+};
 
 export const resolvePlatform = (platform: Web3BioPlatform): Platform => {
   switch (platform) {
@@ -15,8 +23,6 @@ export const resolvePlatform = (platform: Web3BioPlatform): Platform => {
       return "ens";
     case Web3BioPlatform.basenames:
       return "basenames";
-    case Web3BioPlatform.farcaster:
-      return "farcaster";
     default:
       return "unknown";
   }
@@ -30,9 +36,12 @@ export const resolveAddressSchema = z.object({
   addresses: z.string().length(42).startsWith("0x").array().min(1),
 });
 
-export async function resolveAddresses(req: Request, res: Response) {
+export async function resolveProfiles(req: Request, res: Response) {
   try {
     const { addresses } = resolveAddressSchema.parse(req.body);
+    const identities = addresses.reduce<string[]>((result, address) => {
+      return [...result, `ens,${address}`, `basenames,${address}`];
+    }, []);
 
     const cachedProfiles = await prisma.profile.findMany({
       where: {
@@ -42,11 +51,12 @@ export async function resolveAddresses(req: Request, res: Response) {
       },
     });
 
-    // addresses not found in the database
-    const profileAddresses = cachedProfiles.map((p) => p.address);
-    const missingAddresses = addresses.filter(
-      (address) => !profileAddresses.includes(address),
+    // identities not found in the database
+    const missingIdentities = identities.filter(
+      (identity) => !hasIdentity(identity, cachedProfiles),
     );
+
+    // profiles that have been updated within the last 7 days
     const validProfiles = cachedProfiles.filter(
       (profile) => !isAfter(new Date(), addDays(profile.updatedAt, 7)),
     );
@@ -55,31 +65,31 @@ export async function resolveAddresses(req: Request, res: Response) {
     const expired = cachedProfiles.filter((profile) =>
       isAfter(new Date(), addDays(profile.updatedAt, 7)),
     );
-    const expiredProfileAddresses = expired.map((p) => p.address);
+    const expiredProfileIdentities = expired.map(
+      (p) => `${p.platform},${p.address}`,
+    );
 
     const addressesToResolve = [
-      ...missingAddresses,
-      ...expiredProfileAddresses,
+      ...missingIdentities,
+      ...expiredProfileIdentities,
     ];
 
-    const fetchedProfiles = await batchFetchProfiles(addressesToResolve);
+    const fetchedProfiles = await batchFetchNames(addressesToResolve);
 
     // insert new profiles into the database
     const newProfiles = fetchedProfiles.filter(
-      (p) => p.address && missingAddresses.includes(p.address),
+      (p) =>
+        p.address && missingIdentities.includes(`${p.platform},${p.address}`),
     ) as ProfileResponseWithAddress[];
     if (newProfiles.length > 0) {
       const createdProfiles = await prisma.profile.createManyAndReturn({
         data: newProfiles.map((p) => ({
           address: p.address,
-          identity: p.identity,
-          platform: resolvePlatform(p.platform),
-          displayName: p.displayName,
-          email: p.email,
-          location: p.location,
-          status: p.status,
           avatar: p.avatar,
           description: p.description,
+          displayName: p.displayName,
+          identity: p.identity,
+          platform: resolvePlatform(p.platform),
         })),
       });
       validProfiles.push(...createdProfiles);
@@ -87,26 +97,23 @@ export async function resolveAddresses(req: Request, res: Response) {
 
     // update expired profiles in the database
     const expiredProfiles = fetchedProfiles.filter(
-      (p) => p.address && expiredProfileAddresses.includes(p.address),
+      (p) =>
+        p.address &&
+        expiredProfileIdentities.includes(`${p.platform},${p.address}`),
     );
     if (expiredProfiles.length > 0) {
       const updatedProfiles = await prisma.profile.updateManyAndReturn({
         data: expiredProfiles.map((p) => ({
           address: p.address,
-          identity: p.identity,
-          platform: resolvePlatform(p.platform),
-          displayName: p.displayName,
-          email: p.email,
-          location: p.location,
-          status: p.status,
           avatar: p.avatar,
           description: p.description,
+          displayName: p.displayName,
+          identity: p.identity,
+          platform: resolvePlatform(p.platform),
         })),
       });
       validProfiles.push(...updatedProfiles);
     }
-
-    console.log("profiles to return", validProfiles);
 
     // return the profiles
     res.json({
@@ -115,11 +122,8 @@ export async function resolveAddresses(req: Request, res: Response) {
         avatar: p.avatar,
         description: p.description,
         displayName: p.displayName,
-        email: p.email,
         identity: p.identity,
-        location: p.location,
         platform: p.platform,
-        status: p.status,
       })),
     });
   } catch (error: unknown) {
@@ -142,8 +146,12 @@ export async function resolveName(req: Request, res: Response) {
   try {
     const { name } = req.params;
     const validName = resolveNameSchema.parse(name);
-    const address = await fetchAddress(validName);
-    res.json({ address });
+    const profiles = await fetchProfilesFromName(validName);
+    if (!profiles || profiles.length === 0) {
+      res.status(404).json({ error: "No profiles found" });
+      return;
+    }
+    res.json({ address: profiles[0].address });
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
       console.log("zod error", z.prettifyError(error));
@@ -160,6 +168,6 @@ export async function resolveName(req: Request, res: Response) {
 
 const resolveRouter = Router();
 resolveRouter.get("/name/:name", resolveName);
-resolveRouter.post("/addresses", resolveAddresses);
+resolveRouter.post("/profiles", resolveProfiles);
 
 export default resolveRouter;

--- a/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts
+++ b/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts
@@ -121,7 +121,7 @@ export const fetchNames = async (input: string[]) => {
     return [];
   }
 
-  const escapedNames = escape(JSON.stringify(input));
+  const escapedNames = escape(JSON.stringify(identities));
   return await fetchFromWeb3Bio<NSResponse[]>(`/ns/batch/${escapedNames}`);
 };
 


### PR DESCRIPTION
### Refactor chat API by replacing POST /addresses with POST /profiles and updating name resolution to use `resolve.router.resolveProfiles` and `resolve.router.resolveName` for ENS and basenames
This change updates the chat API to resolve and cache profiles by `<platform>,<address>` for ENS and basenames, removes Farcaster support, and aligns the database schema and build configuration with the new endpoints and data model.

- Replace POST `/addresses` with POST `/profiles` and implement profile resolution, caching, and updates in `resolve.router.resolveProfiles` using `batchFetchNames` for ENS and basenames (https://github.com/xmtp/xmtp-js/pull/1244/files#diff-3a462931baf03e05a4db207f17e57de94e028100098dcaa8344034cd25b47bd0)
- Modify GET `/name/:name` to return 404 when no profiles are found and return the first resolved address on success via `resolve.router.resolveName` using `fetchProfilesFromName` (https://github.com/xmtp/xmtp-js/pull/1244/files#diff-3a462931baf03e05a4db207f17e57de94e028100098dcaa8344034cd25b47bd0)
- Remove `farcaster` from the `Platform` enum and drop `email`, `location`, and `status` from `Profile` in Prisma schema and migration (https://github.com/xmtp/xmtp-js/pull/1244/files#diff-859b9462511e0d369651061f4b53122d20282180eca6af5114b619871bfae420)
- Add input validation and batched name-service fetching helpers, replacing address-only lookups (https://github.com/xmtp/xmtp-js/pull/1244/files#diff-ac9728d65b934879787e026906534043b57089346619b722dd71608992915576)
- Run `yarn prisma:generate` before bundling and expand Rollup externals (https://github.com/xmtp/xmtp-js/pull/1244/files#diff-335949a37f90aaa76eb63faf4f459a3aee9a9a036439be154186e3e653637250)

#### 📍Where to Start
Start with the route handlers in `resolve.router` to see the new request flow: [resolve.router.ts](https://github.com/xmtp/xmtp-js/pull/1244/files#diff-3a462931baf03e05a4db207f17e57de94e028100098dcaa8344034cd25b47bd0).

----

_[Macroscope](https://app.macroscope.com) summarized 0fffdb3._