### PR TITLE
Fix reply exports

### DIFF
--- a/sdks/browser-sdk/src/index.ts
+++ b/sdks/browser-sdk/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ReadReceipt,
   RemoteAttachment,
   RemoteAttachmentInfo,
+  Reply,
   SendMessageOpts,
   SignatureRequestHandle,
   TransactionMetadata,

--- a/sdks/browser-sdk/src/types/options.ts
+++ b/sdks/browser-sdk/src/types/options.ts
@@ -2,7 +2,6 @@ import type { ContentCodec } from "@xmtp/content-type-primitives";
 import type {
   Actions,
   Attachment,
-  EnrichedReply,
   GroupUpdated,
   Intent,
   LeaveRequest,
@@ -110,8 +109,8 @@ export type ClientOptions = NetworkOptions &
   StorageOptions &
   OtherOptions;
 
-export type Reply<T = unknown, U = unknown> = {
-  referenceId: EnrichedReply["referenceId"];
+export type EnrichedReply<T = unknown, U = unknown> = {
+  referenceId: string;
   content: T;
   inReplyTo: DecodedMessage<U> | null;
 };
@@ -137,5 +136,5 @@ export type ExtractCodecContentTypes<C extends ContentCodec[] = []> =
       ?
           | T
           | BuiltInContentTypes
-          | Reply<T | BuiltInContentTypes, T | BuiltInContentTypes>
+          | EnrichedReply<T | BuiltInContentTypes, T | BuiltInContentTypes>
       : BuiltInContentTypes;

--- a/sdks/browser-sdk/test/contentTypes.test.ts
+++ b/sdks/browser-sdk/test/contentTypes.test.ts
@@ -22,7 +22,7 @@ import {
   vi,
   type Mock,
 } from "vitest";
-import type { Reply } from "@/types/options";
+import type { EnrichedReply } from "@/types/options";
 import {
   contentTypeActions,
   contentTypeAttachment,
@@ -224,7 +224,7 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(await contentTypeReply());
-      const replyContent = replyMessage.content as Reply<string>;
+      const replyContent = replyMessage.content as EnrichedReply<string>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toBe("This is a text reply");
       expect(replyContent.inReplyTo).toBeDefined();
@@ -236,7 +236,7 @@ describe("Content types", () => {
       const message = await client1.conversations.getMessageById(replyId);
       expect(message).toBeDefined();
       expect(message?.contentType).toEqual(await contentTypeReply());
-      const replyContent2 = message?.content as Reply<string>;
+      const replyContent2 = message?.content as EnrichedReply<string>;
       expect(replyContent2.referenceId).toBe(textMessageId);
       expect(replyContent2.content).toBe("This is a text reply");
       expect(replyContent2.inReplyTo).toBeDefined();
@@ -267,7 +267,7 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(await contentTypeReply());
-      const replyContent = replyMessage.content as Reply<Attachment>;
+      const replyContent = replyMessage.content as EnrichedReply<Attachment>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toEqual(attachment);
       expect(replyContent.inReplyTo).toBeDefined();
@@ -297,7 +297,9 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(await contentTypeReply());
-      const replyContent = replyMessage.content as Reply<{ test: string }>;
+      const replyContent = replyMessage.content as EnrichedReply<{
+        test: string;
+      }>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toEqual({ test: "test" });
       expect(replyContent.inReplyTo).toBeDefined();

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ReadReceipt,
   RemoteAttachment,
   RemoteAttachmentInfo,
+  Reply,
   SendMessageOpts,
   SignatureRequestHandle,
   TransactionMetadata,

--- a/sdks/node-sdk/src/types.ts
+++ b/sdks/node-sdk/src/types.ts
@@ -2,7 +2,6 @@ import type { ContentCodec } from "@xmtp/content-type-primitives";
 import {
   type Actions,
   type Attachment,
-  type EnrichedReply,
   type GroupUpdated,
   type Intent,
   type LeaveRequest,
@@ -129,8 +128,8 @@ export type ClientOptions = NetworkOptions &
   ContentOptions &
   OtherOptions;
 
-export type Reply<T = unknown, U = unknown> = {
-  referenceId: EnrichedReply["referenceId"];
+export type EnrichedReply<T = unknown, U = unknown> = {
+  referenceId: string;
   content: T;
   inReplyTo: DecodedMessage<U> | null;
 };
@@ -156,5 +155,5 @@ export type ExtractCodecContentTypes<C extends ContentCodec[] = []> =
       ?
           | T
           | BuiltInContentTypes
-          | Reply<T | BuiltInContentTypes, T | BuiltInContentTypes>
+          | EnrichedReply<T | BuiltInContentTypes, T | BuiltInContentTypes>
       : BuiltInContentTypes;

--- a/sdks/node-sdk/test/contentTypes.test.ts
+++ b/sdks/node-sdk/test/contentTypes.test.ts
@@ -33,7 +33,7 @@ import {
   type Reply as XmtpReply,
 } from "@xmtp/node-bindings";
 import { describe, expect, it, type Mock } from "vitest";
-import type { Reply } from "@/types";
+import type { EnrichedReply } from "@/types";
 import {
   createRegisteredClient,
   createSigner,
@@ -216,7 +216,7 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(contentTypeReply());
-      const replyContent = replyMessage.content as Reply<string>;
+      const replyContent = replyMessage.content as EnrichedReply<string>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toBe("This is a text reply");
       expect(replyContent.inReplyTo).toBeDefined();
@@ -228,7 +228,7 @@ describe("Content types", () => {
       const message = client1.conversations.getMessageById(replyId);
       expect(message).toBeDefined();
       expect(message?.contentType).toEqual(contentTypeReply());
-      const replyContent2 = message?.content as Reply<string>;
+      const replyContent2 = message?.content as EnrichedReply<string>;
       expect(replyContent2.referenceId).toBe(textMessageId);
       expect(replyContent2.content).toBe("This is a text reply");
       expect(replyContent2.inReplyTo).toBeDefined();
@@ -259,7 +259,7 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(contentTypeReply());
-      const replyContent = replyMessage.content as Reply<Attachment>;
+      const replyContent = replyMessage.content as EnrichedReply<Attachment>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toEqual(attachment);
       expect(replyContent.inReplyTo).toBeDefined();
@@ -289,7 +289,9 @@ describe("Content types", () => {
       const messages = await group.messages();
       const replyMessage = messages[2];
       expect(replyMessage.contentType).toEqual(contentTypeReply());
-      const replyContent = replyMessage.content as Reply<{ test: string }>;
+      const replyContent = replyMessage.content as EnrichedReply<{
+        test: string;
+      }>;
       expect(replyContent.referenceId).toBe(textMessageId);
       expect(replyContent.content).toEqual({ test: "test" });
       expect(replyContent.inReplyTo).toBeDefined();


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix reply exports by re-exporting `Reply` in `sdks/browser-sdk/src/index.ts` and `sdks/node-sdk/src/index.ts`, and update SDK types to use local `EnrichedReply<T, U>`
Introduce a local `EnrichedReply<T, U>` type and update union types to reference it; adjust tests to use `EnrichedReply`; add type-only `Reply` re-exports in both SDK index barrels. See [index.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-954f9a4a1e6b3af2fdebe84ce7c5b6b9336ce8b82fa4d38a9d328f2e2f35553b), [options.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-8e619b9f1c33b56ff4ba5af50abdabccc44300332255d80c931804e0ddf005e5), [index.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-a799851ddab26b071b3e6753eb77936fa9fc3da7839b22d80d9f257177cdd070), and [types.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-5ab8d64966cdd3ef2296dd75417e657434be92abe4cd0072322fa40832ab5485).

#### 📍Where to Start
Start with the type changes in `EnrichedReply<T, U>` in [types.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-5ab8d64966cdd3ef2296dd75417e657434be92abe4cd0072322fa40832ab5485), then review the corresponding browser SDK update in [options.ts](https://github.com/xmtp/xmtp-js/pull/1627/files#diff-8e619b9f1c33b56ff4ba5af50abdabccc44300332255d80c931804e0ddf005e5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 2e9a56e.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->