### PR TITLE
Remove setRedirectUrl on disconnect

### DIFF
--- a/apps/xmtp.chat/src/components/App/AppMenu.tsx
+++ b/apps/xmtp.chat/src/components/App/AppMenu.tsx
@@ -1,19 +1,16 @@
 import { ActionIcon, Menu } from "@mantine/core";
 import { useCallback } from "react";
 import { useNavigate } from "react-router";
-import { useRedirect } from "@/hooks/useRedirect";
 import { useSettings } from "@/hooks/useSettings";
 import { IconDots } from "@/icons/IconDots";
 
 export const AppMenu: React.FC = () => {
   const navigate = useNavigate();
-  const { setRedirectUrl } = useRedirect();
   const { environment } = useSettings();
 
   const handleDisconnect = useCallback(() => {
-    setRedirectUrl(`${location.pathname}${location.search}`);
     void navigate("/disconnect");
-  }, [navigate, setRedirectUrl]);
+  }, [navigate]);
 
   return (
     <Menu shadow="md" position="bottom-end">


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove redirect setting from `AppMenu` disconnect flow to navigate directly to `/disconnect`
The `AppMenu` component stops importing `useRedirect` and removes setting a redirect URL in `handleDisconnect`, leaving only `navigate('/disconnect')`. Dependencies and imports are updated accordingly in [AppMenu.tsx](https://github.com/xmtp/xmtp-js/pull/1499/files#diff-eaef80185d086df61ee2e360b206b477666f5304332cc7256d70f0d3ce39bdfe).

#### 📍Where to Start
Start with the `handleDisconnect` callback in [AppMenu.tsx](https://github.com/xmtp/xmtp-js/pull/1499/files#diff-eaef80185d086df61ee2e360b206b477666f5304332cc7256d70f0d3ce39bdfe).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized aa7b339.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->