### PR TITLE
[WIP] Easier enc-key usage

### DIFF
--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -9,7 +9,6 @@
     "@xmtp/content-type-reply": "^2.0.2",
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/node-sdk": "^4.2.3",
-    "uint8arrays": "^5.1.0",
     "viem": "^2.37.6"
   },
   "description": "XMTP Agent SDK for interacting with XMTP networks",

--- a/sdks/agent-sdk/src/bin/generateKeys.ts
+++ b/sdks/agent-sdk/src/bin/generateKeys.ts
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
-import { getRandomValues } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { toString } from "uint8arrays";
+import { Hex } from "viem";
 import { generatePrivateKey } from "viem/accounts";
 
-const generateClientKeys = () => {
-  const walletKey = generatePrivateKey();
-  const dbEncryptionKey = toString(getRandomValues(new Uint8Array(32)), "hex");
+export const generateClientKeys = (): {
+  XMTP_DB_ENCRYPTION_KEY: Hex;
+  XMTP_WALLET_KEY: Hex;
+} => {
+  const randomValues = crypto.getRandomValues(new Uint8Array(32));
+  const dbEncryptionKey = Buffer.from(randomValues).toString("hex");
   return {
-    XMTP_DB_ENCRYPTION_KEY: dbEncryptionKey,
-    XMTP_WALLET_KEY: walletKey,
+    XMTP_DB_ENCRYPTION_KEY: `0x${dbEncryptionKey}`,
+    XMTP_WALLET_KEY: generatePrivateKey(),
   };
 };
 

--- a/sdks/agent-sdk/src/core/Agent.test.ts
+++ b/sdks/agent-sdk/src/core/Agent.test.ts
@@ -20,6 +20,7 @@ import {
   type Conversation,
   type DecodedMessage,
 } from "@xmtp/node-sdk";
+import { generatePrivateKey } from "viem/accounts";
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { filter } from "@/core/filter.js";
 import { createSigner, createUser } from "@/user/User.js";
@@ -58,7 +59,7 @@ describe("Agent", () => {
   });
 
   describe("types", async () => {
-    const user = createUser();
+    const user = createUser(generatePrivateKey());
     const signer = createSigner(user);
     const ephemeralAgent = await Agent.create(signer, {
       env: "dev",

--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -19,7 +19,6 @@ import {
   type DecodedMessage,
   type XmtpEnv,
 } from "@xmtp/node-sdk";
-import { fromString } from "uint8arrays/from-string";
 import { isHex } from "viem/utils";
 import { filter } from "@/core/filter.js";
 import { getInstallationInfo } from "@/debug.js";
@@ -198,7 +197,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     const initializedOptions = { ...(options ?? {}) };
 
     if (process.env.XMTP_DB_ENCRYPTION_KEY) {
-      initializedOptions.dbEncryptionKey = fromString(
+      initializedOptions.dbEncryptionKey = Buffer.from(
         process.env.XMTP_DB_ENCRYPTION_KEY,
         "hex",
       );

--- a/sdks/agent-sdk/src/demo.ts
+++ b/sdks/agent-sdk/src/demo.ts
@@ -1,5 +1,6 @@
 import { loadEnvFile } from "node:process";
 import { TextCodec } from "@xmtp/content-type-text";
+import { generatePrivateKey } from "viem/accounts";
 import { Agent, AgentError } from "./core/index.js";
 import { getTestUrl } from "./debug/log.js";
 import { CommandRouter } from "./middleware/CommandRouter.js";
@@ -13,7 +14,7 @@ try {
 
 const agent = process.env.XMTP_WALLET_KEY
   ? await Agent.createFromEnv()
-  : await Agent.create(createSigner(createUser()), {
+  : await Agent.create(createSigner(createUser(generatePrivateKey())), {
       dbPath: null,
     });
 

--- a/sdks/agent-sdk/src/user/User.ts
+++ b/sdks/agent-sdk/src/user/User.ts
@@ -8,7 +8,7 @@ import {
   type PrivateKeyAccount,
   type WalletClient,
 } from "viem";
-import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { privateKeyToAccount } from "viem/accounts";
 import { sepolia } from "viem/chains";
 
 export type User = {
@@ -18,10 +18,10 @@ export type User = {
 };
 
 export const createUser = (
-  key?: `0x${string}`,
+  key: `0x${string}`,
   chain: Chain = sepolia,
 ): User => {
-  const accountKey = key ?? generatePrivateKey();
+  const accountKey = key;
   const account = privateKeyToAccount(accountKey);
   return {
     key: accountKey,

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -1,3 +1,5 @@
+import { Client } from "./Client";
+
 export type {
   ClientOptions,
   OtherOptions,

--- a/sdks/node-sdk/src/types.ts
+++ b/sdks/node-sdk/src/types.ts
@@ -13,6 +13,8 @@ export type XmtpEnv = keyof typeof ApiUrls;
 export type NetworkOptions = {
   /**
    * Specify which XMTP environment to connect to. (default: `dev`)
+   *
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-a-client#xmtp-network-environments
    */
   env?: XmtpEnv;
   /**
@@ -23,6 +25,8 @@ export type NetworkOptions = {
   /**
    * historySyncUrl can be used to override the `env` flag and connect to a
    * specific endpoint for syncing history
+   *
+   * @see https://docs.xmtp.org/chat-apps/list-stream-sync/history-sync
    */
   historySyncUrl?: string | null;
 };
@@ -54,7 +58,9 @@ export type StorageOptions = {
    */
   dbPath?: string | null | ((inboxId: string) => string);
   /**
-   * Encryption key for the local DB
+   * Encryption key for the local DB (32 bytes, hex)
+   *
+   * @see https://docs.xmtp.org/chat-apps/core-messaging/create-a-client#view-an-encrypted-databas
    */
   dbEncryptionKey?: Uint8Array;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4070,7 +4070,6 @@ __metadata:
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.5"
     typescript: "npm:^5.9.2"
-    uint8arrays: "npm:^5.1.0"
     viem: "npm:^2.37.6"
     vite: "npm:^7.1.5"
     vite-tsconfig-paths: "npm:^5.1.4"
@@ -8234,13 +8233,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multiformats@npm:^13.0.0":
-  version: 13.4.0
-  resolution: "multiformats@npm:13.4.0"
-  checksum: 10/95a796c0c7d99862d588263ebaa2285aa66a5c1d8915356c17d6863749f7fee28407fb9e16b78411c3d2977780c8e87a37a3f88716894dbda63c18a32e229347
-  languageName: node
-  linkType: hard
-
 "multiformats@npm:^9.4.2":
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
@@ -11125,15 +11117,6 @@ __metadata:
   dependencies:
     multiformats: "npm:^9.4.2"
   checksum: 10/536e70273c040484aa7d522031a9dbca1fe8c06eb58a3ace1064ba68825b4e2764d4a0b604a1c451e7b8be0986dc94f23a419cfe9334bd116716074a2d29b33d
-  languageName: node
-  linkType: hard
-
-"uint8arrays@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "uint8arrays@npm:5.1.0"
-  dependencies:
-    multiformats: "npm:^13.0.0"
-  checksum: 10/6c9cd1c1519cdf20d4c4e3715b4ee1acf730636409528ea54e77c4d9aa6e7f70aacd86d735f7c8a9902a9181cc3b37fa048590978e2fb90a98fa1dc39465c1af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Return 0x-prefixed hex keys for Agent SDK key generation and require callers to pass a private key to `User.createUser` to ease enc-key usage
Refactors key handling across the Agent SDK to standardize 0x-prefixed hex strings and remove `uint8arrays` usage. Updates key generation to export `generateClientKeys` and require explicit private keys in `createUser`, and adjusts env parsing to use `Buffer` for a 32-byte hex DB encryption key.

- Export `generateClientKeys` to return `XMTP_DB_ENCRYPTION_KEY` and `XMTP_WALLET_KEY` as 0x-prefixed hex strings in [generateKeys.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-86b5a6125ba1c710736d6492f009d05fd8690d9a11fb5e08716899115757eea0)
- Require a caller-supplied private key in `User.createUser` in [User.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-118d7ca59b4e7634381ee1b1fd3bf3cd0644190d18aa9f3e5738182d9ae7b6c0)
- Parse `XMTP_DB_ENCRYPTION_KEY` with `Buffer.from(hex, 'hex')` in `Agent.createFromEnv` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4)
- Update tests and demo to pass `viem/accounts.generatePrivateKey()` into `createUser` in [Agent.test.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-10cd54ce8c0c7e2e1f12c9c832981c7e72c688df5930175a2838785a0d9e7d61) and [demo.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-3b064fdd3f4f695a10826e6b00730cabce1abc76ff576338c80e97c3575d1872)
- Remove `uint8arrays` from dependencies in [package.json](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)

#### 📍Where to Start
Start with `generateClientKeys` in [sdks/agent-sdk/src/bin/generateKeys.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-86b5a6125ba1c710736d6492f009d05fd8690d9a11fb5e08716899115757eea0), then review `User.createUser` in [sdks/agent-sdk/src/user/User.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-118d7ca59b4e7634381ee1b1fd3bf3cd0644190d18aa9f3e5738182d9ae7b6c0) and `Agent.createFromEnv` in [sdks/agent-sdk/src/core/Agent.ts](https://github.com/xmtp/xmtp-js/pull/1430/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fca3e7d. 5 files reviewed, 3 issues evaluated, 2 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>sdks/agent-sdk/src/bin/generateKeys.ts — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 11](https://github.com/xmtp/xmtp-js/blob/fca3e7da98a611786da7dbf4623cebbfab7125f5/sdks/agent-sdk/src/bin/generateKeys.ts#L11): `generateClientKeys` uses the global Web Crypto API via `crypto.getRandomValues` (line 11). In Node.js, `globalThis.crypto.getRandomValues` is only reliably available in newer Node versions; on older Node versions, `crypto` may be undefined or not include `getRandomValues`, causing a runtime `ReferenceError` or `TypeError`. Since this is a CLI script intended to run under Node and there is no version guard, the call is reachable and would crash at runtime on unsupported environments. A more robust approach in Node is to use `require('crypto').randomBytes(32)` (or `import { randomBytes } from 'crypto'`), which is available across Node versions and does not depend on the Web Crypto global. <b>[ Low confidence ]</b>
- [line 14](https://github.com/xmtp/xmtp-js/blob/fca3e7da98a611786da7dbf4623cebbfab7125f5/sdks/agent-sdk/src/bin/generateKeys.ts#L14): Behavioral contract change for `XMTP_DB_ENCRYPTION_KEY`: the function now prefixes the generated hex with `0x` (line 14), whereas the prior implementation returned a plain hex string without prefix. This alters the external artifact written to `.env` and can break downstream consumers that expect a bare hex key (e.g., libraries or configurations that parse raw hex and reject `0x`-prefixed values). The type annotation `Hex` suggests intent, but the usage writes raw strings to the environment. Without updating all consumers to accept `0x`-prefixed hex, this is a runtime interoperability bug that can cause failures when initializing the XMTP agent or decrypting the DB. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->