### PR TITLE
Use resolved address when creating a DM

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
@@ -61,7 +61,7 @@ export const LoadDM: React.FC = () => {
 
         setMessage("Verifying address...");
         const inboxId = await client.findInboxIdByIdentifier({
-          identifier: resolvedAddress.toLowerCase(),
+          identifier: resolvedAddress,
           identifierKind: "Ethereum",
         });
 
@@ -78,7 +78,7 @@ export const LoadDM: React.FC = () => {
           // no DM group, create it
           setMessage("Creating new DM...");
           const newDm = await client.conversations.newDmWithIdentifier({
-            identifier: resolvedAddress.toLowerCase(),
+            identifier: resolvedAddress,
             identifierKind: "Ethereum",
           });
           dmId = newDm.id;


### PR DESCRIPTION
This should fix the following error when clicking on http://xmtp.chat/production/dm/xmtp-docs.eth:

<img width="935" height="650" alt="image" src="https://github.com/user-attachments/assets/6bc4396a-68ee-4eb6-a4e9-013dc83cc139" />
