### PR TITLE
Fix blockchain ID for SCW signers

### DIFF
--- a/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
+++ b/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
@@ -14,6 +14,7 @@ export const useConnectXmtp = () => {
   const account = useAccount();
   const { signMessageAsync } = useSignMessage();
   const {
+    blockchain,
     encryptionKey,
     environment,
     ephemeralAccountEnabled,
@@ -46,7 +47,7 @@ export const useConnectXmtp = () => {
     }
 
     // if wallet is not connected or SCW is enabled but chain is not set, return
-    if (!account.address || (useSCW && !account.chainId)) {
+    if (!account.address || (useSCW && blockchain <= 0)) {
       return;
     }
 
@@ -60,7 +61,7 @@ export const useConnectXmtp = () => {
         ? createSCWSigner(
             account.address,
             (message: string) => signMessageAsync({ message }),
-            account.chainId,
+            blockchain,
           )
         : createEOASigner(account.address, (message: string) =>
             signMessageAsync({ message }),


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Route SCW signer chain ID to `settings.blockchain` and gate connect when `blockchain <= 0` in [useConnectXmtp.ts](https://github.com/xmtp/xmtp-js/pull/1601/files#diff-4c0c89e572b419d9ae25ad4badb542d5d4a7a3f57d6bdbd6080e5d80422e3ee8)
Update `useConnectXmtp` to source the chain ID from `settings.blockchain` instead of `account.chainId`, adjust the SCW precondition to return when `useSCW` is true and `blockchain <= 0`, and pass `settings.blockchain` to `createSCWSigner` in [useConnectXmtp.ts](https://github.com/xmtp/xmtp-js/pull/1601/files#diff-4c0c89e572b419d9ae25ad4badb542d5d4a7a3f57d6bdbd6080e5d80422e3ee8).

#### 📍Where to Start
Start with the `connect` callback and the `useSettings` destructure in [useConnectXmtp.ts](https://github.com/xmtp/xmtp-js/pull/1601/files#diff-4c0c89e572b419d9ae25ad4badb542d5d4a7a3f57d6bdbd6080e5d80422e3ee8).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca89904. 1 file reviewed, 4 issues evaluated, 3 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/hooks/useConnectXmtp.ts — 0 comments posted, 4 evaluated, 3 filtered</summary>

- [line 71](https://github.com/xmtp/xmtp-js/blob/ca899044805e6006ae630727dd7cab87ec951273/apps/xmtp.chat/src/hooks/useConnectXmtp.ts#L71): The `ephemeralSigner` is used on line 43 but is not included in the `useCallback` dependency array. If the ephemeral signer changes (e.g., when a new ephemeral account key is generated), the `connect` callback will use a stale signer reference, potentially initializing with the wrong signer. <b>[ Out of scope ]</b>
- [line 71](https://github.com/xmtp/xmtp-js/blob/ca899044805e6006ae630727dd7cab87ec951273/apps/xmtp.chat/src/hooks/useConnectXmtp.ts#L71): The `blockchain` variable is used in the `connect` callback (lines 50 and 64) but is not included in the `useCallback` dependency array (lines 71-85). This will cause the callback to use a stale `blockchain` value if the user changes the blockchain setting, leading to incorrect chain ID being passed to `createSCWSigner` or incorrect validation logic. <b>[ Out of scope ]</b>
- [line 74](https://github.com/xmtp/xmtp-js/blob/ca899044805e6006ae630727dd7cab87ec951273/apps/xmtp.chat/src/hooks/useConnectXmtp.ts#L74): The dependency array includes `setEphemeralAccountKey` (line 74) and `ephemeralAccountKey` (line 76) but neither is used anywhere in the `connect` callback function body. These appear to be stale dependencies that should be removed. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->