### PR TITLE
Add v2 name resolver route

### DIFF
--- a/apps/xmtp.chat-api-service/src/api/index.ts
+++ b/apps/xmtp.chat-api-service/src/api/index.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import v1Router from "./v1/index.js";
+import v2Router from "./v2/index.js";
 
 const apiRouter = Router();
 
 apiRouter.use("/v1", v1Router);
+apiRouter.use("/v2", v2Router);
 
 export default apiRouter;

--- a/apps/xmtp.chat-api-service/src/api/v2/index.ts
+++ b/apps/xmtp.chat-api-service/src/api/v2/index.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import resolveRouter from "./resolve.router.js";
+
+const v2Router = Router();
+
+v2Router.use("/resolve", resolveRouter);
+
+export default v2Router;

--- a/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts
+++ b/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts
@@ -1,0 +1,34 @@
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { fetchProfilesFromName } from "../../helpers/web3.bio.js";
+
+export const resolveNameSchema = z.string().endsWith(".eth");
+
+export async function resolveName(req: Request, res: Response) {
+  try {
+    const { name } = req.params;
+    const validName = resolveNameSchema.parse(name);
+    const profiles = await fetchProfilesFromName(validName);
+    if (!profiles || profiles.length === 0) {
+      res.status(404).json({ error: "No profiles found" });
+      return;
+    }
+    res.json({ profiles });
+  } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      console.log("zod error", z.prettifyError(error));
+      res.status(400).json({
+        error: "Invalid request parameter",
+        details: z.treeifyError(error),
+      });
+      return;
+    }
+    console.error(error);
+    res.status(500).json({ error: "Failed to resolve name" });
+  }
+}
+
+const resolveRouter = Router();
+resolveRouter.get("/name/:name", resolveName);
+
+export default resolveRouter;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `/v2/resolve/name/:name` route in `apps/xmtp.chat-api-service` to serve v2 name resolver requests for names ending with `.eth`
Introduce a v2 API namespace and a name resolution endpoint that validates the `:name` parameter and returns profiles or appropriate errors. 

- Mount the v2 router under `/v2` in `apiRouter` in `apps/xmtp.chat-api-service/src/api/index.ts` ([index.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-a1257612819d06f18da48313791d878075a8fa0c7ffc71e2f313a9a620841a50))
- Add `apps/xmtp.chat-api-service/src/api/v2/index.ts` to configure `v2Router` and mount `resolveRouter` at `/resolve` ([index.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-3d374bb4b6235a85fdfa66436c65de09148c6508102e44f09288fe8e81db77f8))
- Implement `GET /v2/resolve/name/:name` in `apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts` with Zod validation requiring `.eth`, profile fetching via `fetchProfilesFromName`, and 200/404/400/500 responses ([resolve.router.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-6510030cefe9a06362b479f57a88d840a58d113afcbc47a13a7249588ead3d43))

#### 📍Where to Start
Start with the `GET /v2/resolve/name/:name` handler `resolveName` in [resolve.router.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-6510030cefe9a06362b479f57a88d840a58d113afcbc47a13a7249588ead3d43), then follow router mounting in [apps/xmtp.chat-api-service/src/api/v2/index.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-3d374bb4b6235a85fdfa66436c65de09148c6508102e44f09288fe8e81db77f8) and [apps/xmtp.chat-api-service/src/api/index.ts](https://github.com/xmtp/xmtp-js/pull/1400/files#diff-a1257612819d06f18da48313791d878075a8fa0c7ffc71e2f313a9a620841a50).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bbcd79a. 2 files reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 19](https://github.com/xmtp/xmtp-js/blob/bbcd79aa705bf861862664b76f58b73d2f8ab6d1/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts#L19): `resolve.router.ts` calls non-existent Zod helper functions `z.prettifyError(error)` (line 19) and `z.treeifyError(error)` (line 22) when handling validation errors. The Zod library does not provide these functions on the `z` namespace. At runtime, if a `ZodError` is thrown by `resolveNameSchema.parse(name)`, attempting to invoke these properties will cause a `TypeError: z.prettifyError is not a function` (and the same for `treeifyError`) inside the catch block. This will result in an unhandled error within the error handler, likely preventing the intended 400 response and instead causing an Express error or a 500/crash, violating at-most-once response guarantees for that request and leaving the error path without a defined terminal state. <b>[ Invalidated by documentation search ]</b>
- [line 31](https://github.com/xmtp/xmtp-js/blob/bbcd79aa705bf861862664b76f58b73d2f8ab6d1/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts#L31): `v2Router` (defined in `index.ts`, line 4) and `resolveRouter` (defined in `resolve.router.ts`, line 31) are created but no route handlers are registered on either router, and `resolveName` (lines 7–29 in `resolve.router.ts`) is not attached to any route. Both routers are exported (`index.ts` line 8 and `resolve.router.ts` line 34), but as-is they expose no endpoints. This wiring omission results in no reachable API routes under these routers, breaking the externally visible contract for resolving names (and any v2 API endpoints) — requests will never reach `resolveName`, and clients will receive 404s at the framework/router level. This is a functional runtime issue due to missing route registration rather than a compile-time error. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->