### PR TITLE
Remove flaky browser test

### DIFF
--- a/sdks/browser-sdk/test/DebugInformation.test.ts
+++ b/sdks/browser-sdk/test/DebugInformation.test.ts
@@ -35,7 +35,6 @@ describe("DebugInformation", () => {
     expect(apiStats2.fetchKeyPackage).toBe(0n);
     expect(apiStats2.queryGroupMessages).toBe(0n);
     expect(apiStats2.queryWelcomeMessages).toBe(0n);
-    expect(apiStats2.sendGroupMessages).toBe(0n);
     expect(apiStats2.sendWelcomeMessages).toBe(0n);
     expect(apiStats2.subscribeMessages).toBe(0n);
     expect(apiStats2.subscribeWelcomes).toBe(0n);


### PR DESCRIPTION
### Remove the assertion on `sendGroupMessages` equals `0n` in `DebugInformation.should return network API statistics` within [sdks/browser-sdk/test/DebugInformation.test.ts](https://github.com/xmtp/xmtp-js/pull/1298/files#diff-2857d16c894d08f2375a837a41ff252f894a47c96c645194b89387ef4712ab86) to remove a flaky browser test
This change updates the browser SDK test by deleting a single expectation that checks `apiStats2.sendGroupMessages` equals `0n` after `clearAllStatistics()`.

- Remove the assertion on `apiStats2.sendGroupMessages === 0n` in [sdks/browser-sdk/test/DebugInformation.test.ts](https://github.com/xmtp/xmtp-js/pull/1298/files#diff-2857d16c894d08f2375a837a41ff252f894a47c96c645194b89387ef4712ab86) within `DebugInformation.should return network API statistics`

#### 📍Where to Start
Start in the `DebugInformation.should return network API statistics` test case in [sdks/browser-sdk/test/DebugInformation.test.ts](https://github.com/xmtp/xmtp-js/pull/1298/files#diff-2857d16c894d08f2375a837a41ff252f894a47c96c645194b89387ef4712ab86).

----

_[Macroscope](https://app.macroscope.com) summarized c1a9ec9._