### PR TITLE
Add exempt labels for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          exempt-issue-labels: 'wip,important,pinned'
+          exempt-issue-labels: "wip,important,pinned"
           days-before-stale: 3
           days-before-close: 7
           days-before-pr-close: -1


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add exempt issue labels to the GitHub Actions stale workflow in [stale.yml](https://github.com/xmtp/xmtp-js/pull/1502/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) to prevent marking issues with labels "wip", "important", and "pinned" as stale
Introduce `exempt-issue-labels` to the `actions/stale` step in [stale.yml](https://github.com/xmtp/xmtp-js/pull/1502/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) with values `wip`, `important`, and `pinned`.

#### 📍Where to Start
Start in [stale.yml](https://github.com/xmtp/xmtp-js/pull/1502/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) at the `actions/stale` step and review the `exempt-issue-labels` configuration.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b7ec928.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->