### PR TITLE
Disable transactions for ephemeral wallets

### DIFF
--- a/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, List, Space, Text } from "@mantine/core";
+import { Box, Button, List, Space, Text, Tooltip } from "@mantine/core";
 import {
   ContentTypeTransactionReference,
   type TransactionReference,
@@ -7,6 +7,7 @@ import type { WalletSendCallsParams } from "@xmtp/content-type-wallet-send-calls
 import { useCallback } from "react";
 import { useChainId, useSendTransaction, useSwitchChain } from "wagmi";
 import { useClient } from "@/contexts/XMTPContext";
+import { useSettings } from "@/hooks/useSettings";
 
 export type WalletSendCallsContentProps = {
   content: WalletSendCallsParams;
@@ -21,6 +22,7 @@ export const WalletSendCallsContent: React.FC<WalletSendCallsContentProps> = ({
   const { sendTransactionAsync } = useSendTransaction();
   const { switchChainAsync } = useSwitchChain();
   const wagmiChainId = useChainId();
+  const { ephemeralAccountEnabled } = useSettings();
 
   const handleSubmit = useCallback(async () => {
     const chainId = parseInt(content.chainId, 16);
@@ -69,14 +71,19 @@ export const WalletSendCallsContent: React.FC<WalletSendCallsContentProps> = ({
         ))}
       </List>
       <Space h="md" />
-      <Button
-        fullWidth
-        onClick={(event) => {
-          event.stopPropagation();
-          void handleSubmit();
-        }}>
-        Submit
-      </Button>
+      <Tooltip
+        label="Transactions are not supported for ephemeral wallets"
+        disabled={!ephemeralAccountEnabled}>
+        <Button
+          fullWidth
+          disabled={ephemeralAccountEnabled}
+          onClick={(event) => {
+            event.stopPropagation();
+            void handleSubmit();
+          }}>
+          Submit
+        </Button>
+      </Tooltip>
     </Box>
   );
 };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Disable the Submit button and show a tooltip in `Messages/WalletSendCallsContent.tsx` when ephemeral wallets are enabled to block transactions
Add `Tooltip` and `useSettings` to `WalletSendCallsContent` and gate the Submit button with `ephemeralAccountEnabled`, disabling clicks and displaying a tooltip that states transactions are not supported for ephemeral wallets. See [WalletSendCallsContent.tsx](https://github.com/xmtp/xmtp-js/pull/1487/files#diff-7a5e7aeaa095719baa8b7b21cf36ad9571137eb5b016132138e51b41f08d9063).

#### 📍Where to Start
Start with the `WalletSendCallsContent` component in [WalletSendCallsContent.tsx](https://github.com/xmtp/xmtp-js/pull/1487/files#diff-7a5e7aeaa095719baa8b7b21cf36ad9571137eb5b016132138e51b41f08d9063) to review the `Tooltip` integration and the `ephemeralAccountEnabled` gating of the Submit button.

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7676a9e. 1 file reviewed, 5 issues evaluated, 4 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx — 0 comments posted, 5 evaluated, 4 filtered</summary>

- [line 27](https://github.com/xmtp/xmtp-js/blob/7676a9e66379518f8321c82ba00aa690bda3d3e3/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx#L27): `handleSubmit` does not catch rejections from `switchChainAsync` or `sendTransactionAsync`. The click handler invokes `void handleSubmit()`, so any rejection becomes an unhandled promise rejection, leading to noisy errors and bypassing any user-visible failure state. The `onError` option to `sendTransactionAsync` logs but does not prevent the promise from rejecting. Wrap the body in `try/catch`, handle failures gracefully, and ensure all exit paths produce a defined outcome. <b>[ Previously rejected ]</b>
- [line 28](https://github.com/xmtp/xmtp-js/blob/7676a9e66379518f8321c82ba00aa690bda3d3e3/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx#L28): If `content.chainId` is malformed, `parseInt(content.chainId, 16)` yields `NaN`. The subsequent comparison `chainId !== wagmiChainId` is true, and `switchChainAsync({ chainId })` is called with `NaN`, causing a runtime error. Similarly, invalid hex in `call.value` or `call.gas` results in `parseInt(...)` returning `NaN`, and `BigInt(NaN)` throws a `TypeError`. Validate that `content.chainId`, `call.value`, and `call.gas` are valid hex strings before parsing, and handle errors gracefully. <b>[ Low confidence ]</b>
- [line 52](https://github.com/xmtp/xmtp-js/blob/7676a9e66379518f8321c82ba00aa690bda3d3e3/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx#L52): Order of effects can leave the system in an inconsistent state: each transaction is broadcast (`sendTransactionAsync`) before verifying the conversation exists. If `client.conversations.getConversationById(conversationId)` later returns `undefined`, the code logs and returns without posting the transaction reference, leaving the user with a submitted on-chain transaction but no corresponding message. Check for conversation existence before sending any transaction, and ensure all exit paths preserve intended invariants (either post references or abort without sending transactions). <b>[ Low confidence ]</b>
- [line 63](https://github.com/xmtp/xmtp-js/blob/7676a9e66379518f8321c82ba00aa690bda3d3e3/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx#L63): `handleSubmit`'s dependency array omits `wagmiChainId` and `switchChainAsync`, both used within the callback. This can cause `handleSubmit` to read stale values (e.g., a previous chain id), leading to incorrect chain mismatch detection and failure to switch chains appropriately if the network changes before clicking Submit. Add `wagmiChainId` and `switchChainAsync` to the dependency list. <b>[ Code style ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->

Preview

![Screenshot 2025-11-05 at 3 01 54 PM](https://github.com/user-attachments/assets/957554e4-1f17-401a-916f-87d0a58ad2ec)
