### PR TITLE
Add minimum width to audio tags

### DIFF
--- a/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx
@@ -208,6 +208,7 @@ export const RemoteAttachmentContent: React.FC<
             controls
             style={{
               width: "100%",
+              minWidth: "300px",
               display: "block",
             }}
           />


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set a 300px minimum width on `<audio>` in `Messages.RemoteAttachmentContent` to address audio tag sizing
Add a `minWidth: "300px"` style to the `<audio>` element rendered by `Messages.RemoteAttachmentContent` in [RemoteAttachmentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1449/files#diff-d7d40b72b8c21795b6b272d198b05219ffa531fe902ac513c10e21ea4f0772ab).

#### 📍Where to Start
Start with the audio rendering logic in `Messages.RemoteAttachmentContent` in [RemoteAttachmentContent.tsx](https://github.com/xmtp/xmtp-js/pull/1449/files#diff-d7d40b72b8c21795b6b272d198b05219ffa531fe902ac513c10e21ea4f0772ab).

----

<!-- MACROSCOPE_FOOTER_START -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 400bf5c. 1 file reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>

- [line 74](https://github.com/xmtp/xmtp-js/blob/400bf5c753377b6a1ad001791a4ebc08562f2529/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx#L74): Every successful load creates a Blob URL via `URL.createObjectURL` (line 74) and caches it in the global `urlCache`, but the code never calls `URL.revokeObjectURL`—not when the component unmounts, not when the cache is overwritten, and not when an attachment is no longer displayed. Because the cache retains the URL strings indefinitely, each attachment keeps its Blob alive for the lifetime of the app, causing an unbounded in-memory leak. <b>[ Out of scope ]</b>
- [line 82](https://github.com/xmtp/xmtp-js/blob/400bf5c753377b6a1ad001791a4ebc08562f2529/apps/xmtp.chat/src/components/Messages/RemoteAttachmentContent.tsx#L82): `loadAttachment` captures the current `content` values when it kicks off the async load. If the `content` prop changes before `RemoteAttachmentCodec.load` resolves, this function still runs `setDecryptedUrl(blobUrl)` for the *old* attachment (line 82). The component already wipes `decryptedUrl` to `null` on prop changes, but that reset is immediately overwritten by the late-arriving promise, so the UI shows the previous attachment while the rest of the component renders metadata for the new `content`. A simple way to fix is to capture `content.url` at invocation and verify it still matches (or abort) before calling `setDecryptedUrl` and updating the cache. <b>[ Out of scope ]</b>
</details>


</details>
<!-- MACROSCOPE_FOOTER_END -->
<!-- Macroscope's pull request summary ends here -->