### PR TITLE
Add links to docs for Conversations

### DIFF
--- a/sdks/node-sdk/src/Conversations.ts
+++ b/sdks/node-sdk/src/Conversations.ts
@@ -44,6 +44,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param id - The conversation ID to look up
    * @returns The conversation if found, undefined otherwise
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#conversation-helper-methods
    */
   async getConversationById(id: string) {
     try {
@@ -63,6 +64,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param inboxId - The inbox ID to look up
    * @returns The DM if found, undefined otherwise
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#conversation-helper-methods
    */
   getDmByInboxId(inboxId: string) {
     try {
@@ -79,6 +81,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param id - The message ID to look up
    * @returns The decoded message if found, undefined otherwise
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#conversation-helper-methods
    */
   getMessageById(id: string) {
     try {
@@ -95,6 +98,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional group creation options
    * @returns The new group
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#optimistically-create-a-new-group-chat
    */
   newGroupOptimistic(options?: CreateGroupOptions) {
     const group = this.#conversations.createGroupOptimistic(options);
@@ -107,6 +111,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param identifiers - Array of identifiers for group members
    * @param options - Optional group creation options
    * @returns The new group
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#create-a-new-group-chat
    */
   async newGroupWithIdentifiers(
     identifiers: Identifier[],
@@ -123,6 +128,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param inboxIds - Array of inbox IDs for group members
    * @param options - Optional group creation options
    * @returns The new group
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-conversations#create-a-new-group-chat
    */
   async newGroup(inboxIds: string[], options?: CreateGroupOptions) {
     const group = await this.#conversations.createGroupByInboxId(
@@ -139,6 +145,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param identifier - Identifier for the DM recipient
    * @param options - Optional DM creation options
    * @returns The new DM
+   * @see https://docs.xmtp.org/agents/build-agents/create-conversations#by-ethereum-address-1
    */
   async newDmWithIdentifier(identifier: Identifier, options?: CreateDmOptions) {
     const group = await this.#conversations.createDm(identifier, options);
@@ -152,6 +159,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param inboxId - Inbox ID for the DM recipient
    * @param options - Optional DM creation options
    * @returns The new DM
+   * @see https://docs.xmtp.org/agents/build-agents/create-conversations#by-inbox-id-1
    */
   async newDm(inboxId: string, options?: CreateDmOptions) {
     const group = await this.#conversations.createDmByInboxId(inboxId, options);
@@ -164,6 +172,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional filtering and pagination options
    * @returns Array of conversations
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/list
    */
   async list(options?: ListConversationsOptions) {
     const groups = this.#conversations.list(options);
@@ -197,6 +206,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional filtering and pagination options
    * @returns Array of groups
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/list#list-existing-conversations
    */
   listGroups(options?: Omit<ListConversationsOptions, "conversationType">) {
     const groups = this.#conversations.list({
@@ -218,6 +228,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional filtering and pagination options
    * @returns Array of DMs
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/list#list-existing-conversations
    */
   listDms(options?: Omit<ListConversationsOptions, "conversationType">) {
     const groups = this.#conversations.list({
@@ -238,6 +249,7 @@ export class Conversations<ContentTypes = unknown> {
    * Synchronizes conversations for the current client from the network
    *
    * @returns Promise that resolves when sync is complete
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/sync-and-syncall
    */
   async sync() {
     return this.#conversations.sync();
@@ -249,6 +261,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param consentStates - Optional array of consent states to filter by
    * @returns Promise that resolves when sync is complete
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/sync-and-syncall#sync-all-new-welcomes-conversations-messages-and-preferences
    */
   async syncAll(consentStates?: ConsentState[]) {
     return this.#conversations.syncAllConversations(consentStates);
@@ -260,6 +273,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @param options.conversationType - Optional conversation type to filter by
    * @returns Stream instance for new conversations
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-conversations
    */
   async stream(
     options?: StreamOptions<
@@ -303,6 +317,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional stream options
    * @returns Stream instance for new group conversations
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-conversations
    */
   async streamGroups(
     options?: StreamOptions<Conversation, Group<ContentTypes>>,
@@ -330,6 +345,7 @@ export class Conversations<ContentTypes = unknown> {
    *
    * @param options - Optional stream options
    * @returns Stream instance for new DM conversations
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-conversations
    */
   async streamDms(options?: StreamOptions<Conversation, Dm<ContentTypes>>) {
     const stream = async (
@@ -353,6 +369,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param options.conversationType - Optional conversation type to filter by
    * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new messages
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-messages
    */
   async streamAllMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
@@ -385,6 +402,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new group messages
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-messages
    */
   async streamAllGroupMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
@@ -404,6 +422,7 @@ export class Conversations<ContentTypes = unknown> {
    * @param options - Optional stream options
    * @param options.consentStates - Optional array of consent states to filter by
    * @returns Stream instance for new DM messages
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/stream#stream-new-group-chat-and-dm-messages
    */
   async streamAllDmMessages(
     options?: StreamOptions<Message, DecodedMessage<ContentTypes>> & {
@@ -421,6 +440,7 @@ export class Conversations<ContentTypes = unknown> {
    * Retrieves HMAC keys for all conversations
    *
    * @returns The HMAC keys for all conversations
+   * @see https://docs.xmtp.org/chat-apps/push-notifs/push-notifs#get-hmac-keys-for-a-conversation
    */
   hmacKeys() {
     return this.#conversations.getHmacKeys();


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add @see documentation links to JSDoc for methods in `sdks/node-sdk/src/Conversations.ts` to provide docs for Conversations
This change adds `@see` references to JSDoc comments across multiple methods in [Conversations.ts](https://github.com/xmtp/xmtp-js/pull/1304/files#diff-dc800b0893e90a87dfadf86954a9670886461b143fa8ef01fcf91e72f3cd5186).

- Update JSDoc for `Conversations.getConversationById`, `Conversations.getDmByInboxId`, and `Conversations.getMessageById` with `@see` links
- Update JSDoc for creation methods `Conversations.newGroupOptimistic`, `Conversations.newGroupWithIdentifiers`, `Conversations.newGroup`, `Conversations.newDmWithIdentifier`, and `Conversations.newDm` with `@see` links
- Update JSDoc for list and sync methods `Conversations.list`, `Conversations.listGroups`, `Conversations.listDms`, `Conversations.sync`, and `Conversations.syncAll` with `@see` links
- Update JSDoc for stream methods `Conversations.stream`, `Conversations.streamGroups`, `Conversations.streamDms`, `Conversations.streamAllMessages`, `Conversations.streamAllGroupMessages`, and `Conversations.streamAllDmMessages` with `@see` links, including references to conversation helper methods
- Update JSDoc for `Conversations.hmacKeys` with an `@see` link

#### 📍Where to Start
Start with the JSDoc updates in [sdks/node-sdk/src/Conversations.ts](https://github.com/xmtp/xmtp-js/pull/1304/files#diff-dc800b0893e90a87dfadf86954a9670886461b143fa8ef01fcf91e72f3cd5186), reviewing method comment blocks for `@see` additions beginning at the top of the class.

----

_[Macroscope](https://app.macroscope.com) summarized 27c1440._
<!-- Macroscope's pull request summary ends here -->