### PR TITLE
fix vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "buildCommand": "yarn turbo run build --filter=xmtp-agents...",
+  "outputDirectory": "apps/xmtp-agents/dist",
+  "installCommand": "corepack enable && corepack prepare yarn@4.10.3 --activate && yarn install",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Fixed Vercel monorepo build configuration by adding root-level vercel.json with proper workspace build commands and SPA rewrites.