### PR TITLE
Refactor and add Conversation lastMessage()

### DIFF
--- a/.changeset/rare-apples-ring.md
+++ b/.changeset/rare-apples-ring.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/browser-sdk": minor
+"@xmtp/node-sdk": patch
+---
+
+Refactor and add Conversation lastMessage()

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -84,6 +84,18 @@ export class Conversation<ContentTypes = unknown> {
     return this.#metadata;
   }
 
+  async lastMessage() {
+    const lastMessage = await this.#client.sendMessage(
+      "conversation.lastMessage",
+      {
+        id: this.#id,
+      },
+    );
+    return lastMessage
+      ? new DecodedMessage(this.#client, lastMessage)
+      : undefined;
+  }
+
   /**
    * Gets the conversation members
    *

--- a/sdks/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/browser-sdk/src/WorkerConversation.ts
@@ -1,5 +1,6 @@
 import {
   MessageDisappearingSettings,
+  SortDirection,
   type ConsentState,
   type Conversation,
   type ConversationDebugInfo,
@@ -77,6 +78,17 @@ export class WorkerConversation {
 
   get createdAtNs() {
     return this.#group.createdAtNs();
+  }
+
+  async lastMessage() {
+    const messages = await this.messages({
+      limit: 1n,
+      direction: SortDirection.Descending,
+    });
+    if (messages.length > 0) {
+      return messages[0];
+    }
+    return undefined;
   }
 
   async metadata() {

--- a/sdks/browser-sdk/src/types/actions/conversation.ts
+++ b/sdks/browser-sdk/src/types/actions/conversation.ts
@@ -143,4 +143,12 @@ export type ConversationAction =
         id: string;
         state: ConsentState;
       };
+    }
+  | {
+      action: "conversation.lastMessage";
+      id: string;
+      result: SafeMessage | undefined;
+      data: {
+        id: string;
+      };
     };

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -718,6 +718,16 @@ self.onmessage = async (
         postMessage({ id, action, result });
         break;
       }
+      case "conversation.lastMessage": {
+        const group = getGroup(data.id);
+        const result = await group.lastMessage();
+        postMessage({
+          id,
+          action,
+          result: result ? toSafeMessage(result) : undefined,
+        });
+        break;
+      }
       case "conversation.consentState": {
         const group = getGroup(data.id);
         const result = group.consentState;

--- a/sdks/browser-sdk/test/Conversation.test.ts
+++ b/sdks/browser-sdk/test/Conversation.test.ts
@@ -193,12 +193,19 @@ describe("Conversation", () => {
       client2.inboxId!,
     ]);
 
+    expect(await conversation.lastMessage()).toBeDefined();
+
     const text = "gm";
     await conversation.send(text);
 
     const messages = await conversation.messages();
     expect(messages.length).toBe(2);
     expect(messages[1].content).toBe(text);
+
+    const lastMessage = await conversation.lastMessage();
+    expect(lastMessage).toBeDefined();
+    expect(lastMessage?.id).toBe(messages[1].id);
+    expect(lastMessage?.content).toBe(text);
 
     await client2.conversations.sync();
     const conversations = await client2.conversations.list();
@@ -212,6 +219,11 @@ describe("Conversation", () => {
     const messages2 = await conversation2.messages();
     expect(messages2.length).toBe(2);
     expect(messages2[1].content).toBe(text);
+
+    const lastMessage2 = await conversation2.lastMessage();
+    expect(lastMessage2).toBeDefined();
+    expect(lastMessage2?.id).toBe(messages2[1].id);
+    expect(lastMessage2?.content).toBe(text);
   });
 
   it("should require content type when sending non-string content", async () => {

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -32,7 +32,6 @@ export class Conversation<ContentTypes = unknown> {
    *
    * @param client - The client instance managing the conversation
    * @param conversation - The underlying conversation instance
-   * @param lastMessage - Optional last message in the conversation
    * @param isCommitLogForked
    */
   constructor(

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -1,10 +1,11 @@
 import type { ContentTypeId } from "@xmtp/content-type-primitives";
 import { ContentTypeText } from "@xmtp/content-type-text";
-import type {
-  ConsentState,
-  ListMessagesOptions,
-  Message,
-  Conversation as XmtpConversation,
+import {
+  SortDirection,
+  type ConsentState,
+  type ListMessagesOptions,
+  type Message,
+  type Conversation as XmtpConversation,
 } from "@xmtp/node-bindings";
 import type { Client } from "@/Client";
 import { DecodedMessage } from "@/DecodedMessage";
@@ -24,7 +25,6 @@ import {
 export class Conversation<ContentTypes = unknown> {
   #client: Client<ContentTypes>;
   #conversation: XmtpConversation;
-  #lastMessage?: DecodedMessage<ContentTypes>;
   #isCommitLogForked: boolean | null = null;
 
   /**
@@ -38,14 +38,10 @@ export class Conversation<ContentTypes = unknown> {
   constructor(
     client: Client<ContentTypes>,
     conversation: XmtpConversation,
-    lastMessage?: Message | null,
     isCommitLogForked?: boolean | null,
   ) {
     this.#client = client;
     this.#conversation = conversation;
-    this.#lastMessage = lastMessage
-      ? new DecodedMessage(client, lastMessage)
-      : undefined;
     this.#isCommitLogForked = isCommitLogForked ?? null;
   }
 
@@ -210,7 +206,14 @@ export class Conversation<ContentTypes = unknown> {
    * @returns Promise that resolves with the last message or undefined if none exists
    */
   async lastMessage() {
-    return this.#lastMessage ?? (await this.messages({ limit: 1 }))[0];
+    const messages = await this.messages({
+      limit: 1,
+      direction: SortDirection.Descending,
+    });
+    if (messages.length > 0) {
+      return messages[0];
+    }
+    return undefined;
   }
 
   /**

--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -176,14 +176,12 @@ export class Conversations<ContentTypes = unknown> {
             return new Dm(
               this.#client,
               item.conversation,
-              item.lastMessage,
               item.isCommitLogForked,
             );
           case "group":
             return new Group(
               this.#client,
               item.conversation,
-              item.lastMessage,
               item.isCommitLogForked,
             );
           default:
@@ -209,7 +207,6 @@ export class Conversations<ContentTypes = unknown> {
       const conversation = new Group(
         this.#client,
         item.conversation,
-        item.lastMessage,
         item.isCommitLogForked,
       );
       return conversation;
@@ -231,7 +228,6 @@ export class Conversations<ContentTypes = unknown> {
       const conversation = new Dm(
         this.#client,
         item.conversation,
-        item.lastMessage,
         item.isCommitLogForked,
       );
       return conversation;

--- a/sdks/node-sdk/src/Dm.ts
+++ b/sdks/node-sdk/src/Dm.ts
@@ -1,7 +1,4 @@
-import type {
-  Message,
-  Conversation as XmtpConversation,
-} from "@xmtp/node-bindings";
+import type { Conversation as XmtpConversation } from "@xmtp/node-bindings";
 import type { Client } from "@/Client";
 import { Conversation } from "@/Conversation";
 
@@ -19,13 +16,11 @@ export class Dm<ContentTypes = unknown> extends Conversation<ContentTypes> {
    *
    * @param client - The client instance managing this direct message conversation
    * @param conversation - The underlying conversation instance
-   * @param lastMessage - Optional last message in the conversation
    * @param isCommitLogForked
    */
   constructor(
     client: Client<ContentTypes>,
     conversation: XmtpConversation,
-    lastMessage?: Message | null,
     isCommitLogForked?: boolean | null,
   ) {
     super(client, conversation, isCommitLogForked);

--- a/sdks/node-sdk/src/Dm.ts
+++ b/sdks/node-sdk/src/Dm.ts
@@ -28,7 +28,7 @@ export class Dm<ContentTypes = unknown> extends Conversation<ContentTypes> {
     lastMessage?: Message | null,
     isCommitLogForked?: boolean | null,
   ) {
-    super(client, conversation, lastMessage, isCommitLogForked);
+    super(client, conversation, isCommitLogForked);
     this.#client = client;
     this.#conversation = conversation;
   }

--- a/sdks/node-sdk/src/Group.ts
+++ b/sdks/node-sdk/src/Group.ts
@@ -1,6 +1,5 @@
 import type {
   Identifier,
-  Message,
   MetadataField,
   PermissionPolicy,
   PermissionUpdateType,
@@ -22,13 +21,11 @@ export class Group<ContentTypes = unknown> extends Conversation<ContentTypes> {
    *
    * @param client - The client instance managing this group conversation
    * @param conversation - The underlying conversation object
-   * @param lastMessage - Optional last message in the conversation
    * @param isCommitLogForked
    */
   constructor(
     client: Client<ContentTypes>,
     conversation: XmtpConversation,
-    lastMessage?: Message | null,
     isCommitLogForked?: boolean | null,
   ) {
     super(client, conversation, isCommitLogForked);

--- a/sdks/node-sdk/src/Group.ts
+++ b/sdks/node-sdk/src/Group.ts
@@ -31,7 +31,7 @@ export class Group<ContentTypes = unknown> extends Conversation<ContentTypes> {
     lastMessage?: Message | null,
     isCommitLogForked?: boolean | null,
   ) {
-    super(client, conversation, lastMessage, isCommitLogForked);
+    super(client, conversation, isCommitLogForked);
     this.#conversation = conversation;
   }
 

--- a/sdks/node-sdk/test/Conversation.test.ts
+++ b/sdks/node-sdk/test/Conversation.test.ts
@@ -194,12 +194,19 @@ describe("Conversation", () => {
       client2.inboxId,
     ]);
 
+    expect(await conversation.lastMessage()).toBeDefined();
+
     const text = "gm";
     await conversation.send(text);
 
     const messages = await conversation.messages();
     expect(messages.length).toBe(2);
     expect(messages[1].content).toBe(text);
+
+    const lastMessage = await conversation.lastMessage();
+    expect(lastMessage).toBeDefined();
+    expect(lastMessage?.id).toBe(messages[1].id);
+    expect(lastMessage?.content).toBe(text);
 
     await client2.conversations.sync();
     const conversations = client2.conversations.listGroups();
@@ -213,6 +220,11 @@ describe("Conversation", () => {
     const messages2 = await conversation2.messages();
     expect(messages2.length).toBe(2);
     expect(messages2[1].content).toBe(text);
+
+    const lastMessage2 = await conversation2.lastMessage();
+    expect(lastMessage2).toBeDefined();
+    expect(lastMessage2?.id).toBe(messages2[1].id);
+    expect(lastMessage2?.content).toBe(text);
   });
 
   it("should require content type when sending non-string content", async () => {


### PR DESCRIPTION
### Refactor and add `Conversation.lastMessage()` to return the most recent message across browser and node SDKs
This change adds `Conversation.lastMessage()` to the browser and worker implementations and refactors the node implementation to fetch the latest message on demand. It also wires a new worker action and updates tests to cover the behavior.

- Add `conversation.lastMessage` action handling in worker client and expose `Conversation.lastMessage()` in [sdks/browser-sdk/src/Conversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-442a0904610463a860abea81ae109cff22108c7a599634ae1928262b829de8c7), [sdks/browser-sdk/src/workers/client.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-b926d6c9b5b94a9c838a230dd9fdf6f0d3c15b73e1120bedb91fbde594f1efc3), and [sdks/browser-sdk/src/types/actions/conversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-35cc1bec7cc50fdba8c1eb1d3849f4e1dcd3b64c2667e3fc38c1fda64af6652b)
- Implement `WorkerConversation.lastMessage()` using `messages()` with `limit=1n` and `SortDirection.Descending` in [sdks/browser-sdk/src/WorkerConversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-15be72accbed98f722d2a1417ca660692a38e6e48243ab270804e61bb247f7de)
- Refactor node `Conversation.lastMessage()` to query messages with `limit: 1` and `SortDirection.Descending` and remove cached field in [sdks/node-sdk/src/Conversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-88be862a6501dd06623529cecebf1fb68b69ecb13dd49a6cb709ca7c5532c117), updating constructors in [sdks/node-sdk/src/Dm.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-869699fc063ff65380c23b20a8c4c0437e1feea7862886058fe11c34683ac297) and [sdks/node-sdk/src/Group.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-db3ff857ec4aee1e8856e25eb0058b4f7d8a48e448b12b9b0f50b307ac8cd56c)
- Update tests in [sdks/browser-sdk/test/Conversation.test.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-af2cf47ba8387a2a9e8f48fd023928d98871acbb121a3bb3e50242fe2847eec0) and [sdks/node-sdk/test/Conversation.test.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-4d082636d2af8ef2629b7f2b11bda18a2879370d5fedf26f3e61156becc27bee)
- Add changeset in [.changeset/rare-apples-ring.md](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-1b9c3ca932d440aec3ff5bbbd6ba4bc788332ac1202e45622c3b8afa3c5c5391)

#### 📍Where to Start
Start with the new worker action handling for `conversation.lastMessage` in [sdks/browser-sdk/src/workers/client.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-b926d6c9b5b94a9c838a230dd9fdf6f0d3c15b73e1120bedb91fbde594f1efc3), then review `Conversation.lastMessage()` in [sdks/browser-sdk/src/Conversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-442a0904610463a860abea81ae109cff22108c7a599634ae1928262b829de8c7) and [sdks/node-sdk/src/Conversation.ts](https://github.com/xmtp/xmtp-js/pull/1292/files#diff-88be862a6501dd06623529cecebf1fb68b69ecb13dd49a6cb709ca7c5532c117).



#### Changes since #1292 opened

- Removed lastMessage parameter from conversation constructors and updated all instantiation calls [7a40184]
----

_[Macroscope](https://app.macroscope.com) summarized 7a40184._