### PR TITLE
Add disclaimer to xmtp.chat

### DIFF
--- a/apps/xmtp.chat/src/components/App/AppLayout.tsx
+++ b/apps/xmtp.chat/src/components/App/AppLayout.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 import { AppFooter } from "@/components/App/AppFooter";
 import { AppHeader } from "@/components/App/AppHeader";
+import { Disclaimer } from "@/components/App/Disclaimer";
 import { ConversationsNavbar } from "@/components/Conversations/ConversationsNavbar";
 import { useXMTP } from "@/contexts/XMTPContext";
 import { useRedirect } from "@/hooks/useRedirect";
@@ -41,19 +42,22 @@ export const AppLayout: React.FC = () => {
       <LoadingOverlay visible />
     </CenteredLayout>
   ) : (
-    <MainLayout>
-      <MainLayoutHeader>
-        <AppHeader client={client} opened={opened} toggle={toggle} />
-      </MainLayoutHeader>
-      <MainLayoutNav opened={opened} toggle={toggle}>
-        <ConversationsNavbar />
-      </MainLayoutNav>
-      <MainLayoutContent>
-        <Outlet />
-      </MainLayoutContent>
-      <MainLayoutFooter>
-        <AppFooter />
-      </MainLayoutFooter>
-    </MainLayout>
+    <>
+      <MainLayout>
+        <MainLayoutHeader>
+          <AppHeader client={client} opened={opened} toggle={toggle} />
+        </MainLayoutHeader>
+        <MainLayoutNav opened={opened} toggle={toggle}>
+          <ConversationsNavbar />
+        </MainLayoutNav>
+        <MainLayoutContent>
+          <Outlet />
+        </MainLayoutContent>
+        <MainLayoutFooter>
+          <AppFooter />
+        </MainLayoutFooter>
+      </MainLayout>
+      <Disclaimer />
+    </>
   );
 };

--- a/apps/xmtp.chat/src/components/App/Disclaimer.tsx
+++ b/apps/xmtp.chat/src/components/App/Disclaimer.tsx
@@ -1,0 +1,46 @@
+import { Button, Group, Text } from "@mantine/core";
+import { Modal } from "@/components/Modal";
+import { useCollapsedMediaQuery } from "@/hooks/useCollapsedMediaQuery";
+import { useSettings } from "@/hooks/useSettings";
+import { ContentLayout } from "@/layouts/ContentLayout";
+
+export const Disclaimer: React.FC = () => {
+  const { showDisclaimer, setShowDisclaimer } = useSettings();
+  const fullScreen = useCollapsedMediaQuery();
+
+  return (
+    <Modal
+      centered
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      withCloseButton={false}
+      fullScreen={fullScreen}
+      opened={showDisclaimer}
+      onClose={() => {
+        setShowDisclaimer(false);
+      }}
+      padding={0}>
+      <ContentLayout
+        title="Disclaimer"
+        footer={
+          <Group align="center" justify="center" w="100%" p="md">
+            <Button
+              onClick={() => {
+                setShowDisclaimer(false);
+              }}>
+              I understand
+            </Button>
+          </Group>
+        }
+        withScrollArea={false}
+        withScrollFade={false}
+        withScrollAreaPadding={false}>
+        <Text p="md">
+          XMTP has no token or airdrop and will never ask you for funds. Anyone
+          making such claims—even if they appear official—is attempting to
+          defraud you. Be cautious when messaging with unknown addresses.
+        </Text>
+      </ContentLayout>
+    </Modal>
+  );
+};

--- a/apps/xmtp.chat/src/hooks/useSettings.ts
+++ b/apps/xmtp.chat/src/hooks/useSettings.ts
@@ -59,6 +59,11 @@ export const useSettings = () => {
     defaultValue: false,
     getInitialValueInEffect: false,
   });
