### PR TITLE
Add `MessageContext.useCodec`

### DIFF
--- a/.changeset/chatty-teachers-lay.md
+++ b/.changeset/chatty-teachers-lay.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Added `MessageContext.useCodec` to identify custom content types

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -87,12 +87,13 @@ Subscribe only to what you need using Node’s `EventEmitter` interface. Events 
 
 **Message Events**
 
-- `attachment` – a new incoming remote attachment message
-- `message` – all incoming messages (fires for every message regardless of type)
-- `reaction` – a new incoming reaction message
-- `reply` – a new incoming reply message
-- `text` – a new incoming text message
-- `unknownMessage` – a message that doesn't match any specific type
+- `attachment` – an incoming [remote attachment message](https://docs.xmtp.org/chat-apps/content-types/attachments)
+- `message` – all messages that are not having a [custom content type](https://docs.xmtp.org/agents/content-types/content-types) (fires for every message regardless of type)
+- `group-update` – an incoming [group update](https://docs.xmtp.org/agents/content-types/group-updates#listen-for-group-updates) (like name change, member update, etc.)
+- `reaction` – an incoming [reaction message](https://docs.xmtp.org/agents/content-types/reactions)
+- `reply` – an incoming [reply message](https://docs.xmtp.org/agents/content-types/replies)
+- `text` – an incoming [text message](https://docs.xmtp.org/agents/content-types/content-types#text-content-type)
+- `unknownMessage` – a message that does not correspond to any of the pre-implemented event types
 
 **Conversation Events**
 

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -88,12 +88,12 @@ Subscribe only to what you need using Node’s `EventEmitter` interface. Events 
 **Message Events**
 
 - `attachment` – an incoming [remote attachment message](https://docs.xmtp.org/chat-apps/content-types/attachments)
-- `message` – all messages that are not having a [custom content type](https://docs.xmtp.org/agents/content-types/content-types) (fires for every message regardless of type)
+- `message` – all messages that are not having a [custom content type](https://docs.xmtp.org/agents/content-types/content-types#custom-content-types)
 - `group-update` – an incoming [group update](https://docs.xmtp.org/agents/content-types/group-updates#listen-for-group-updates) (like name change, member update, etc.)
 - `reaction` – an incoming [reaction message](https://docs.xmtp.org/agents/content-types/reactions)
 - `reply` – an incoming [reply message](https://docs.xmtp.org/agents/content-types/replies)
 - `text` – an incoming [text message](https://docs.xmtp.org/agents/content-types/content-types#text-content-type)
-- `unknownMessage` – a message that does not correspond to any of the pre-implemented event types
+- `unknownMessage` – a message event that does not correspond to any of the pre-implemented event types
 
 **Conversation Events**
 

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -29,7 +29,7 @@ import {
   vi,
   type Mock,
 } from "vitest";
-import { filter } from "@/core/filter.js";
+import { filter, type DecodedMessageWithContent } from "@/core/filter.js";
 import { createSigner, createUser } from "@/user/User.js";
 import {
   Agent,
@@ -49,7 +49,7 @@ type CurrentClientTypes =
 
 const createMockMessage = <ContentType = string>(
   overrides: Partial<DecodedMessage> & { content: ContentType },
-): DecodedMessage & { content: ContentType } => {
+): DecodedMessageWithContent<ContentType> => {
   const { content, ...rest } = overrides;
   return {
     id: "mock-message-id",
@@ -58,7 +58,7 @@ const createMockMessage = <ContentType = string>(
     contentType: ContentTypeText,
     ...rest,
     content,
-  } as unknown as DecodedMessage & { content: ContentType };
+  } as unknown as DecodedMessageWithContent<ContentType>;
 };
 
 const createMockStreamWithCallbacks = (messages: DecodedMessage[]) => {

--- a/sdks/agent-sdk/src/core/MessageContext.test.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.test.ts
@@ -1,0 +1,64 @@
+import {
+  ContentTypeReply,
+  ReplyCodec,
+  type Reply,
+} from "@xmtp/content-type-reply";
+import { ContentTypeText } from "@xmtp/content-type-text";
+import { Dm } from "@xmtp/node-sdk";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  createMockMessage,
+  mockClient,
+  type CurrentClientTypes,
+} from "@/utils/TestUtil.js";
+import { MessageContext } from "./MessageContext.js";
+
+describe("MessageContext", () => {
+  describe("usesCodec", () => {
+    const mockDm = Object.create(Dm.prototype) as Dm;
+
+    it("should properly type the content when using ReplyCodec as input", () => {
+      const replyMessage = createMockMessage<Reply>({
+        id: "reply-message-id",
+        senderInboxId: "other-inbox-id",
+        contentType: ContentTypeReply,
+        content: {
+          content: "This is a reply",
+          reference: "original-message-id",
+          referenceInboxId: "original-sender-inbox-id",
+          contentType: ContentTypeText,
+        },
+      });
+
+      const messageContext = new MessageContext<CurrentClientTypes>({
+        message: replyMessage,
+        conversation: mockDm,
+        client: mockClient,
+      });
+
+      expect(messageContext.usesCodec(ReplyCodec)).toBe(true);
+      const typedContext = messageContext as MessageContext<Reply>;
+      expectTypeOf(typedContext.message.content).toEqualTypeOf<Reply>();
+      const { content } = typedContext.message;
+      expect(content.content).toBe(replyMessage.content.content);
+    });
+
+    it("should return false for ReplyCodec when message is not a reply", () => {
+      const textMessage = createMockMessage({
+        id: "text-message-id",
+        senderInboxId: "sender-inbox-id",
+        contentType: ContentTypeText,
+        content: "This is just a regular text message",
+      });
+
+      const messageContext = new MessageContext<CurrentClientTypes>({
+        message: textMessage,
+        conversation: mockDm,
+        client: mockClient,
+      });
+
+      const isReplyCodec = messageContext.usesCodec(ReplyCodec);
+      expect(isReplyCodec).toBe(false);
+    });
+  });
+});

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -1,4 +1,7 @@
-import type { ContentTypeId } from "@xmtp/content-type-primitives";
+import type {
+  ContentCodec,
+  ContentTypeId,
+} from "@xmtp/content-type-primitives";
 import {
   ContentTypeReaction,
   type Reaction,
@@ -36,8 +39,10 @@ export class MessageContext<
     this.#message = message;
   }
 
-  isContentType(id: ContentTypeId) {
-    return this.#message.contentType?.sameAs(id);
+  isContentType<T extends ContentCodec>(
+    codec: T,
+  ): this is MessageContext<ReturnType<T["decode"]>> {
+    return this.#message.contentType?.sameAs(codec.contentType) || false;
   }
 
   isText(): this is MessageContext<ReturnType<TextCodec["decode"]>> {

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -1,7 +1,4 @@
-import type {
-  ContentCodec,
-  ContentTypeId,
-} from "@xmtp/content-type-primitives";
+import type { ContentCodec } from "@xmtp/content-type-primitives";
 import {
   ContentTypeReaction,
   type Reaction,

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -11,15 +11,9 @@ import {
   type ReplyCodec,
 } from "@xmtp/content-type-reply";
 import { ContentTypeText, type TextCodec } from "@xmtp/content-type-text";
-import type { DecodedMessage } from "@xmtp/node-sdk";
-import { filter } from "@/core/filter.js";
+import { filter, type DecodedMessageWithContent } from "@/core/filter.js";
 import type { AgentBaseContext } from "./Agent.js";
 import { ConversationContext } from "./ConversationContext.js";
-
-export type DecodedMessageWithContent<ContentTypes = unknown> =
-  DecodedMessage<ContentTypes> & {
-    content: ContentTypes;
-  };
 
 export type MessageContextParams<ContentTypes = unknown> = Omit<
   AgentBaseContext<ContentTypes>,

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -39,10 +39,12 @@ export class MessageContext<
     this.#message = message;
   }
 
-  isContentType<T extends ContentCodec>(
-    codec: T,
+  usesCodec<T extends ContentCodec>(
+    codecClass: new () => T,
   ): this is MessageContext<ReturnType<T["decode"]>> {
-    return this.#message.contentType?.sameAs(codec.contentType) || false;
+    return (
+      this.#message.contentType?.sameAs(new codecClass().contentType) || false
+    );
   }
 
   isText(): this is MessageContext<ReturnType<TextCodec["decode"]>> {

--- a/sdks/agent-sdk/src/core/MessageContext.ts
+++ b/sdks/agent-sdk/src/core/MessageContext.ts
@@ -1,3 +1,4 @@
+import type { ContentTypeId } from "@xmtp/content-type-primitives";
 import {
   ContentTypeReaction,
   type Reaction,
@@ -39,6 +40,10 @@ export class MessageContext<
   }: MessageContextParams<ContentTypes>) {
     super({ conversation, client });
     this.#message = message;
+  }
+
+  isContentType(id: ContentTypeId) {
+    return this.#message.contentType?.sameAs(id);
   }
 
   isText(): this is MessageContext<ReturnType<TextCodec["decode"]>> {

--- a/sdks/agent-sdk/src/core/filter.ts
+++ b/sdks/agent-sdk/src/core/filter.ts
@@ -20,6 +20,11 @@ import {
   type DecodedMessage,
 } from "@xmtp/node-sdk";
 
+export type DecodedMessageWithContent<ContentTypes = unknown> =
+  DecodedMessage<ContentTypes> & {
+    content: ContentTypes;
+  };
+
 const fromSelf = <ContentTypes>(
   message: DecodedMessage<ContentTypes>,
   client: Client<ContentTypes>,
@@ -29,9 +34,7 @@ const fromSelf = <ContentTypes>(
 
 const hasContent = <ContentTypes>(
   message: DecodedMessage<ContentTypes>,
-): message is DecodedMessage<ContentTypes> & {
-  content: NonNullable<ContentTypes>;
-} => {
+): message is DecodedMessageWithContent<ContentTypes> => {
   return message.content !== undefined && message.content !== null;
 };
 
@@ -94,7 +97,7 @@ const isRemoteAttachment = (
 
 const isText = (
   message: DecodedMessage,
-): message is DecodedMessage & { content: ReturnType<TextCodec["decode"]> } => {
+): message is DecodedMessageWithContent<ReturnType<TextCodec["decode"]>> => {
   return !!message.contentType?.sameAs(ContentTypeText);
 };
 

--- a/sdks/agent-sdk/src/demo.ts
+++ b/sdks/agent-sdk/src/demo.ts
@@ -1,4 +1,5 @@
 import { loadEnvFile } from "node:process";
+import { TextCodec } from "@xmtp/content-type-text";
 import { Agent, AgentError } from "./core/index.js";
 import { getTestUrl } from "./debug/log.js";
 import { CommandRouter } from "./middleware/CommandRouter.js";
@@ -63,6 +64,14 @@ agent.on("start", (ctx) => {
 
 agent.on("stop", (ctx) => {
   console.log("Agent stopped", ctx);
+});
+
+agent.on("unknownMessage", (ctx) => {
+  // Narrow down by codec
+  if (ctx.usesCodec(TextCodec)) {
+    const content = ctx.message.content;
+    console.log(`Text content: ${content.toUpperCase()}`);
+  }
 });
 
 await agent.start();

--- a/sdks/agent-sdk/src/utils/TestUtil.ts
+++ b/sdks/agent-sdk/src/utils/TestUtil.ts
@@ -1,0 +1,102 @@
+import type { GroupUpdated } from "@xmtp/content-type-group-updated";
+import type { Reaction } from "@xmtp/content-type-reaction";
+import type { RemoteAttachment } from "@xmtp/content-type-remote-attachment";
+import type { Reply } from "@xmtp/content-type-reply";
+import { ContentTypeText } from "@xmtp/content-type-text";
+import type { Client, Conversation, DecodedMessage } from "@xmtp/node-sdk";
+import type { Mock } from "vitest";
+import { Agent } from "@/core/Agent.js";
+import type { DecodedMessageWithContent } from "@/core/filter.js";
+
+export type CurrentClientTypes =
+  | string
+  | Reaction
+  | Reply
+  | RemoteAttachment
+  | GroupUpdated;
+
+export const createMockMessage = <ContentType>(
+  overrides: Partial<DecodedMessage> & { content: ContentType },
+): DecodedMessageWithContent<ContentType> => {
+  const { content, ...rest } = overrides;
+  return {
+    id: "mock-message-id",
+    conversationId: "test-conversation-id",
+    senderInboxId: "sender-inbox-id",
+    contentType: ContentTypeText,
+    ...rest,
+    content,
+  } as DecodedMessageWithContent<ContentType>;
+};
+
+export const makeAgent = () => {
+  return { agent: new Agent({ client: mockClient }), mockClient };
+};
+
+export const mockClient = {
+  inboxId: "test-inbox-id",
+  conversations: {
+    sync: vi.fn().mockResolvedValue(undefined),
+    stream: vi.fn().mockResolvedValue(undefined),
+    streamAllMessages: vi.fn(),
+    getConversationById: vi.fn().mockResolvedValue({
+      send: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+  preferences: {
+    inboxStateFromInboxIds: vi.fn(),
+  },
+} as unknown as Client & {
+  conversations: {
+    stream: Mock;
+    streamAllMessages: Mock;
+  };
+};
+
+export const createMockStreamWithCallbacks = (messages: DecodedMessage[]) => {
+  const mockStream = {
+    end: vi.fn().mockResolvedValue(undefined),
+    [Symbol.asyncIterator]: vi.fn(),
+  };
+
+  return vi
+    .fn()
+    .mockImplementation(
+      (options: { onValue: (value: DecodedMessage) => void }) => {
+        // Simulate async message delivery
+        queueMicrotask(() => {
+          messages.forEach((message) => {
+            options.onValue(message);
+          });
+        });
+        return Promise.resolve(mockStream);
+      },
+    );
+};
+
+export const createMockConversationStreamWithCallbacks = (
+  conversations: Conversation[],
+) => {
+  const mockStream = {
+    end: vi.fn().mockResolvedValue(undefined),
+    [Symbol.asyncIterator]: vi.fn(),
+  };
+
+  return vi
+    .fn()
+    .mockImplementation(
+      (options: { onValue: (value: Conversation) => void }) => {
+        // Simulate async conversation delivery
+        queueMicrotask(() => {
+          conversations.forEach((conversation) => {
+            options.onValue(conversation);
+          });
+        });
+        return Promise.resolve(mockStream);
+      },
+    );
+};
+
+export const flushMicrotasks = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `MessageContext.isContentType` to check a message’s content type in [MessageContext.ts](https://github.com/xmtp/xmtp-js/pull/1301/files#diff-2c7d0bcd16f1cefdfff785910d6ec26e62817ba275ba58d5490320842bb014de)
This change introduces a new instance method on `MessageContext` and updates imports in [MessageContext.ts](https://github.com/xmtp/xmtp-js/pull/1301/files#diff-2c7d0bcd16f1cefdfff785910d6ec26e62817ba275ba58d5490320842bb014de).

- Add `MessageContext.isContentType(id: ContentTypeId)` that returns `this.#message.contentType?.sameAs(id)`
- Add a type-only import of `ContentTypeId` from `@xmtp/content-type-primitives`

#### 📍Where to Start
Start with the `isContentType` method implementation in [MessageContext.ts](https://github.com/xmtp/xmtp-js/pull/1301/files#diff-2c7d0bcd16f1cefdfff785910d6ec26e62817ba275ba58d5490320842bb014de).



#### Changes since #1301 opened

- Introduced centralized type alias for decoded messages with content [af2b01c]
- Updated type guard functions to use the new type alias [af2b01c]
- Refactored imports and removed duplicate type definitions [af2b01c]
- Updated test helper function type signature [af2b01c]
- Refactored `MessageContext.isContentType` method signature and implementation to accept `ContentCodec` instead of `ContentTypeId` [36c4be9]
- Renamed and refactored the `core.MessageContext.isContentType` method to `core.MessageContext.usesCodec` with parameter signature changes [3a6d16e]
- Refactored test infrastructure by creating shared testing utilities and updating existing tests to use them [a83fa27]
- Added `usesCodec` functionality to `MessageContext` with corresponding test coverage [a83fa27]
- Enhanced demo script with `unknownMessage` event handling using content type detection [a83fa27]
- Updated documentation for message event descriptions [a83fa27]
- Updated message event documentation in agent SDK [0b1a2bd]
- Added changeset declaration for new `MessageContext.useCodec` feature in `@xmtp/agent-sdk` package [e763467]
----

_[Macroscope](https://app.macroscope.com) summarized e763467._
<!-- Macroscope's pull request summary ends here -->