### PR TITLE
Remove identity uniqueness

### DIFF
--- a/apps/xmtp.chat-api-service/prisma/migrations/20251014231222_identity_not_unique/migration.sql
+++ b/apps/xmtp.chat-api-service/prisma/migrations/20251014231222_identity_not_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "public"."Profile_identity_key";

--- a/apps/xmtp.chat-api-service/prisma/schema.prisma
+++ b/apps/xmtp.chat-api-service/prisma/schema.prisma
@@ -29,7 +29,7 @@ model Profile {
   avatar      String?
   description String?
   displayName String?
-  identity    String   @unique
+  identity    String
   platform    Platform
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove uniqueness constraint on `Profile.identity` in the chat API service database to allow non-unique identities
This change removes the database-level and schema-level uniqueness on the `Profile.identity` field in the chat API service. It drops the unique index in the migration and updates the Prisma model to make `identity` a non-unique `String`.

- Drop the `Profile_identity_key` unique index in [migration.sql](https://github.com/xmtp/xmtp-js/pull/1346/files#diff-00ea3530607af660aad40367c91606af2a8fe49d8b498dbc6a1c8dd3a82e718a)
- Remove the `@unique` attribute from `Profile.identity` in [schema.prisma](https://github.com/xmtp/xmtp-js/pull/1346/files#diff-4235fcc3ad91b285975904b8e37c956aca555304b434fbb28a471b75eb6f77f2)

#### 📍Where to Start
Start with the migration that drops the unique index in [migration.sql](https://github.com/xmtp/xmtp-js/pull/1346/files#diff-00ea3530607af660aad40367c91606af2a8fe49d8b498dbc6a1c8dd3a82e718a), then review the model change in [schema.prisma](https://github.com/xmtp/xmtp-js/pull/1346/files#diff-4235fcc3ad91b285975904b8e37c956aca555304b434fbb28a471b75eb6f77f2).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7be2823. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->