### PR TITLE
Refresh conversation list on syncAll

### DIFF
--- a/apps/xmtp.chat/src/hooks/useConversations.ts
+++ b/apps/xmtp.chat/src/hooks/useConversations.ts
@@ -22,19 +22,8 @@ export const useConversations = () => {
   const [loading, setLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
 
-  const sync = async (fromNetwork: boolean = false) => {
-    if (fromNetwork) {
-      setSyncing(true);
-
-      try {
-        await client.conversations.sync();
-      } finally {
-        setSyncing(false);
-      }
-    }
-
+  const refreshConversationsList = async () => {
     setLoading(true);
-
     try {
       const convos = await client.conversations.list({
         createdAfterNs: lastCreatedAt,
@@ -47,6 +36,20 @@ export const useConversations = () => {
     }
   };
 
+  const sync = async (fromNetwork: boolean = false) => {
+    if (fromNetwork) {
+      setSyncing(true);
+
+      try {
+        await client.conversations.sync();
+      } finally {
+        setSyncing(false);
+      }
+    }
+
+    await refreshConversationsList();
+  };
+
   const syncAll = async () => {
     setSyncing(true);
 
@@ -55,6 +58,8 @@ export const useConversations = () => {
     } finally {
       setSyncing(false);
     }
+
+    await refreshConversationsList();
   };
 
   const getConversationById = async (conversationId: string) => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refresh the conversation list in `useConversations.syncAll` to update state after network sync in [useConversations.ts](https://github.com/xmtp/xmtp-js/pull/1620/files#diff-6e753981ee9ce08d8174dc8a755d3e2de5523ebc06ca81e6efd2c05ebc96700c)
Add `refreshConversationsList` and call it from `useConversations.sync` and `useConversations.syncAll` to list conversations, update state, and set last synced time in [useConversations.ts](https://github.com/xmtp/xmtp-js/pull/1620/files#diff-6e753981ee9ce08d8174dc8a755d3e2de5523ebc06ca81e6efd2c05ebc96700c).

#### 📍Where to Start
Start with the `refreshConversationsList` helper and its usage in `sync` and `syncAll` in [useConversations.ts](https://github.com/xmtp/xmtp-js/pull/1620/files#diff-6e753981ee9ce08d8174dc8a755d3e2de5523ebc06ca81e6efd2c05ebc96700c).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 324f735.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->