### PR TITLE
Normalize ens input names to lowercase

### DIFF
--- a/apps/xmtp.chat/src/helpers/names.ts
+++ b/apps/xmtp.chat/src/helpers/names.ts
@@ -23,14 +23,17 @@ export const resolveName = async (name: string, force: boolean = false) => {
     return null;
   }
 
+  // normalize name to lowercase for case-insensitive matching
+  const normalizedName = name.toLowerCase();
+
   // check cached profiles
-  const cachedProfiles = profilesStore.getState().getProfilesByName(name);
+  const cachedProfiles = profilesStore.getState().getProfilesByName(normalizedName);
   if (!force && cachedProfiles.length > 0) {
     return cachedProfiles;
   }
 
   const response = await fetch(
-    `${import.meta.env.VITE_API_SERVICE_URL}/api/v2/resolve/name/${window.encodeURIComponent(name)}`,
+    `${import.meta.env.VITE_API_SERVICE_URL}/api/v2/resolve/name/${window.encodeURIComponent(normalizedName)}`,
     {
       method: "GET",
     },
@@ -48,7 +51,7 @@ export const resolveName = async (name: string, force: boolean = false) => {
   }
 
   // return updated cached profiles
-  return profilesStore.getState().getProfilesByName(name);
+  return profilesStore.getState().getProfilesByName(normalizedName);
 };
 
 export const getInboxIdForAddressQuery = async (

--- a/apps/xmtp.chat/src/hooks/useMemberId.ts
+++ b/apps/xmtp.chat/src/hooks/useMemberId.ts
@@ -63,7 +63,9 @@ export const useMemberId = () => {
       } else if (isValidName(memberId)) {
         setLoading(true);
         try {
-          const profiles = await resolveNameQuery(memberId);
+          // normalize name to lowercase for case-insensitive matching
+          const normalizedName = memberId.toLowerCase();
+          const profiles = await resolveNameQuery(normalizedName);
           if (!profiles || profiles.length === 0) {
             setError("Invalid ENS or Base name");
           } else {
@@ -71,7 +73,7 @@ export const useMemberId = () => {
               const profile = combineProfiles(
                 profiles[0].address,
                 profiles,
-                memberId,
+                normalizedName,
               );
               const inboxId = await getInboxIdForAddressQuery(
                 profile.address,

--- a/apps/xmtp.chat/src/stores/profiles.ts
+++ b/apps/xmtp.chat/src/stores/profiles.ts
@@ -59,7 +59,8 @@ export const profilesStore = createStore<ProfilesState & ProfilesActions>()(
       const existingProfiles = state.profiles.get(profile.address) ?? [];
       newProfiles.set(profile.address, [...existingProfiles, profile]);
       if (profile.identity) {
-        newNames.set(profile.identity, profile.address);
+        // normalize identity to lowercase for case-insensitive matching
+        newNames.set(profile.identity.toLowerCase(), profile.address);
       }
       set(() => ({
         profiles: newProfiles,
@@ -77,7 +78,8 @@ export const profilesStore = createStore<ProfilesState & ProfilesActions>()(
         const existingProfiles = state.profiles.get(profile.address) ?? [];
         newProfiles.set(profile.address, [...existingProfiles, profile]);
         if (profile.identity) {
-          newNames.set(profile.identity, profile.address);
+          // normalize identity to lowercase for case-insensitive matching
+          newNames.set(profile.identity.toLowerCase(), profile.address);
         }
       }
       set(() => ({


### PR DESCRIPTION
Normalize ENS/Base names to lowercase for case-insensitive matching in xmtp.chat input fields.

This ensures that user-provided ENS/Base names, regardless of casing, correctly resolve to the intended profile when creating direct messages, group conversations, or adding members.

---
[Slack Thread](https://xmtp-labs.slack.com/archives/C09UWPZCGQ6/p1764007061478729?thread_ts=1764007061.478729&cid=C09UWPZCGQ6)

<a href="https://cursor.com/background-agent?bcId=bc-c18179c6-8f81-402f-b726-ec1c9e8fd243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c18179c6-8f81-402f-b726-ec1c9e8fd243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

