### PR TITLE
Update Node SDK in Agent SDK

### DIFF
--- a/.changeset/fluffy-onions-know.md
+++ b/.changeset/fluffy-onions-know.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Updated Node SDK in Agent SDK

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -8,7 +8,7 @@
     "@xmtp/content-type-remote-attachment": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-sdk": "^4.2.0",
+    "@xmtp/node-sdk": "^4.2.1",
     "uint8arrays": "^5.1.0",
     "viem": "^2.37.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,7 +4066,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:^4.2.0"
+    "@xmtp/node-sdk": "npm:^4.2.1"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.5"
     typescript: "npm:^5.9.2"
@@ -4298,7 +4298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:^4.2.0, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:^4.2.1, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
### Update Agent SDK dependency to use @xmtp/node-sdk 4.2.1 to align with the Node SDK update
This change updates the Agent SDK dependency on the Node SDK and records a patch release.

- Bump `@xmtp/node-sdk` from `^4.2.0` to `^4.2.1` in [package.json](https://github.com/xmtp/xmtp-js/pull/1289/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Update lockfile entries in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1289/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)
- Add a changeset for a patch release in [.changeset/fluffy-onions-know.md](https://github.com/xmtp/xmtp-js/pull/1289/files#diff-53cc97292cb88c4f89c27eee377c8176b012026d43b74b72145074b910e54688)

#### 📍Where to Start
Start by reviewing the dependency bump in [sdks/agent-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1289/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3), then verify corresponding resolutions in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1289/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de).

----

_[Macroscope](https://app.macroscope.com) summarized f24cd4a._