### PR TITLE
Prevent sending empty messages

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Composer.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Composer.tsx
@@ -37,7 +37,7 @@ export const Composer: React.FC<ComposerProps> = ({ conversationId }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const remoteAttachmentRef = useRef<RemoteAttachment | null>(null);
   const isSending = sending || uploadingAttachment;
-  const hasContent = message || attachment;
+  const hasContent = message.trim() !== "" || attachment;
 
   const handleFileSelect = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Treat whitespace-only input as empty in `Conversation.Composer` to prevent sending empty messages in [Composer.tsx](https://github.com/xmtp/xmtp-js/pull/1436/files#diff-20ed1230ceee3c7ddb623893b5e354e43472b4c4dd9835854e6d09773a404d9c)
Update `Conversation.Composer` `hasContent` to require `message.trim() !== ""` or an attachment, replacing a truthy check on `message` or attachment in [Composer.tsx](https://github.com/xmtp/xmtp-js/pull/1436/files#diff-7ead040ce0f5dc2d570c69e5b651dc219658a628ca0923c07279670e17abab7c).

#### 📍Where to Start
Start with the `hasContent` logic in `Conversation.Composer` in [Composer.tsx](https://github.com/xmtp/xmtp-js/pull/1436/files#diff-20ed1230ceee3c7ddb623893b5e354e43472b4c4dd9835854e6d09773a404d9c).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 155c9a7. 1 files reviewed, 1 issues evaluated, 1 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/components/Conversation/Composer.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 40](https://github.com/xmtp/xmtp-js/blob/155c9a73c9a045a282735f47543f2ee94c9213b7/apps/xmtp.chat/src/components/Conversation/Composer.tsx#L40): Potential runtime crash due to calling `trim()` on `message` without guaranteeing it is a non-empty string. The updated line uses `message.trim() !== "" || attachment`, which will throw if `message` is `undefined`, `null`, or any non-string value. Previously, `hasContent = message || attachment` did not dereference `message` and was safe for `undefined` or `null`. Unless `message` is always initialized to a string (e.g., `""`) by construction, this change introduces a reachable runtime error on initial render or other states where `message` may be unset. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->