### PR TITLE
Increase input size for better mobile UX

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/AddMembers.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/AddMembers.tsx
@@ -86,7 +86,7 @@ export const AddMembers: React.FC<AddMembersProps> = ({
       <Group gap="xs" align="flex-start">
         <TextInput
           flex={1}
-          size="sm"
+          size="md"
           label="Address, inbox ID, ENS name, or Base name"
           styles={{
             label: {
@@ -111,7 +111,7 @@ export const AddMembers: React.FC<AddMembersProps> = ({
           }}
         />
         <Button
-          size="sm"
+          size="md"
           mt="32px"
           disabled={
             memberIdError !== null ||

--- a/apps/xmtp.chat/src/components/Conversation/Metadata.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Metadata.tsx
@@ -49,7 +49,7 @@ export const Metadata: React.FC<MetadataProps> = ({
           Name
         </Text>
         <TextInput
-          size="sm"
+          size="md"
           flex="1 1 65%"
           value={name}
           disabled={
@@ -67,7 +67,7 @@ export const Metadata: React.FC<MetadataProps> = ({
           Description
         </Text>
         <Textarea
-          size="sm"
+          size="md"
           flex="1 1 65%"
           value={description}
           disabled={
@@ -85,7 +85,7 @@ export const Metadata: React.FC<MetadataProps> = ({
           Image URL
         </Text>
         <TextInput
-          size="sm"
+          size="md"
           flex="1 1 65%"
           value={imageUrl}
           disabled={

--- a/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx
+++ b/apps/xmtp.chat/src/components/Conversations/CreateDmModal.tsx
@@ -76,7 +76,7 @@ export const CreateDmModal: React.FC = () => {
         withScrollAreaPadding={false}>
         <Box p="md">
           <TextInput
-            size="sm"
+            size="md"
             label="Address, inbox ID, ENS name, or Base name"
             styles={{
               label: {

--- a/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
+++ b/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
@@ -231,7 +231,7 @@ export const InboxTools: React.FC = () => {
                   )}
                 </Group>
                 <TextInput
-                  size="sm"
+                  size="md"
                   error={!!memberIdError}
                   value={memberId}
                   onChange={(event) => {

--- a/apps/xmtp.chat/src/components/Messages/ReactionPopover.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReactionPopover.tsx
@@ -1,6 +1,5 @@
 import {
   ActionIcon,
-  Box,
   Button,
   Group,
   Popover,
@@ -76,14 +75,9 @@ export const ReactionPopover: React.FC<ReactionBarProps> = ({ message }) => {
           mb="sm"
           size="sm"
         />
-        <Box
-          style={{
-            height: 36,
-            display: "flex",
-            alignItems: "center",
-          }}>
+        <Group align="center" h="42px" wrap="nowrap">
           {schema === "unicode" ? (
-            <Group gap={4}>
+            <Group gap="xxs">
               {EMOJIS.map((emoji) => (
                 <ActionIcon
                   key={emoji}
@@ -95,14 +89,15 @@ export const ReactionPopover: React.FC<ReactionBarProps> = ({ message }) => {
               ))}
             </Group>
           ) : (
-            <Group gap="sm">
+            <Group gap="sm" w="100%">
               <TextInput
+                flex={1}
                 value={text}
                 onChange={(event) => {
                   setText(event.currentTarget.value);
                 }}
                 placeholder={schema === "shortcode" ? ":xmtp:" : "Enter custom"}
-                size="sm"
+                size="md"
                 style={{ width: 180 }}
                 onKeyDown={(event) => {
                   if (
@@ -115,14 +110,14 @@ export const ReactionPopover: React.FC<ReactionBarProps> = ({ message }) => {
                 }}
               />
               <ActionIcon
-                size="sm"
+                size="md"
                 variant="filled"
                 onClick={() => void sendReaction(text)}>
                 ➤
               </ActionIcon>
             </Group>
           )}
-        </Box>
+        </Group>
       </Popover.Dropdown>
     </Popover>
   );


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Increase Mantine input and button sizes to 'md' across conversation forms and reaction popover to improve mobile UX
Update Mantine `TextInput`, `Textarea`, `Button`, and `ActionIcon` sizes from `sm` to `md`, and refactor the reaction popover layout to use `Group` with a 42px container and flexible input.

#### 📍Where to Start
Start with the reaction popover layout changes in [ReactionPopover.tsx](https://github.com/xmtp/xmtp-js/pull/1561/files#diff-01dec0e443e69e5efd563b9a51e49e37c54b2f983f022f354344eee687e465ab).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2423ec2.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->