### PR TITLE
Fix template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,10 +17,10 @@ body:
       multiple: false
       description: What are you having an issue with?
       options:
-        - label: Browser SDK
-        - label: Node SDK
-        - label: Agent SDK
-        - label: xmtp.chat
+        - Browser SDK
+        - Node SDK
+        - Agent SDK
+        - xmtp.chat
       default: 0
     validations:
       required: true


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix GitHub bug report template labels in .github/ISSUE_TEMPLATE/bug_report.yml
Update the select options in the GitHub bug report template to use scalar string entries instead of map entries with `label` keys in [bug_report.yml](https://github.com/xmtp/xmtp-js/pull/1316/files#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653ef).

#### 📍Where to Start
Start with the options list under the `body` section in [bug_report.yml](https://github.com/xmtp/xmtp-js/pull/1316/files#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653ef).

----

_[Macroscope](https://app.macroscope.com) summarized ff31d47._
<!-- Macroscope's pull request summary ends here -->