### PR TITLE
Refactor profiles store to use identity

### DIFF
--- a/apps/xmtp.chat/src/stores/profiles.ts
+++ b/apps/xmtp.chat/src/stores/profiles.ts
@@ -12,6 +12,7 @@ export type Profile = {
   description: string | null;
   displayName: string | null;
   platform: Platform | null;
+  identity: string | null;
 };
 
 export const createEmptyProfile = (address: string): Profile => ({
@@ -20,6 +21,7 @@ export const createEmptyProfile = (address: string): Profile => ({
   description: null,
   displayName: null,
   platform: null,
+  identity: null,
 });
 
 // alias types for clarity
@@ -56,8 +58,8 @@ export const profilesStore = createStore<ProfilesState & ProfilesActions>()(
       const newProfiles = new Map(state.profiles);
       const existingProfiles = state.profiles.get(profile.address) ?? [];
       newProfiles.set(profile.address, [...existingProfiles, profile]);
-      if (profile.displayName) {
-        newNames.set(profile.displayName, profile.address);
+      if (profile.identity) {
+        newNames.set(profile.identity, profile.address);
       }
       set(() => ({
         profiles: newProfiles,
@@ -74,8 +76,8 @@ export const profilesStore = createStore<ProfilesState & ProfilesActions>()(
         }
         const existingProfiles = state.profiles.get(profile.address) ?? [];
         newProfiles.set(profile.address, [...existingProfiles, profile]);
-        if (profile.displayName) {
-          newNames.set(profile.displayName, profile.address);
+        if (profile.identity) {
+          newNames.set(profile.identity, profile.address);
         }
       }
       set(() => ({
@@ -122,20 +124,21 @@ export const profilesStore = createStore<ProfilesState & ProfilesActions>()(
 export const combineProfiles = (
   address: string,
   profiles: Profile[],
-  displayName?: string,
+  identity?: string,
 ) => {
-  const isValidDisplayName =
-    displayName &&
-    profiles.some((profile) => profile.displayName === displayName);
+  const forcedProfile = profiles.find(
+    (profile) => profile.identity === identity,
+  );
   return profiles.reduce((profile, value) => {
     return {
       ...profile,
-      displayName: isValidDisplayName
-        ? displayName
+      displayName: forcedProfile
+        ? forcedProfile.displayName
         : (profile.displayName ?? value.displayName),
       avatar: profile.avatar ?? value.avatar,
       description: profile.description ?? value.description,
       platform: profile.platform ?? value.platform,
+      identity: profile.identity ?? value.identity,
     };
   }, createEmptyProfile(address));
 };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor profiles store in `apps/xmtp.chat/src/stores/profiles.ts` to key names by `Profile.identity` and accept identity in `combineProfiles`
The profiles store shifts from displayName-based logic to identity-based logic.

- Add `identity: string | null` to `Profile` and return `identity: null` from `createEmptyProfile` in [profiles.ts](https://github.com/xmtp/xmtp-js/pull/1443/files#diff-5122a5eca0af6b518c080ac60fcacb380adca5da84039e35d4b203393d1e2327)
- Update `profilesStore.addProfile` and `profilesStore.addProfiles` to key the `names` map by `profile.identity` when present in [profiles.ts](https://github.com/xmtp/xmtp-js/pull/1443/files#diff-5122a5eca0af6b518c080ac60fcacb380adca5da84039e35d4b203393d1e2327)
- Change `combineProfiles` to accept `identity?: string`, derive `displayName` from the matching profile, and merge `identity` into the result in [profiles.ts](https://github.com/xmtp/xmtp-js/pull/1443/files#diff-5122a5eca0af6b518c080ac60fcacb380adca5da84039e35d4b203393d1e2327)

#### 📍Where to Start
Start with `combineProfiles` and the `profilesStore.addProfile`/`profilesStore.addProfiles` methods in [profiles.ts](https://github.com/xmtp/xmtp-js/pull/1443/files#diff-5122a5eca0af6b518c080ac60fcacb380adca5da84039e35d4b203393d1e2327).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized da0174e. 1 file reviewed, 5 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/stores/profiles.ts — 0 comments posted, 5 evaluated, 4 filtered</summary>

- [line 46](https://github.com/xmtp/xmtp-js/blob/da0174e30e50ea53adec1b578435ee34e3ae8043/apps/xmtp.chat/src/stores/profiles.ts#L46): `EMPTY_PROFILES` is a shared mutable array returned by `getProfiles(address)` when no profiles exist and by `getProfilesByName` when no address is found. External callers can mutate this array (e.g., `push`), inadvertently affecting all subsequent empty-profile reads across the app. Return a new empty array or a frozen array to avoid global state corruption. <b>[ Out of scope ]</b>
- [line 61](https://github.com/xmtp/xmtp-js/blob/da0174e30e50ea53adec1b578435ee34e3ae8043/apps/xmtp.chat/src/stores/profiles.ts#L61): Silent overwrite in `names` map on duplicate `identity` keys. If multiple profiles provide the same `identity` but map to different `address` values, `newNames.set(profile.identity, profile.address)` will overwrite previous entries without any validation or error. This silently violates uniqueness/mutual-exclusion constraints and can lead to inconsistent lookups. <b>[ Low confidence ]</b>
- [line 77](https://github.com/xmtp/xmtp-js/blob/da0174e30e50ea53adec1b578435ee34e3ae8043/apps/xmtp.chat/src/stores/profiles.ts#L77): `addProfiles` reads `existingProfiles` from `state.profiles` instead of the progressively updated `newProfiles` within the loop. When the input `profiles` array contains multiple profiles for the same `address`, each iteration overwrites the previous entry with `existingProfiles (from the original state) + current profile`, effectively dropping previously processed profiles in the same batch. This yields only the last profile in the batch per address. Use `newProfiles.get(profile.address)` when building up the batch. <b>[ Out of scope ]</b>
- [line 102](https://github.com/xmtp/xmtp-js/blob/da0174e30e50ea53adec1b578435ee34e3ae8043/apps/xmtp.chat/src/stores/profiles.ts#L102): `names` map now stores `identity -> address` (see `addProfile`/`addProfiles`), but `getProfilesByName(name)` still accepts a `name` string and implies lookup by display name. This silently changes the contract: callers passing a display name will not find profiles anymore, because the map is keyed by identity. The semantic mismatch between `names: Map<DisplayName, Address>` and the stored keys (`identity`) causes incorrect lookups. <b>[ Low confidence ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->