### PR TITLE
feat: add attachment utility functions

### DIFF
--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -41,6 +41,10 @@
     "./user": {
       "types": "./dist/user.d.ts",
       "import": "./dist/user.js"
+    },
+    "./utils": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js"
     }
   },
   "main": "dist/index.js",

--- a/sdks/agent-sdk/src/utils.ts
+++ b/sdks/agent-sdk/src/utils.ts
@@ -1,0 +1,2 @@
+export * from "./utils/index.js";
+

--- a/sdks/agent-sdk/src/utils/atttachment.ts
+++ b/sdks/agent-sdk/src/utils/atttachment.ts
@@ -1,0 +1,71 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  AttachmentCodec,
+  RemoteAttachmentCodec,
+  type Attachment,
+  type RemoteAttachment,
+} from "@xmtp/content-type-remote-attachment";
+import type { Client } from "@xmtp/node-sdk";
+
+export interface EncryptedAttachment {
+  encryptedData: Uint8Array;
+  filename: string;
+}
+
+export async function encryptAttachment(
+  data: Uint8Array,
+  filename: string,
+  mimeType: string,
+): Promise<EncryptedAttachment> {
+  const encrypted = await RemoteAttachmentCodec.encodeEncrypted(
+    { filename, mimeType, data },
+    new AttachmentCodec(),
+  );
+  return { encryptedData: encrypted.payload, filename };
+}
+
+export async function createRemoteAttachmentFromFile(
+  filePath: string,
+  fileUrl: string,
+  mimeType: string,
+): Promise<RemoteAttachment> {
+  const fileData = await readFile(filePath);
+  const filename = path.basename(filePath);
+  return createRemoteAttachmentFromData(
+    new Uint8Array(fileData),
+    filename,
+    mimeType,
+    fileUrl,
+  );
+}
+
+export async function createRemoteAttachmentFromData(
+  data: Uint8Array,
+  filename: string,
+  mimeType: string,
+  fileUrl: string,
+): Promise<RemoteAttachment> {
+  const encrypted = await RemoteAttachmentCodec.encodeEncrypted(
+    { filename, mimeType, data },
+    new AttachmentCodec(),
+  );
+
+  return {
+    url: fileUrl,
+    contentDigest: encrypted.digest,
+    salt: encrypted.salt,
+    nonce: encrypted.nonce,
+    secret: encrypted.secret,
+    scheme: `${new URL(fileUrl).protocol}//`,
+    filename,
+    contentLength: data.byteLength,
+  };
+}
+
+export async function loadRemoteAttachment<ContentTypes = unknown>(
+  remoteAttachment: RemoteAttachment,
+  client: Client<ContentTypes>,
+): Promise<Attachment> {
+  return await RemoteAttachmentCodec.load(remoteAttachment, client);
+}

--- a/sdks/agent-sdk/src/utils/index.ts
+++ b/sdks/agent-sdk/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./atttachment.js";
+


### PR DESCRIPTION
## Summary

This PR adds utility functions for working with XMTP attachments.

## Changes

- **New utility functions:**
  - `encryptAttachment` - Encrypts attachment data
  - `createRemoteAttachmentFromFile` - Creates remote attachments from file paths
  - `createRemoteAttachmentFromData` - Creates remote attachments from data buffers
  - `loadRemoteAttachment` - Loads and decrypts remote attachments using a Client instance

- **Exports:**
  - Added `@xmtp/agent-sdk/utils` export path
  - All attachment utilities are properly exported and typed

## Usage

```typescript
import { 
  encryptAttachment,
  createRemoteAttachmentFromFile,
  createRemoteAttachmentFromData,
  loadRemoteAttachment 
} from '@xmtp/agent-sdk/utils';
```

## Testing

- ✅ Type checking passes
- ✅ Build succeeds
- ✅ No linting errors
- ✅ Follows codebase patterns and conventions