### PR TITLE
Release new Agent SDK

### DIFF
--- a/.changeset/cold-balloons-hammer.md
+++ b/.changeset/cold-balloons-hammer.md
@@ -1,5 +1,5 @@
 ---
-"@xmtp/agent-sdk": patch
+"@xmtp/agent-sdk": minor
 ---
 
 Added listening to conversation events

--- a/.changeset/quick-dolphins-guess.md
+++ b/.changeset/quick-dolphins-guess.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": minor
+---
+
+Added listening to conversation events

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -220,12 +220,16 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     return this;
   }
 
-  async #handleStreamError(error: unknown) {
+  async #stopStreams() {
     await this.#conversationsStream?.end();
     this.#conversationsStream = undefined;
 
     await this.#messageStream?.end();
     this.#messageStream = undefined;
+  }
+
+  async #handleStreamError(error: unknown) {
+    await this.#stopStreams();
 
     const recovered = await this.#runErrorChain(error, {
       client: this.#client,
@@ -481,11 +485,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
   async stop() {
     this.#isLocked = true;
 
-    await this.#conversationsStream?.end();
-    this.#conversationsStream = undefined;
-
-    await this.#messageStream?.end();
-    this.#messageStream = undefined;
+    await this.#stopStreams();
 
     this.emit("stop", new ClientContext({ client: this.#client }));
 

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -221,11 +221,17 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
   }
 
   async #stopStreams() {
-    await this.#conversationsStream?.end();
-    this.#conversationsStream = undefined;
+    try {
+      await this.#conversationsStream?.end();
+    } finally {
+      this.#conversationsStream = undefined;
+    }
 
-    await this.#messageStream?.end();
-    this.#messageStream = undefined;
+    try {
+      await this.#messageStream?.end();
+    } finally {
+      this.#messageStream = undefined;
+    }
   }
 
   async #handleStreamError(error: unknown) {

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -234,6 +234,9 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     }
   }
 
+  /**
+   * Closes all existing streams and restarts the streaming system.
+   */
   async #handleStreamError(error: unknown) {
     await this.#stopStreams();
 
@@ -345,7 +348,15 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
           }
         },
         onError: async (error) => {
-          await this.#handleStreamError(error);
+          const recovered = await this.#runErrorChain(
+            new AgentError(
+              1004,
+              "Error occured during message streaming.",
+              error,
+            ),
+            new ClientContext({ client: this.#client }),
+          );
+          if (!recovered) await this.stop();
         },
       });
 

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -245,6 +245,8 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     if (this.#isLocked || this.#conversationsStream || this.#messageStream)
       return;
 
+    this.#isLocked = true;
+
     try {
       this.#conversationsStream = await this.#client.conversations.stream({
         onValue: async (conversation) => {


### PR DESCRIPTION
### Release new @xmtp/agent-sdk and prevent concurrent initialization by setting `Agent.#isLocked` before stream creation in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
Introduce centralized stream shutdown and adjust initialization locking in the Agent SDK.

- Add private `Agent.#stopStreams` to end and clear `#conversationsStream` and `#messageStream` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Update `Agent.#handleStreamError` to call `#stopStreams` before running error middleware in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Set `Agent.#isLocked = true` at the start of `start()` before stream creation in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Delegate `stop()` stream shutdown to `#stopStreams` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Change `@xmtp/agent-sdk` release classification to minor in [.changeset/cold-balloons-hammer.md](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-f38ef6c835caf684ffc4199144a3ac0cfe7367d7d1d91f80d4d5c86d1f0bf667)

#### 📍Where to Start
Start with `Agent.start`, `Agent.#handleStreamError`, and the new `Agent.#stopStreams` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1279/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).



#### Changes since #1279 opened

- Added changeset file declaring minor version bump for `@xmtp/agent-sdk` package with conversation event listening functionality [972ab88]
- Modified `Agent.#stopStreams` method in `agent-sdk` to wrap stream shutdown operations in try/finally blocks [b2f34b7]
- Modified error handling behavior in `Agent.start` method's message stream configuration [2298559]
- Added JSDoc documentation to `Agent.#handleStreamError` method [2298559]
----

_[Macroscope](https://app.macroscope.com) summarized 2298559._