### PR TITLE
Ensure working redirect after group creation

### DIFF
--- a/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx
+++ b/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx
@@ -6,9 +6,11 @@ import { useCollapsedMediaQuery } from "@/hooks/useCollapsedMediaQuery";
 import { useConversations } from "@/hooks/useConversations";
 import { useMemberId } from "@/hooks/useMemberId";
 import { ContentLayout } from "@/layouts/ContentLayout";
+import { useActions } from "@/stores/inbox/hooks";
 
 export const CreateDmModal: React.FC = () => {
   const { newDm } = useConversations();
+  const { addConversation } = useActions();
   const [loading, setLoading] = useState(false);
   const {
     memberId,
@@ -29,6 +31,8 @@ export const CreateDmModal: React.FC = () => {
 
     try {
       const conversation = await newDm(inboxId);
+      // ensure conversation is added to store so navigation works
+      await addConversation(conversation);
       void navigate(`/conversations/${conversation.id}`);
     } finally {
       setLoading(false);

--- a/apps/xmtp.chat/src/components/Conversations/CreateGroupModal.tsx
+++ b/apps/xmtp.chat/src/components/Conversations/CreateGroupModal.tsx
@@ -14,6 +14,7 @@ import { isValidEthereumAddress, isValidInboxId } from "@/helpers/strings";
 import { useCollapsedMediaQuery } from "@/hooks/useCollapsedMediaQuery";
 import { useConversations } from "@/hooks/useConversations";
 import { ContentLayout } from "@/layouts/ContentLayout";
+import { useActions } from "@/stores/inbox/hooks";
 import type { PolicySet } from "@/types";
 
 const permissionsPolicyValue = (policy: GroupPermissionsOptions) => {
@@ -29,6 +30,7 @@ const permissionsPolicyValue = (policy: GroupPermissionsOptions) => {
 
 export const CreateGroupModal: React.FC = () => {
   const { newGroup } = useConversations();
+  const { addConversation } = useActions();
   const [loading, setLoading] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -75,6 +77,8 @@ export const CreateGroupModal: React.FC = () => {
         );
       }
 
+      // ensure conversation is added to store so navigation works
+      await addConversation(conversation);
       void navigate(`/conversations/${conversation.id}`);
     } finally {
       setLoading(false);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Ensure working redirect after group creation by adding new conversations to the inbox store in `CreateGroupModal` and `CreateDmModal` before navigation
Add awaited `addConversation` from `useActions` to commit newly created conversations to the inbox store prior to route navigation.

- Call `addConversation` after `newDm` in `CreateDmModal` to persist the DM before redirecting in [CreateDmModal.tsx](https://github.com/xmtp/xmtp-js/pull/1434/files#diff-5999c4df34062651d5ad267e96f480a29937c246f4fee9c8cba2fbb79ee4e73a)
- Call `addConversation` after group creation in `CreateGroupModal` to persist the group before redirecting in [CreateGroupModal.tsx](https://github.com/xmtp/xmtp-js/pull/1434/files#diff-88efea536fb212a1022a0ba417a32da76487077cc28b91ef4ad0fca851b0a345)

#### 📍Where to Start
Start with the `handleCreate` flow in [CreateGroupModal.tsx](https://github.com/xmtp/xmtp-js/pull/1434/files#diff-88efea536fb212a1022a0ba417a32da76487077cc28b91ef4ad0fca851b0a345), then review the analogous `handleCreate` changes in [CreateDmModal.tsx](https://github.com/xmtp/xmtp-js/pull/1434/files#diff-5999c4df34062651d5ad267e96f480a29937c246f4fee9c8cba2fbb79ee4e73a).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 236b939. 2 files reviewed, 8 issues evaluated, 7 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx — 0 comments posted, 5 evaluated, 5 filtered</summary>

- [line 29](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx#L29): No re-entrancy guard: `handleCreate` can be invoked multiple times concurrently (e.g., rapid clicks) because `loading` isn’t used to disable or early-return. This can lead to duplicate DM creation requests, multiple `addConversation` calls (double-application), and race conditions for navigation. Add a guard that returns early when `loading` is true or disables the initiating control while in-flight. <b>[ Low confidence ]</b>
- [line 32](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx#L32): Errors from `newDm(inboxId)` or `addConversation(conversation)` are not caught, and there’s no user-visible error path. In React, an `async` handler that throws/rejects leads to an unhandled promise rejection unless explicitly caught, causing console errors and leaving the UI without feedback. Although `finally` resets `loading`, the user gets no error message and cannot recover. Add a `catch` that reports the error and ensures a defined terminal state. <b>[ Previously rejected ]</b>
- [line 33](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx#L33): `handleCreate` calls `newDm(inboxId)` without validating `inboxId`. If `inboxId` is `undefined`, `null`, or otherwise invalid (which is reachable given `useMemberId()` appears to provide `inboxId` alongside `memberIdError`), `newDm` may throw or create a malformed conversation. This is an unguarded input that can cause a runtime failure or unexpected behavior. Add an explicit check (and user-visible error) before invoking `newDm`. <b>[ Low confidence ]</b>
- [line 35](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx#L35): New dependency on `addConversation` introduces a failure mode where navigation won’t occur even if `newDm` succeeds. If `addConversation(conversation)` rejects (or partially mutates state and then rejects), `navigate` is skipped, leaving the user on the modal and potentially with the conversation present in the store (inconsistency). Consider ensuring navigation still occurs when the conversation exists, or make `addConversation` atomic or retry-once, with clear error reporting. <b>[ Low confidence ]</b>
- [line 36](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx#L36): `conversation` is dereferenced (`conversation.id`) and passed to `addConversation` without verifying it’s a non-null object with an `id`. If `newDm(inboxId)` returns `null`/`undefined` or an object missing `id` (reachable when `inboxId` is invalid or the DM creation fails but returns a sentinel), this will throw or produce a malformed navigation path. Add a guard that verifies `conversation` and `conversation.id` exist before use, with a user-visible fallback. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/xmtp.chat/src/components/Conversations/CreateGroupModal.tsx — 0 comments posted, 3 evaluated, 2 filtered</summary>

- [line 68](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateGroupModal.tsx#L68): Duplicate membership additions are not prevented. Members can be specified both as Inbox IDs (`addedMemberInboxIds` passed to `newGroup`) and as Ethereum addresses added via `addMembersByIdentifiers`. If the same logical user is present in both lists or appears multiple times, the code does not de-duplicate, which can cause errors from the SDK, partial failures, or inconsistent group membership state. <b>[ Low confidence ]</b>
- [line 72](https://github.com/xmtp/xmtp-js/blob/236b9399cc4979bd4fe63bcc24394bde6a1d57cc/apps/xmtp.chat/src/components/Conversations/CreateGroupModal.tsx#L72): If `conversation.addMembersByIdentifiers(...)` throws, the created group will not be added to the store nor navigated to, leaving the newly created group inaccessible in the UI with no rollback or user-visible outcome. The `try` block does not catch errors from member addition separately, and `addConversation(conversation)` plus navigation are skipped on this failure path. <b>[ Previously rejected ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->