### PR TITLE
Fix accidental publishing

### DIFF
--- a/sdks/node-sdk/CHANGELOG.md
+++ b/sdks/node-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/node-sdk
 
+## 4.3.1
+
+Fixed accidental publishing of `4.3.0`
+
 ## 4.2.6
 
 ### Patch Changes

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/node-sdk",
-  "version": "4.2.6",
+  "version": "4.3.1",
   "description": "XMTP Node client SDK for interacting with XMTP networks",
   "keywords": [
     "xmtp",


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Update Node SDK version to 4.3.1 to fix accidental publishing of 4.3.0 in [package.json](https://github.com/xmtp/xmtp-js/pull/1508/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb)
Bump the Node SDK version to 4.3.1 and add a 4.3.1 changelog entry noting the fix for accidental 4.3.0 publishing in [CHANGELOG.md](https://github.com/xmtp/xmtp-js/pull/1508/files#diff-db5a4eeef0a8dfa24b1588eae9e1f19dc84c99e4200218c4a568995cab681110).

#### 📍Where to Start
Start with the version change in `package.json` at [package.json](https://github.com/xmtp/xmtp-js/pull/1508/files#diff-cbb4c498d795050d33eefc1eff8544d36f5a4976898b6d3e300948820f34e8cb).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 48ebc07.
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->