### PR TITLE
feat: Support ENS names in DM route

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
@@ -55,7 +55,7 @@ export const LoadDM: React.FC = () => {
         const resolvedAddress = await resolveAddress(address);
 
         if (!resolvedAddress) {
-          navigateToHome("Invalid address, redirecting...");
+          navigateToHome("Invalid identifier, redirecting...");
           return;
         }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Accept ENS names in DM route by resolving names to Ethereum addresses in `LoadDM` component in [LoadDM.tsx](https://github.com/xmtp/xmtp-js/pull/1597/files#diff-f999c8ef5e116330d863dbca66126681e618fa2e7c75744d86705106e220bc74)
Adds `isValidName` and `resolveNameQuery` to resolve human-readable names, introduces `navigateToHome` for centralized redirect messaging with `REDIRECT_TIMEOUT`, and adds `resolveAddress` to handle ENS or hex inputs before address verification. Updates user-facing status messages and consolidates redirect/error handling in the `LoadDM` flow.

#### 📍Where to Start
Start with the `LoadDM` component flow in [LoadDM.tsx](https://github.com/xmtp/xmtp-js/pull/1597/files#diff-f999c8ef5e116330d863dbca66126681e618fa2e7c75744d86705106e220bc74), focusing on `resolveAddress` and `navigateToHome` and how they integrate into initial validation and redirect handling.

<!-- Macroscope's changelog starts here -->
#### Changes since #1597 opened

- Updated error message text in `LoadDM` component at `/dm` route when address resolution fails [f062c50]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 862ab48.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->