### PR TITLE
Add listening to conversation events

### DIFF
--- a/.changeset/cold-balloons-hammer.md
+++ b/.changeset/cold-balloons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Added listening to conversation events

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -93,6 +93,11 @@ Subscribe only to what you need using Node’s `EventEmitter` interface. Events 
 - `text` – a new incoming text message
 - `unknownMessage` – a message that doesn't match any specific type
 
+**Conversation Events**
+
+- `dm` – a new DM conversation
+- `group` – a new group conversation
+
 **Lifecycle Events**
 
 - `start` / `stop` – agent lifecycle events
@@ -112,6 +117,15 @@ agent.on("reaction", async (ctx) => {
 
 agent.on("reply", async (ctx) => {
   console.log(`Reply to: ${ctx.message.content.reference}`);
+});
+
+// Listen to new conversations
+agent.on("dm", async (ctx) => {
+  await ctx.conversation.send("Welcome to our DM!");
+});
+
+agent.on("group", async (ctx) => {
+  await ctx.conversation.send("Hello group!");
 });
 
 // Listen to unhandled events

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -95,6 +95,7 @@ Subscribe only to what you need using Node’s `EventEmitter` interface. Events 
 
 **Conversation Events**
 
+- `conversation` – a new group or DM conversation
 - `dm` – a new DM conversation
 - `group` – a new group conversation
 

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -8,7 +8,7 @@
     "@xmtp/content-type-remote-attachment": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-sdk": "^4.1.2",
+    "@xmtp/node-sdk": "^4.2.0",
     "uint8arrays": "^5.1.0",
     "viem": "^2.37.6"
   },

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -511,7 +511,7 @@ describe("Agent", () => {
 
   describe("conversation events", () => {
     it("should emit 'conversation' events for new conversations", async () => {
-      const mockDm: Dm = Object.create(Dm.prototype);
+      const mockDm = Object.create(Dm.prototype) as Dm;
       Object.defineProperty(mockDm, "id", {
         value: "dm-conversation-id",
         writable: false,
@@ -521,7 +521,7 @@ describe("Agent", () => {
         writable: false,
       });
 
-      const mockGroup: Group = Object.create(Group.prototype);
+      const mockGroup = Object.create(Group.prototype) as Group;
       Object.defineProperty(mockGroup, "id", {
         value: "group-conversation-id",
         writable: false,
@@ -567,7 +567,7 @@ describe("Agent", () => {
     });
 
     it("should emit specific 'dm' events for direct messages", async () => {
-      const mockDm: Dm = Object.create(Dm.prototype);
+      const mockDm = Object.create(Dm.prototype) as Dm;
       Object.defineProperty(mockDm, "id", {
         value: "dm-conversation-id",
         writable: false,
@@ -608,7 +608,7 @@ describe("Agent", () => {
     });
 
     it("should emit specific 'group' events for Group conversations", async () => {
-      const mockGroup: Group = Object.create(Group.prototype);
+      const mockGroup = Object.create(Group.prototype) as Group;
       Object.defineProperty(mockGroup, "id", {
         value: "group-conversation-id",
         writable: false,

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -221,6 +221,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
   }
 
   async #handleStreamError(error: unknown) {
+    this.#conversationsStream = undefined;
     this.#messageStream = undefined;
     const recovered = await this.#runErrorChain(error, {
       client: this.#client,

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -221,11 +221,16 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
   }
 
   async #handleStreamError(error: unknown) {
+    await this.#conversationsStream?.end();
     this.#conversationsStream = undefined;
+
+    await this.#messageStream?.end();
     this.#messageStream = undefined;
+
     const recovered = await this.#runErrorChain(error, {
       client: this.#client,
     });
+
     if (recovered) {
       this.#isLocked = false;
       queueMicrotask(() => this.start());

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,7 +4066,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:^4.1.2"
+    "@xmtp/node-sdk": "npm:^4.2.0"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.5"
     typescript: "npm:^5.9.2"
@@ -4298,7 +4298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:^4.1.2, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:^4.2.0, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
### Add conversation event listening by emitting `conversation`, `dm`, and `group` events from `Agent.start` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
Introduce conversation event streaming alongside message streaming in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4), emitting `conversation`, `dm`, and `group` events for new conversations.

- Extend `EventHandlerMap` with `conversation`, `dm`, and `group` handlers in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Start and manage a conversations stream via `client.conversations.stream` in `Agent.start`, with error handling and cleanup in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Update tests to cover conversation events and stream lifecycle in [Agent.test.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-10cd54ce8c0c7e2e1f12c9c832981c7e72c688df5930175a2838785a0d9e7d61)
- Document conversation events and usage in [README.md](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a)
- Bump `@xmtp/node-sdk` to `^4.2.0` in [package.json](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Add a changeset for a patch release in [cold-balloons-hammer.md](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-f38ef6c835caf684ffc4199144a3ac0cfe7367d7d1d91f80d4d5c86d1f0bf667)

#### 📍Where to Start
Start with `Agent.start` and the conversations stream setup in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1277/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).

----

_[Macroscope](https://app.macroscope.com) summarized 3985b24._