### PR TITLE
Don't mark PRs as "stale"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,10 +15,13 @@ jobs:
       - uses: actions/stale@v10
         with:
           exempt-issue-labels: "wip,important,pinned"
+          # Stale
           days-before-stale: 3
-          days-before-close: 7
-          days-before-pr-close: -1
+          days-before-pr-stale: -1
           stale-issue-message: >
             There has been no activity on this issue. It will be closed in 7 days if there is no new activity.
+          # Close
+          days-before-close: 7
+          days-before-pr-close: -1
           close-issue-message: >
             Closed due to inactivity. If still interested, please reopen and continue the discussion.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Disable PR staleness by setting `days-before-pr-stale: -1` in [.github/workflows/stale.yml](https://github.com/xmtp/xmtp-js/pull/1574/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894)
Updates the Actions Stale config to never mark pull requests as stale by adding `days-before-pr-stale: -1` and groups close-related keys under a `# Close` section in [.github/workflows/stale.yml](https://github.com/xmtp/xmtp-js/pull/1574/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894).

#### 📍Where to Start
Start in [.github/workflows/stale.yml](https://github.com/xmtp/xmtp-js/pull/1574/files#diff-b5e0854ed0838024d5cc25b4e030922e34648b9ea8c432807e35495fb805b894) and review the `days-before-pr-stale` setting and the reorganized `# Close` section.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4b4d7a8.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->