### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/agent-sdk.yml
+++ b/.github/workflows/agent-sdk.yml
@@ -21,7 +21,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -39,7 +39,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -61,7 +61,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/api-service.yml
+++ b/.github/workflows/api-service.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -49,7 +49,7 @@ jobs:
       contents: read
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/browser-sdk.yml
+++ b/.github/workflows/browser-sdk.yml
@@ -22,7 +22,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -40,7 +40,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -65,7 +65,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/content-types.yml
+++ b/.github/workflows/content-types.yml
@@ -23,7 +23,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -41,7 +41,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -63,7 +63,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/node-sdk.yml
+++ b/.github/workflows/node-sdk.yml
@@ -21,7 +21,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -39,7 +39,7 @@ jobs:
     name: Test
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -61,7 +61,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,7 +14,7 @@ jobs:
     name: Prettier
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/sync-documentation.yml
+++ b/.github/workflows/sync-documentation.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout XMTP-JS SDK
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: xmtp-js
@@ -42,7 +42,7 @@ jobs:
         run: corepack enable
 
       - name: Checkout Documentation Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.DOCS_REPO }}
           token: ${{ secrets.DOCS_SYNC_TOKEN }}

--- a/.github/workflows/xmtp-chat-sentry.yml
+++ b/.github/workflows/xmtp-chat-sentry.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6

--- a/.github/workflows/xmtp-chat.yml
+++ b/.github/workflows/xmtp-chat.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"

--- a/.github/workflows/xmtp-cli.yml
+++ b/.github/workflows/xmtp-cli.yml
@@ -21,7 +21,7 @@ jobs:
     name: Typecheck
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"
@@ -45,7 +45,7 @@ jobs:
     name: Build
     runs-on: warp-ubuntu-latest-x64-8x
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version-file: ".node-version"


### PR DESCRIPTION
Bumps `actions/checkout` from v5 to v6. Workflow-only change, no impact on functionality.

https://github.com/actions/checkout/releases/tag/v6.0.0