### PR TITLE
Update descriptions of release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ on:
         options:
           - standard
           - prerelease
-        default: standard
+        default: prerelease
       # Prerelease-specific inputs
       prerelease_sdk:
-        description: "SDK (prerelease only)"
+        description: "SDK you want to release"
         type: choice
         options:
           - node-sdk
@@ -29,17 +29,17 @@ on:
           - agent-sdk
         default: node-sdk
       prerelease_dependency_version:
-        description: "Dependency version for bindings or node sdk (prerelease only)"
+        description: "Dependency version (i.e. 1.7.0-dev.b057f23) for @xmtp/node-bindings (when releasing Node SDK) or @xmtp/node-sdk (when releasing Agent SDK)"
         type: string
       prerelease_tag:
-        description: "Release tag (prerelease only)"
+        description: "Release tag"
         type: choice
         options:
           - prerelease
           - dev
         default: prerelease
       prerelease_version:
-        description: "Prerelease version (prerelease only)"
+        description: "Prerelease version (i.e. 4.4.1-dev.b057f23)"
         type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Set the default release type to 'prerelease' and update input descriptions in [.github/workflows/release.yml](https://github.com/xmtp/xmtp-js/pull/1583/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to clarify the release workflow
Switches the manual dispatch default to `prerelease` and revises input help text for `prerelease_sdk`, `prerelease_dependency_version`, `prerelease_tag`, and `prerelease_version` in [.github/workflows/release.yml](https://github.com/xmtp/xmtp-js/pull/1583/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34).

#### 📍Where to Start
Start with the workflow inputs section in [.github/workflows/release.yml](https://github.com/xmtp/xmtp-js/pull/1583/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34), focusing on `on.workflow_dispatch.inputs`.

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a96ba0d.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->