+  const [showDisclaimer, setShowDisclaimer] = useLocalStorage<boolean>({
+    key: "XMTP_SHOW_DISCLAIMER",
+    defaultValue: true,
+    getInitialValueInEffect: false,
+  });
 
   return {
     autoConnect,
@@ -71,6 +76,7 @@ export const useSettings = () => {
     forceSCW,
     loggingLevel,
     useSCW,
+    showDisclaimer,
     setAutoConnect,
     setBlockchain,
     setConnector,
@@ -81,5 +87,6 @@ export const useSettings = () => {
     setForceSCW,
     setLoggingLevel,
     setUseSCW,
+    setShowDisclaimer,
   };
 };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Render a modal disclaimer in xmtp.chat by adding `Disclaimer` to `AppLayout` in [AppLayout.tsx](https://github.com/xmtp/xmtp-js/pull/1477/files#diff-7b352ce15cbb8c2281a61ec851102cb96af7d906ccdca0646247d2477e082c4b)
Add `Disclaimer` to the authenticated render path in `AppLayout`, introduce a persisted `showDisclaimer` setting via `useSettings`, and display a non-dismissable modal with an acknowledge button in `Disclaimer`.

#### 📍Where to Start
Start with the authenticated branch in `AppLayout` where `Disclaimer` is rendered after `MainLayout` in [AppLayout.tsx](https://github.com/xmtp/xmtp-js/pull/1477/files#diff-7b352ce15cbb8c2281a61ec851102cb96af7d906ccdca0646247d2477e082c4b), then review the modal behavior in [Disclaimer.tsx](https://github.com/xmtp/xmtp-js/pull/1477/files#diff-92c4477b93481479ac21bcd66020d085d3c1b101f8b53589cd1dec99ebf82a60) and the `showDisclaimer` state in [useSettings.ts](https://github.com/xmtp/xmtp-js/pull/1477/files#diff-3352baf8ab72df764886915121861c43c08a6c8127be64e615d9b6b3f5a2c287).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5013497. 3 files reviewed, 8 issues evaluated, 8 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/components/App/AppLayout.tsx — 0 comments posted, 3 evaluated, 3 filtered</summary>

- [line 27](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/components/App/AppLayout.tsx#L27): The `useEffect` that saves the redirect URL depends only on `client`. If `client` remains falsy for a period and the user changes the location (e.g., via manual URL edit or navigation within unauthenticated routes), the redirect URL will not be updated because `location` is not a dependency. Including `location.pathname` and `location.search` (and `location.hash` per the other issue) in the dependency array or handling updates on route change would prevent saving a stale redirect target. <b>[ Low confidence ]</b>
- [line 34](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/components/App/AppLayout.tsx#L34): The redirect URL saved omits the hash fragment (`location.hash`). At a data-conversion boundary (capturing the URL for later redirect), silently dropping the fragment can lose state if the app or linked content uses hash-based anchors. Preserve the full URL components, e.g., `${location.pathname}${location.search}${location.hash}`, or explicitly document that hash fragments are intentionally ignored. <b>[ Low confidence ]</b>
- [line 36](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/components/App/AppLayout.tsx#L36): Unconditional navigation to `"/welcome"` occurs whenever `client` is falsy, even if the current route is already `"/welcome"`. This can create redundant history entries and an unnecessary navigation side-effect. The guard around saving the redirect URL does not guard the `navigate` call. Consider guarding the `navigate` call with `if (location.pathname !== "/welcome")` or using `replace: true` to avoid stacking identical entries. The relevant code is the `navigate("/welcome")` call inside the `useEffect`. <b>[ Code style ]</b>
</details>

<details>
<summary>apps/xmtp.chat/src/components/App/Disclaimer.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 15](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/components/App/Disclaimer.tsx#L15): The `Disclaimer` modal intentionally disables closing via escape, outside click, and close button (`closeOnEscape={false}`, `closeOnClickOutside={false}`, `withCloseButton={false}`). Combined with `withScrollArea={false}` and `withScrollFade={false}` on `ContentLayout`, this can trap users if the "I understand" button becomes inaccessible (e.g., overflowing content on very small viewports, keyboard-only users unable to reach the button). Provide at least one guaranteed accessible dismissal mechanism (e.g., allow escape to close, ensure content is scrollable, or keep the close button enabled), and verify focus management so every state reaches a defined terminal outcome. <b>[ Low confidence ]</b>
</details>

<details>
<summary>apps/xmtp.chat/src/hooks/useSettings.ts — 0 comments posted, 4 evaluated, 4 filtered</summary>

- [line 7](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/hooks/useSettings.ts#L7): Values loaded from `localStorage` are trusted without runtime validation, which can return invalid values for constrained settings such as `environment` (`XmtpEnv`), `loggingLevel` (`ClientOptions["loggingLevel"]`), and `connector` (`ConnectorString`). Because `useLocalStorage` performs JSON (de)serialization but does not validate enumerations, stale or user-modified `localStorage` entries (e.g., from an older app version or devtools edits) can produce invalid strings typed as valid at compile-time, leading to downstream runtime errors or inconsistent behavior. For example: `environment` (lines 7–11), `loggingLevel` (lines 30–36), and `connector` (lines 52–56) should be validated against allowed values after retrieval and fallback to a safe default on mismatch. <b>[ Low confidence ]</b>
- [line 7](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/hooks/useSettings.ts#L7): Potential SSR hydration mismatch or server-side access discrepancy: all `useLocalStorage` calls set `getInitialValueInEffect: false`, which reads from storage synchronously during render. In SSR contexts, the server render will not read `window.localStorage` and likely use `defaultValue`, while the client render may immediately read a different stored value, causing React hydration warnings or UI flicker. This applies to all keys (e.g., lines 7–11, 12–17, 18–22, 23–29, 30–36, 37–41, 42–46, 47–51, 52–56, 57–61, 62–66). Consider setting `getInitialValueInEffect: true` for SSR safety or gating hook usage to client-only components. <b>[ Low confidence ]</b>
- [line 12](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/hooks/useSettings.ts#L12): `ephemeralAccountKey` is typed as `Hex | null` but the value retrieved from `localStorage` is not validated to be a proper hex string (e.g., `0x`-prefixed and even length). A malformed string stored in `XMTP_EPHEMERAL_ACCOUNT_KEY` (lines 12–17) would propagate as though valid, potentially causing downstream cryptographic/API failures at runtime. Add format validation (and null fallback) when reading from storage. <b>[ Out of scope ]</b>
- [line 37](https://github.com/xmtp/xmtp-js/blob/50134975885ca4bad6085622522f2cbc673a4a53/apps/xmtp.chat/src/hooks/useSettings.ts#L37): Numeric and boolean settings retrieved from `localStorage` are not validated or coerced, risking type/shape mismatches at runtime. For example: `blockchain` is typed as `number` but a stored string (e.g. "137") or malformed value could be returned (lines 47–51); `forceSCW`, `useSCW`, `autoConnect`, and `showDisclaimer` are typed as booleans but could be stored as strings (lines 37–41, 42–46, 57–61, 62–66). Without runtime checks/coercion, consumers may perform numeric/boolean operations and encounter unexpected behavior (e.g., string concatenation instead of arithmetic, truthy string values, or NaN propagation). Add explicit parsing/validation with fallback to defaults for these fields. <b>[ Low confidence ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->