### PR TITLE
Locking XMTP Proto version

### DIFF
--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -71,6 +71,7 @@
     "@xmtp/content-type-transaction-reference": "^2.0.2",
     "@xmtp/content-type-wallet-send-calls": "^2.0.0",
     "@xmtp/node-sdk": "4.3.1",
+    "@xmtp/proto": "3.78.0",
     "viem": "^2.37.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4270,6 +4270,7 @@ __metadata:
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^2.0.0"
     "@xmtp/node-sdk": "npm:4.3.1"
+    "@xmtp/proto": "npm:3.78.0"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.6"
     typescript: "npm:^5.9.3"
@@ -4570,7 +4571,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/proto@npm:^3.78.0":
+"@xmtp/proto@npm:3.78.0, @xmtp/proto@npm:^3.78.0":
   version: 3.78.0
   resolution: "@xmtp/proto@npm:3.78.0"
   dependencies:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Pin `sdks/agent-sdk` to `@xmtp/proto@3.78.0` in [package.json](https://github.com/xmtp/xmtp-js/pull/1539/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3) to lock the XMTP Proto version
Add `@xmtp/proto` dependency at version `3.78.0` in `sdks/agent-sdk` and update `yarn.lock` to reflect the resolved versions.

#### 📍Where to Start
Start with the dependencies section in [package.json](https://github.com/xmtp/xmtp-js/pull/1539/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 04f867d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->