### PR TITLE
Update CORS policy on API service

### DIFF
--- a/apps/xmtp.chat-api-service/src/index.ts
+++ b/apps/xmtp.chat-api-service/src/index.ts
@@ -12,7 +12,7 @@ const app = express();
 const env = process.env.NODE_ENV || "development";
 const allowedOrigins = [
   "https://xmtp.chat",
-  "https://experimental.xmtp.chat",
+  "https://d14n.xmtp.chat",
   // vercel preview domains
   /^https:\/\/(.*)-ephemerahq\.vercel\.app$/,
 ];
@@ -26,7 +26,7 @@ app.use(helmet()); // Set security headers
 app.use(
   cors({
     origin: allowedOrigins,
-    methods: ["GET", "OPTIONS"],
+    methods: ["GET", "OPTIONS", "POST"],
     allowedHeaders: ["*"],
     credentials: true,
     maxAge: 86400,


### PR DESCRIPTION
### Update CORS policy on API service to allow POST and replace allowed origin with https://d14n.xmtp.chat in `apps/xmtp.chat-api-service/src/index.ts`
Modify CORS configuration in [index.ts](https://github.com/xmtp/xmtp-js/pull/1283/files#diff-589d989d2e3a6457a59d32a9fcbb3f02ed22b1ac6a6c47202772109d0fcc7b5c).

- Replace allowed origin `https://experimental.xmtp.chat` with `https://d14n.xmtp.chat`
- Expand allowed methods from `["GET", "OPTIONS"]` to `["GET", "OPTIONS", "POST"]`

#### 📍Where to Start
Start with the CORS configuration in `index.ts` within the server initialization in [apps/xmtp.chat-api-service/src/index.ts](https://github.com/xmtp/xmtp-js/pull/1283/files#diff-589d989d2e3a6457a59d32a9fcbb3f02ed22b1ac6a6c47202772109d0fcc7b5c).

----

_[Macroscope](https://app.macroscope.com) summarized 8ebef81._