### PR TITLE
Guard against unreachable web3.bio API service

### DIFF
--- a/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts
+++ b/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts
@@ -23,21 +23,25 @@ const isWeb3BioErrorResponse = (
 
 const fetchFromWeb3Bio = async <T>(path: string) => {
   const endpoint = `${WEB3BIO_API_ENDPOINT}${path}`;
-  const response = await fetch(endpoint, {
-    method: "GET",
-    headers: {
-      "X-API-KEY": `Bearer ${process.env.WEB3BIO_API_KEY}`,
-    },
-  });
+  try {
+    const response = await fetch(endpoint, {
+      method: "GET",
+      headers: {
+        "X-API-KEY": `Bearer ${process.env.WEB3BIO_API_KEY}`,
+      },
+    });
 
-  if (!response.ok) {
-    return {
-      status: response.status,
-      statusText: response.statusText,
-    };
+    if (!response.ok) {
+      return {
+        status: response.status,
+        statusText: response.statusText,
+      };
+    }
+
+    return (await response.json()) as T;
+  } catch {
+    return null;
   }
-
-  return response.json() as Promise<T>;
 };
 
 export const fetchProfiles = async (input: string[]) => {
@@ -50,8 +54,10 @@ export const fetchProfiles = async (input: string[]) => {
   }
 
   const escapedIdentities = escape(JSON.stringify(identities));
-  return await fetchFromWeb3Bio<ProfileResponse[]>(
-    `/profile/batch/${escapedIdentities}`,
+  return (
+    (await fetchFromWeb3Bio<ProfileResponse[]>(
+      `/profile/batch/${escapedIdentities}`,
+    )) ?? []
   );
 };
 
@@ -122,7 +128,9 @@ export const fetchNames = async (input: string[]) => {
   }
 
   const escapedNames = escape(JSON.stringify(identities));
-  return await fetchFromWeb3Bio<NSResponse[]>(`/ns/batch/${escapedNames}`);
+  return (
+    (await fetchFromWeb3Bio<NSResponse[]>(`/ns/batch/${escapedNames}`)) ?? []
+  );
 };
 
 export const batchFetchNames = async (input: string[]) => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Guard against unreachable web3.bio API service by updating `apps/xmtp.chat-api-service/src/helpers/web3.bio.ts` helpers to return null or empty arrays on fetch and parsing failures
Wrap the network call in `fetchFromWeb3Bio` with a try/catch in [web3.bio.ts](https://github.com/xmtp/xmtp-js/pull/1391/files#diff-ac9728d65b934879787e026906534043b57089346619b722dd71608992915576), returning parsed JSON on successful `ok` responses, an object with `status` and `statusText` on non-ok responses, and `null` on exceptions. Adjust `fetchProfiles` and `fetchNames` to coalesce `null` results from `fetchFromWeb3Bio` to `[]`.

- Implement try/catch around the fetch in `fetchFromWeb3Bio` to return `null` on exceptions and parse `response.json()` on `ok` responses in [web3.bio.ts](https://github.com/xmtp/xmtp-js/pull/1391/files#diff-ac9728d65b934879787e026906534043b57089346619b722dd71608992915576)
- Update `fetchProfiles` to return `[]` when `fetchFromWeb3Bio` returns `null`
- Update `fetchNames` to return `[]` when `fetchFromWeb3Bio` returns `null`

#### 📍Where to Start
Start with the `fetchFromWeb3Bio` helper in [web3.bio.ts](https://github.com/xmtp/xmtp-js/pull/1391/files#diff-ac9728d65b934879787e026906534043b57089346619b722dd71608992915576), then review how `fetchProfiles` and `fetchNames` handle `null` by returning empty arrays.

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0705865. 1 files reviewed, 4 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat-api-service/src/helpers/web3.bio.ts — 0 comments posted, 4 evaluated, 3 filtered</summary>

- [line 42](https://github.com/xmtp/xmtp-js/blob/07058655ddc5613c57bd6169682a057adec564b3/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts#L42): `fetchFromWeb3Bio` swallows all exceptions (network failures, timeouts, JSON parse errors) and returns `null` in the `catch` block. This eliminates error context and makes downstream handling ambiguous. Downstream functions (`fetchProfiles`/`fetchNames`) then coalesce `null` to `[]`, silently turning failures into successful-but-empty results, which can cause data loss and mislead callers into thinking the request succeeded. <b>[ Low confidence ]</b>
- [line 58](https://github.com/xmtp/xmtp-js/blob/07058655ddc5613c57bd6169682a057adec564b3/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts#L58): `fetchProfiles` coalesces `null` from `fetchFromWeb3Bio` into `[]` via `?? []`. This turns network/parse failures into a silent successful empty result, bypassing the error-handling branch that checks `isWeb3BioErrorResponse`. As a result, batches that fail will be treated as having no profiles, causing silent data loss and misleading downstream logic. <b>[ Low confidence ]</b>
- [line 132](https://github.com/xmtp/xmtp-js/blob/07058655ddc5613c57bd6169682a057adec564b3/apps/xmtp.chat-api-service/src/helpers/web3.bio.ts#L132): `fetchNames` coalesces `null` from `fetchFromWeb3Bio` into `[]` via `?? []`, mirroring the same silent error-to-empty conversion as `fetchProfiles`. This causes network/parse failures to be treated as a successful empty set of names, bypassing error handling and leading to silent data loss. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->