### PR TITLE
Release version 1.5.4

### DIFF
--- a/.changeset/shy-walls-rhyme.md
+++ b/.changeset/shy-walls-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@xmtp/browser-sdk": patch
+"@xmtp/node-sdk": patch
+---
+
+- Fix for Duplicate Welcome errors being fired erroneously
+- Fixes a bug where building a client does a network request when not needed

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -63,7 +63,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/wasm-bindings": "1.5.3",
+    "@xmtp/wasm-bindings": "1.5.4",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -52,7 +52,7 @@
     "@xmtp/content-type-group-updated": "^2.0.2",
     "@xmtp/content-type-primitives": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
-    "@xmtp/node-bindings": "1.5.3"
+    "@xmtp/node-bindings": "1.5.4"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,7 +4093,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/wasm-bindings": "npm:1.5.3"
+    "@xmtp/wasm-bindings": "npm:1.5.4"
     playwright: "npm:^1.55.0"
     rollup: "npm:^4.50.2"
     rollup-plugin-dts: "npm:^6.2.3"
@@ -4291,10 +4291,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.5.3":
-  version: 1.5.3
-  resolution: "@xmtp/node-bindings@npm:1.5.3"
-  checksum: 10/88f6550a96161b41773c01ea2fc8c19021740c456b82a745f623ddc995c6365691193be28cf35ca8bc08f45cf08bbd1613eeedc6ae934160ae80223632cf6c7c
+"@xmtp/node-bindings@npm:1.5.4":
+  version: 1.5.4
+  resolution: "@xmtp/node-bindings@npm:1.5.4"
+  checksum: 10/0365969ef88d8e0cd55fe0197ba65046ed61268d6a9898631df07b39f1fd37f82a549b277bef9ef42446ea8248e8ad8bfc32310b0d4194f573833973c1bbb28d
   languageName: node
   linkType: hard
 
@@ -4309,7 +4309,7 @@ __metadata:
     "@xmtp/content-type-group-updated": "npm:^2.0.2"
     "@xmtp/content-type-primitives": "npm:^2.0.2"
     "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.5.3"
+    "@xmtp/node-bindings": "npm:1.5.4"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.50.2"
@@ -4351,10 +4351,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.5.3":
-  version: 1.5.3
-  resolution: "@xmtp/wasm-bindings@npm:1.5.3"
-  checksum: 10/976a74297ade56107d04bbec8d16b28b38d10fd959266fe419c5fa0a352d32deed215d6fd25444ef7ce15526ba288128a15aaf4bf1c4a428b5d965a04053dafb
+"@xmtp/wasm-bindings@npm:1.5.4":
+  version: 1.5.4
+  resolution: "@xmtp/wasm-bindings@npm:1.5.4"
+  checksum: 10/eeeabfc06e22ad76c49b407947c47744f69054596dff97b25738db665ae523a1e05594ebc30f894105e1c1f9e8cd4bdaa18f8d77f366927500167595ca89689e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Release version 1.5.4 by updating `@xmtp/browser-sdk` to resolve `@xmtp/wasm-bindings` 1.5.4 and `@xmtp/node-sdk` to resolve `@xmtp/node-bindings` 1.5.4
This change updates dependency versions for the browser and node SDKs and records the patch release. It includes a changeset entry describing fixes to duplicate `Welcome` errors and avoiding an unnecessary network request during client build.

- Update `@xmtp/wasm-bindings` to 1.5.4 in `@xmtp/browser-sdk` in [package.json](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82)
- Update `@xmtp/node-bindings` to 1.5.4 in `@xmtp/node-sdk` in [package.json](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
- Add changeset detailing the patch release and notes in [shy-walls-rhyme.md](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-ca59490776bc9d9bbb667efc48be5cdde844098b71d332455ab6b02bc1ef14ef)
- Refresh lockfile entries in [yarn.lock](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2de)

#### 📍Where to Start
Start with the dependency bumps in [sdks/browser-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-9662028c4ecb4e1095fba48caef293e6318267b2ebea2cafd2541417fe7e4e82) and [sdks/node-sdk/package.json](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb), then review the release notes in [.changeset/shy-walls-rhyme.md](https://github.com/xmtp/xmtp-js/pull/1323/files#diff-ca59490776bc9d9bbb667efc48be5cdde844098b71d332455ab6b02bc1ef14ef).

----

_[Macroscope](https://app.macroscope.com) summarized 05c11c9._
<!-- Macroscope's pull request summary ends here -->