### PR TITLE
Specify libXMTP Version

### DIFF
--- a/.changeset/famous-numbers-exist.md
+++ b/.changeset/famous-numbers-exist.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Updated `@xmtp/node-sdk` dependency to `^4.2.2`

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -362,6 +362,8 @@ const agent = await Agent.create(signer, {
 | --------------------- | --------------- |
 | 4.2.2                 | 1.5.3           |
 
+To verify which LibXMTP version is installed, run `npm why @xmtp/node-bindings` after installing the Agent SDK.
+
 ## Debugging
 
 - [Debug an agent](https://docs.xmtp.org/agents/debug-agents)

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -361,11 +361,11 @@ const agent = await Agent.create(signer, {
 
 ## LibXMTP Version
 
-LibXMTP is a shared library encapsulating the core functionality of the XMTP messaging protocol, such as cryptography, networking, and language bindings. This version of the Agent SDK uses:
+[LibXMTP](https://github.com/xmtp/libxmtp/) is a shared library encapsulating the core functionality of the XMTP messaging protocol, such as cryptography, networking, and language bindings. This version of the Agent SDK uses:
 
-| Node SDK Version | LibXMTP Version |
-| ---------------- | --------------- |
-| 4.2.2            | x.x.x           |
+| XMTP Node SDK Version | LibXMTP Version |
+| --------------------- | --------------- |
+| 4.2.2                 | x.x.x           |
 
 ## Contributing / Feedback
 

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -359,6 +359,14 @@ const agent = await Agent.create(signer, {
 - [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
 - [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
 
+## LibXMTP Version
+
+LibXMTP is a shared library encapsulating the core functionality of the XMTP messaging protocol, such as cryptography, networking, and language bindings. This version of the Agent SDK uses:
+
+| Node SDK Version | LibXMTP Version |
+| ---------------- | --------------- |
+| 4.2.2            | x.x.x           |
+
 ## Contributing / Feedback
 
 We’d love your feedback: [open an issue](https://github.com/xmtp/xmtp-js/issues) or discussion. PRs welcome for docs, examples, and core improvements.

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -365,7 +365,7 @@ const agent = await Agent.create(signer, {
 
 | XMTP Node SDK Version | LibXMTP Version |
 | --------------------- | --------------- |
-| 4.2.2                 | x.x.x           |
+| 4.2.2                 | 1.5.3           |
 
 ## Contributing / Feedback
 

--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -354,11 +354,6 @@ const agent = await Agent.create(signer, {
 });
 ```
 
-## Debugging
-
-- [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
-- [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
-
 ## LibXMTP Version
 
 [LibXMTP](https://github.com/xmtp/libxmtp/) is a shared library encapsulating the core functionality of the XMTP messaging protocol, such as cryptography, networking, and language bindings. This version of the Agent SDK uses:
@@ -366,6 +361,11 @@ const agent = await Agent.create(signer, {
 | XMTP Node SDK Version | LibXMTP Version |
 | --------------------- | --------------- |
 | 4.2.2                 | 1.5.3           |
+
+## Debugging
+
+- [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
+- [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
 
 ## Contributing / Feedback
 

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -8,7 +8,7 @@
     "@xmtp/content-type-remote-attachment": "^2.0.2",
     "@xmtp/content-type-reply": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-sdk": "^4.2.1",
+    "@xmtp/node-sdk": "^4.2.2",
     "uint8arrays": "^5.1.0",
     "viem": "^2.37.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,7 +4066,7 @@ __metadata:
     "@xmtp/content-type-remote-attachment": "npm:^2.0.2"
     "@xmtp/content-type-reply": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-sdk": "npm:^4.2.1"
+    "@xmtp/node-sdk": "npm:^4.2.2"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.5"
     typescript: "npm:^5.9.2"
@@ -4298,7 +4298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:^4.2.1, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:^4.2.2, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Document LibXMTP version mapping in `sdks/agent-sdk/README.md` and update `sdks/agent-sdk/package.json` to use `@xmtp/node-sdk` ^4.2.2
This pull request adds documentation to the agent SDK README detailing the relationship between `XMTP Node SDK` 4.2.2 and `LibXMTP` 1.5.3, including a version mapping table and instructions to verify the installed `LibXMTP` using `npm why @xmtp/node-bindings`, and updates the agent SDK dependency to `@xmtp/node-sdk` ^4.2.2 with a corresponding lockfile change.

- Update `@xmtp/node-sdk` dependency to ^4.2.2 in [package.json](https://github.com/xmtp/xmtp-js/pull/1317/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
- Add a 'LibXMTP Version' section with version mapping and verification steps in [README.md](https://github.com/xmtp/xmtp-js/pull/1317/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a)
- Regenerate [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1317/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de) to reflect dependency changes

#### 📍Where to Start
Start with the dependency update in [package.json](https://github.com/xmtp/xmtp-js/pull/1317/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3), then review the new 'LibXMTP Version' section in [README.md](https://github.com/xmtp/xmtp-js/pull/1317/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a) to confirm version mapping and verification instructions.



#### Changes since #1317 opened

- Updated dependency version specification for `@xmtp/node-sdk` [7a50a01]
----

_[Macroscope](https://app.macroscope.com) summarized 7a50a01._
<!-- Macroscope's pull request summary ends here -->