### PR TITLE
Add stale issue management

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add scheduled GitHub Actions workflow to mark issues stale after 3 days and close after 7 days in [.github/workflows/stale.yml](https://github.com/xmtp/xmtp-js/pull/1454/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) to manage stale issues
Introduce a daily `actions/stale@v10` workflow at 00:00 UTC with write permissions that marks issues stale after 3 days, closes issues after 7 days, and leaves pull requests unclosed (`days-before-pr-close: -1`).

#### 📍Where to Start
Start with the workflow configuration in [.github/workflows/stale.yml](https://github.com/xmtp/xmtp-js/pull/1454/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d235fc5. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->