### PR TITLE
Refactor Conversation isActive in the Browser SDK

### DIFF
--- a/.changeset/lazy-files-sparkle.md
+++ b/.changeset/lazy-files-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/browser-sdk": major
+---
+
+Refactor Conversation isActive in the Browser SDK

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -27,7 +27,6 @@ export class Conversation<ContentTypes = unknown> {
   #client: Client<ContentTypes>;
   #createdAtNs?: SafeConversation["createdAtNs"];
   #id: string;
-  #isActive?: SafeConversation["isActive"];
   #metadata?: SafeConversation["metadata"];
   #isCommitLogForked?: SafeConversation["isCommitLogForked"];
 
@@ -49,7 +48,6 @@ export class Conversation<ContentTypes = unknown> {
   }
 
   #syncData(data?: SafeConversation) {
-    this.#isActive = data?.isActive;
     this.#addedByInboxId = data?.addedByInboxId;
     this.#metadata = data?.metadata;
     this.#createdAtNs = data?.createdAtNs;
@@ -58,10 +56,6 @@ export class Conversation<ContentTypes = unknown> {
 
   get id() {
     return this.#id;
-  }
-
-  get isActive() {
-    return this.#isActive;
   }
 
   get isCommitLogForked() {
@@ -94,6 +88,12 @@ export class Conversation<ContentTypes = unknown> {
     return lastMessage
       ? new DecodedMessage(this.#client, lastMessage)
       : undefined;
+  }
+
+  async isActive() {
+    return this.#client.sendMessage("conversation.isActive", {
+      id: this.#id,
+    });
   }
 
   /**

--- a/sdks/browser-sdk/src/types/actions/conversation.ts
+++ b/sdks/browser-sdk/src/types/actions/conversation.ts
@@ -151,4 +151,12 @@ export type ConversationAction =
       data: {
         id: string;
       };
+    }
+  | {
+      action: "conversation.isActive";
+      id: string;
+      result: boolean;
+      data: {
+        id: string;
+      };
     };

--- a/sdks/browser-sdk/src/utils/conversions.ts
+++ b/sdks/browser-sdk/src/utils/conversions.ts
@@ -332,7 +332,6 @@ export type SafeConversation = {
       updateMessageDisappearingPolicy: PermissionPolicy;
     };
   };
-  isActive: boolean;
   addedByInboxId: string;
   metadata: {
     creatorInboxId: string;
@@ -352,7 +351,6 @@ export const toSafeConversation = async (
   const imageUrl = conversation.imageUrl;
   const description = conversation.description;
   const permissions = conversation.permissions;
-  const isActive = conversation.isActive;
   const addedByInboxId = conversation.addedByInboxId;
   const metadata = await conversation.metadata();
   const admins = conversation.admins;
@@ -381,7 +379,6 @@ export const toSafeConversation = async (
           policySet.updateMessageDisappearingPolicy,
       },
     },
-    isActive,
     addedByInboxId,
     metadata,
     admins,

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -728,6 +728,12 @@ self.onmessage = async (
         });
         break;
       }
+      case "conversation.isActive": {
+        const group = getGroup(data.id);
+        const result = group.isActive;
+        postMessage({ id, action, result });
+        break;
+      }
       case "conversation.consentState": {
         const group = getGroup(data.id);
         const result = group.consentState;

--- a/sdks/browser-sdk/test/Conversation.test.ts
+++ b/sdks/browser-sdk/test/Conversation.test.ts
@@ -163,6 +163,16 @@ describe("Conversation", () => {
 
     await conversation.addMembers([client3.inboxId!]);
 
+    await client2.conversations.sync();
+    const conversation2 = await client2.conversations.getConversationById(
+      conversation.id,
+    );
+
+    await client3.conversations.sync();
+    const conversation3 = await client3.conversations.getConversationById(
+      conversation.id,
+    );
+
     const members2 = await conversation.members();
     expect(members2.length).toBe(3);
 
@@ -172,6 +182,13 @@ describe("Conversation", () => {
     expect(memberInboxIds2).toContain(client3.inboxId);
 
     await conversation.removeMembers([client2.inboxId!]);
+
+    await conversation2!.sync();
+    await conversation3!.sync();
+
+    expect(await conversation.isActive()).toBe(true);
+    expect(await conversation2!.isActive()).toBe(false);
+    expect(await conversation3!.isActive()).toBe(true);
 
     const members3 = await conversation.members();
     expect(members3.length).toBe(2);

--- a/sdks/browser-sdk/test/Conversations.test.ts
+++ b/sdks/browser-sdk/test/Conversations.test.ts
@@ -39,7 +39,7 @@ describe("Conversations", () => {
     expect(conversation.id).toBeDefined();
     expect(conversation.createdAtNs).toBeDefined();
     expect(conversation.createdAt).toBeDefined();
-    expect(conversation.isActive).toBe(true);
+    expect(await conversation.isActive()).toBe(true);
     expect(conversation.isCommitLogForked).toBeUndefined();
     expect(conversation.name).toBe("");
     expect(await conversation.messageDisappearingSettings()).toBeUndefined();
@@ -55,7 +55,7 @@ describe("Conversations", () => {
     expect(conversation2.id).toBeDefined();
     expect(conversation2.createdAtNs).toBeDefined();
     expect(conversation2.createdAt).toBeDefined();
-    expect(conversation2.isActive).toBe(true);
+    expect(await conversation2.isActive()).toBe(true);
     expect(conversation2.name).toBe("");
     expect(await conversation2.messageDisappearingSettings()).toBeUndefined();
     expect(await conversation2.isMessageDisappearingEnabled()).toBe(false);
@@ -156,7 +156,7 @@ describe("Conversations", () => {
     expect(group.id).toBeDefined();
     expect(group.createdAtNs).toBeDefined();
     expect(group.createdAt).toBeDefined();
-    expect(group.isActive).toBe(true);
+    expect(await group.isActive()).toBe(true);
     expect(group.isCommitLogForked).toBeUndefined();
     expect(await group.messageDisappearingSettings()).toBeUndefined();
     expect(await group.isMessageDisappearingEnabled()).toBe(false);
@@ -166,7 +166,7 @@ describe("Conversations", () => {
     expect(group2.id).toBeDefined();
     expect(group2.createdAtNs).toBeDefined();
     expect(group2.createdAt).toBeDefined();
-    expect(group2.isActive).toBe(true);
+    expect(await group2.isActive()).toBe(true);
     expect(await group2.messageDisappearingSettings()).toBeUndefined();
     expect(await group2.isMessageDisappearingEnabled()).toBe(false);
 
@@ -807,7 +807,7 @@ describe("Streaming", () => {
     expect(group.id).toBeDefined();
     expect(group.createdAtNs).toBeDefined();
     expect(group.createdAt).toBeDefined();
-    expect(group.isActive).toBe(true);
+    expect(await group.isActive()).toBe(true);
     expect(group.name).toBe("");
     const permissions = await group.permissions();
     expect(permissions.policyType).toBe(GroupPermissionsOptions.Default);
@@ -848,7 +848,7 @@ describe("Streaming", () => {
     expect(group2.id).toBeDefined();
     expect(group2.createdAtNs).toBeDefined();
     expect(group2.createdAt).toBeDefined();
-    expect(group2.isActive).toBe(true);
+    expect(await group2.isActive()).toBe(true);
     expect(group2.name).toBe("test");
     expect(group2.description).toBe("test");
     expect(group2.imageUrl).toBe("test");


### PR DESCRIPTION
# Summary

This update changes the signature of `Conversation.isActive` from a getter to an async method. As a result, this is a breaking change.

### Why?

The `isActive` property of a `Conversation` should be read directly from the database every time to get the latest value. Before, the value was cached and would not reflect an inactive state in some cases.