### PR TITLE
feat: implement conversations pagination with total count display

### DIFF
--- a/apps/xmtp.chat/src/components/Conversations/ConversationList.tsx
+++ b/apps/xmtp.chat/src/components/Conversations/ConversationList.tsx
@@ -1,4 +1,5 @@
 import type { Conversation } from "@xmtp/browser-sdk";
+import { Button, Box } from "@mantine/core";
 import { useMemo, type ComponentProps } from "react";
 import { useParams } from "react-router";
 import { Virtuoso } from "react-virtuoso";
@@ -12,10 +13,16 @@ const List = (props: ComponentProps<"div">) => {
 
 export type ConversationsListProps = {
   conversations: Conversation<ContentTypes>[];
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 };
 
 export const ConversationsList: React.FC<ConversationsListProps> = ({
   conversations,
+  hasMore,
+  loadingMore,
+  onLoadMore,
 }) => {
   const { conversationId } = useParams();
   const selectedConversationIndex = useMemo(
@@ -25,17 +32,32 @@ export const ConversationsList: React.FC<ConversationsListProps> = ({
       ),
     [conversations, conversationId],
   );
+
   return (
-    <Virtuoso
-      components={{
-        List,
-      }}
-      initialTopMostItemIndex={Math.max(selectedConversationIndex, 0)}
-      style={{ flexGrow: 1 }}
-      data={conversations}
-      itemContent={(_, conversation) => (
-        <ConversationCard conversation={conversation} />
+    <Box style={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
+      <Virtuoso
+        components={{
+          List,
+        }}
+        initialTopMostItemIndex={Math.max(selectedConversationIndex, 0)}
+        style={{ flexGrow: 1 }}
+        data={conversations}
+        itemContent={(_, conversation) => (
+          <ConversationCard conversation={conversation} />
+        )}
+      />
+      {hasMore && onLoadMore && (
+        <Box p="md" style={{ borderTop: '1px solid #e9ecef' }}>
+          <Button
+            fullWidth
+            variant="light"
+            loading={loadingMore}
+            onClick={onLoadMore}
+          >
+            Load More Conversations
+          </Button>
+        </Box>
       )}
-    />
+    </Box>
   );
 };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add manual pagination with a 'Load More' button and total conversations count to Conversations views to implement pagination with total count display
Introduce pagination state and actions in `useConversations` and wire them into the navbar and list UI. The navbar loads 20 conversations on mount, shows the total count, and triggers pagination; the list renders a footer button to load more and reflects loading state.

- Add pagination state and methods (`conversationsCount`, `hasMore`, `loadingMore`, `loadMore`, `resetPagination`) to `useConversations` in [useConversations.ts](https://github.com/xmtp/xmtp-js/pull/1314/files#diff-6e753981ee9ce08d8174dc8a755d3e2de5523ebc06ca81e6efd2c05ebc96700c), update `list` to support `syncFromNetwork`, `reset`, limits, and set `hasMore` and `conversationsCount`
- Update [ConversationsNavbar.tsx](https://github.com/xmtp/xmtp-js/pull/1314/files#diff-1c20110ef33defa0ed5f3cdb8ea974e75f4c94e437235995ee75d064399ff9e3) to load 20 items on mount, display `conversationsCount`, reset pagination on sync actions, and pass pagination props/handlers to the list
- Update [ConversationList.tsx](https://github.com/xmtp/xmtp-js/pull/1314/files#diff-1aa208caee61898856e9b64fe75c5ab51e7776ed42adc37e22d11a4932003f43) to accept `hasMore`, `loadingMore`, and `onLoadMore`, and render a footer button to fetch additional pages

#### 📍Where to Start
Start with the pagination logic in `useConversations` at [useConversations.ts](https://github.com/xmtp/xmtp-js/pull/1314/files#diff-6e753981ee9ce08d8174dc8a755d3e2de5523ebc06ca81e6efd2c05ebc96700c), focusing on `list`, `loadMore`, and `resetPagination`.

----

_[Macroscope](https://app.macroscope.com) summarized cf2bbdc._
<!-- Macroscope's pull request summary ends here -->