### PR TITLE
Agent SDK 1.1.17 release

### DIFF
--- a/sdks/agent-sdk/CHANGELOG.md
+++ b/sdks/agent-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/agent-sdk
 
+## 1.1.17
+
+### Patch Changes
+
+Upgraded `@xmtp/node-sdk` dependency to `4.5.0`
+
 ## 1.1.16
 
 ### Patch Changes

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/agent-sdk",
-  "version": "1.1.16-rc.0",
+  "version": "1.1.17",
   "description": "XMTP Agent SDK for interacting with XMTP networks",
   "keywords": [
     "agents",
@@ -70,7 +70,7 @@
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/content-type-transaction-reference": "^2.0.2",
     "@xmtp/content-type-wallet-send-calls": "^2.0.0",
-    "@xmtp/node-sdk": "4.5.0-rc1",
+    "@xmtp/node-sdk": "4.5.0",
     "viem": "^2.37.6"
   },
   "devDependencies": {
@@ -89,7 +89,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": false,
+    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4683,7 +4683,7 @@ __metadata:
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^2.0.0"
-    "@xmtp/node-sdk": "npm:4.5.0-rc1"
+    "@xmtp/node-sdk": "npm:4.5.0"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.6"
     typescript: "npm:^5.9.3"
@@ -4946,13 +4946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.6.1-rc3":
-  version: 1.6.1-rc3
-  resolution: "@xmtp/node-bindings@npm:1.6.1-rc3"
-  checksum: 10/64e72da74c0552758c360a0f4596c04a0e091017fa07471d454bb25da4e36293005c830c1adc09974333e3d073f2fb164c922ce59ced15fce99389848a16e71f
-  languageName: node
-  linkType: hard
-
 "@xmtp/node-bindings@npm:1.6.6":
   version: 1.6.6
   resolution: "@xmtp/node-bindings@npm:1.6.6"
@@ -4984,19 +4977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:4.5.0-rc1":
-  version: 4.5.0-rc1
-  resolution: "@xmtp/node-sdk@npm:4.5.0-rc1"
-  dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.2"
-    "@xmtp/content-type-primitives": "npm:^2.0.2"
-    "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.6.1-rc3"
-  checksum: 10/3df3027cc189cf2c31a83ad47b0a917081046522e3bca8761672d2850f122f87c5b5ea4dc430a59498c02074183f510b2f599f1a15653788a365c160b1423f67
-  languageName: node
-  linkType: hard
-
-"@xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:4.5.0, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Release Agent SDK 1.1.17 to switch dependency to `@xmtp/node-sdk@4.5.0` and enable npm provenance
Bumps `sdks/agent-sdk` to version `1.1.17`, updates dependency `@xmtp/node-sdk` from `4.5.0-rc1` to `4.5.0`, enables `publishConfig.provenance: true`, and refreshes the lockfile.

#### 📍Where to Start
Start with the version and dependency changes in [package.json](https://github.com/xmtp/xmtp-js/pull/1580/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3), then confirm the corresponding entry in [CHANGELOG.md](https://github.com/xmtp/xmtp-js/pull/1580/files#diff-2c984d6bcb574b8ecaaa2777904881ae8dac6f97f9dc0cfa438d615ccaa62eb5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 6d85473.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->