### PR TITLE
Fix sentry workflow

### DIFF
--- a/.github/workflows/xmtp-chat-sentry.yml
+++ b/.github/workflows/xmtp-chat-sentry.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Build
-        working-directory: apps/xmtp.chat
         run: yarn build
       - name: Create Sentry release
         uses: getsentry/action-release@v3


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Run `yarn build` from the repository root in the xmtp-chat-sentry GitHub Actions workflow to fix the Sentry workflow
Update the xmtp-chat-sentry GitHub Actions workflow to remove the `working-directory` on the Build step so `yarn build` runs from the repository root, modifying [xmtp-chat-sentry.yml](https://github.com/xmtp/xmtp-js/pull/1485/files#diff-ed0845fd319dff8632676fe3535c919a8f8ab1fe341fc4184e13abf5b5299a4b).

#### 📍Where to Start
Start with the Build step in [xmtp-chat-sentry.yml](https://github.com/xmtp/xmtp-js/pull/1485/files#diff-ed0845fd319dff8632676fe3535c919a8f8ab1fe341fc4184e13abf5b5299a4b) to review the removal of the `working-directory` setting and confirm the root-level `yarn build` execution.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a1f95d6. 0 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->