### PR TITLE
Upgrade to latest Node SDK in Agent SDK

### DIFF
--- a/sdks/agent-sdk/CHANGELOG.md
+++ b/sdks/agent-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @xmtp/agent-sdk
 
+## 1.2.2
+
+Upgraded Node SDK to `4.6.0`
+
 ## 1.2.1
 
 ### Patch Changes

--- a/sdks/agent-sdk/package.json
+++ b/sdks/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/agent-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "XMTP Agent SDK for interacting with XMTP networks",
   "keywords": [
     "agents",
@@ -70,7 +70,7 @@
     "@xmtp/content-type-text": "^2.0.2",
     "@xmtp/content-type-transaction-reference": "^2.0.2",
     "@xmtp/content-type-wallet-send-calls": "^2.0.0",
-    "@xmtp/node-sdk": "4.5.1",
+    "@xmtp/node-sdk": "4.6.0",
     "viem": "^2.37.6"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4683,7 +4683,7 @@ __metadata:
     "@xmtp/content-type-text": "npm:^2.0.2"
     "@xmtp/content-type-transaction-reference": "npm:^2.0.2"
     "@xmtp/content-type-wallet-send-calls": "npm:^2.0.0"
-    "@xmtp/node-sdk": "npm:4.5.1"
+    "@xmtp/node-sdk": "npm:4.6.0"
     tsc-alias: "npm:^1.8.16"
     tsx: "npm:^4.20.6"
     typescript: "npm:^5.9.3"
@@ -4946,13 +4946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-bindings@npm:1.6.6":
-  version: 1.6.6
-  resolution: "@xmtp/node-bindings@npm:1.6.6"
-  checksum: 10/314f2c8c53a8af7bd67e4a32c66d48472674c0ec7a24dc4d695a89131645c1fb4f9513dc6c8f98dc9b2ff87a3e0f59bf30912cd84d83c1fa6f0ffa13fcae1f5b
-  languageName: node
-  linkType: hard
-
 "@xmtp/node-bindings@npm:1.6.8":
   version: 1.6.8
   resolution: "@xmtp/node-bindings@npm:1.6.8"
@@ -4984,19 +4977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/node-sdk@npm:4.5.1":
-  version: 4.5.1
-  resolution: "@xmtp/node-sdk@npm:4.5.1"
-  dependencies:
-    "@xmtp/content-type-group-updated": "npm:^2.0.2"
-    "@xmtp/content-type-primitives": "npm:^2.0.2"
-    "@xmtp/content-type-text": "npm:^2.0.2"
-    "@xmtp/node-bindings": "npm:1.6.6"
-  checksum: 10/3efa4ddb2de91d966c359d31dd90ca615f6bba39a44b36a73bfcea3783edd922d0eb8b3db0a8d6531a6ae273868809f97bf6981c018f1c9f3d5ff49d887dd4c3
-  languageName: node
-  linkType: hard
-
-"@xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
+"@xmtp/node-sdk@npm:4.6.0, @xmtp/node-sdk@workspace:^, @xmtp/node-sdk@workspace:sdks/node-sdk":
   version: 0.0.0-use.local
   resolution: "@xmtp/node-sdk@workspace:sdks/node-sdk"
   dependencies:


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Upgrade Agent SDK to use @xmtp/node-sdk 4.6.0 and bump package version to 1.2.2 in [package.json](https://github.com/xmtp/xmtp-js/pull/1603/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3)
Update dependency `@xmtp/node-sdk` to `4.6.0` and bump Agent SDK version to `1.2.2`. Regenerate lockfile. Note the change in [CHANGELOG.md](https://github.com/xmtp/xmtp-js/pull/1603/files#diff-2c984d6bcb574b8ecaaa2777904881ae8dac6f97f9dc0cfa438d615ccaa62eb5).

#### 📍Where to Start
Start with the version and dependency updates in [package.json](https://github.com/xmtp/xmtp-js/pull/1603/files#diff-a40ed8b00e5d12c39e58c3ba35b9a9ea7fa807483c07b63ed29366f7e960cff3), then verify the changelog entry in [CHANGELOG.md](https://github.com/xmtp/xmtp-js/pull/1603/files#diff-2c984d6bcb574b8ecaaa2777904881ae8dac6f97f9dc0cfa438d615ccaa62eb5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 80f969f.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->