### PR TITLE
Add group members with addresses

### DIFF
--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -548,6 +548,20 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     );
   }
 
+  addMembersWithAddresses<ContentTypes>(
+    group: Group<ContentTypes>,
+    addresses: `0x${string}`[],
+  ) {
+    const identifiers = addresses.map((address) => {
+      return {
+        identifier: address,
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
+
+    return group.addMembersByIdentifiers(identifiers);
+  }
+
   get address() {
     return this.#client.accountIdentifier?.identifier;
   }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `core.Agent.addMembersWithAddresses` to add group members using Ethereum addresses
Introduce a method on `core.Agent` that converts Ethereum-style addresses to `IdentifierKind.Ethereum` identifiers and calls `group.addMembersByIdentifiers` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1438/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).

#### 📍Where to Start
Start with `core.Agent.addMembersWithAddresses` in [Agent.ts](https://github.com/xmtp/xmtp-js/pull/1438/files#diff-86fb5a7aeff0525692d6db76ada7057958f615d7c746035cea44fe3745ac4cb4).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 27757ba. 1 files reviewed, 5 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>sdks/agent-sdk/src/core/Agent.ts — 0 comments posted, 5 evaluated, 3 filtered</summary>

- [line 555](https://github.com/xmtp/xmtp-js/blob/27757ba50f6aca7fa924aa600bc729e9a7cc4e32/sdks/agent-sdk/src/core/Agent.ts#L555): The function calls `addresses.map(...)` without validating that `addresses` is a non-null array. If `addresses` is `undefined`, `null`, or any non-array value at runtime, this will throw a `TypeError` (`Cannot read properties of undefined (reading 'map')`). There is no guard or runtime validation enforcing the declared TypeScript type, so this is reachable in JavaScript execution. <b>[ Low confidence ]</b>
- [line 555](https://github.com/xmtp/xmtp-js/blob/27757ba50f6aca7fa924aa600bc729e9a7cc4e32/sdks/agent-sdk/src/core/Agent.ts#L555): The function does not de-duplicate `addresses` before constructing `identifiers`. If duplicates are present, it may cause duplicate adds, potentially violating a "no double-application" constraint or resulting in errors from `group.addMembersByIdentifiers`. There is no visible guarantee of uniqueness upstream. <b>[ Low confidence ]</b>
- [line 562](https://github.com/xmtp/xmtp-js/blob/27757ba50f6aca7fa924aa600bc729e9a7cc4e32/sdks/agent-sdk/src/core/Agent.ts#L562): The function forwards an empty `identifiers` list when `addresses` is an empty array, without explicit handling. If `group.addMembersByIdentifiers` expects at least one identifier, this could produce an error or a misleading no-op without feedback. The method does not define a terminal state for empty input distinct from success/failure. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->