### PR TITLE
Fix members list

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Members.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Members.tsx
@@ -1,4 +1,5 @@
 import { Badge, Group, Stack, Text } from "@mantine/core";
+import { PermissionLevel } from "@xmtp/browser-sdk";
 import { useCallback, useMemo } from "react";
 import {
   AddMembers,
@@ -55,22 +56,19 @@ export const Members: React.FC<MembersProps> = ({
 
   const superAdmins = useMemo(() => {
     return finalMembers.filter(
-      // @ts-expect-error - the types are wrong
-      (member) => member.permissionLevel === "SuperAdmin",
+      (member) => member.permissionLevel === PermissionLevel.SuperAdmin,
     );
   }, [finalMembers]);
 
   const admins = useMemo(() => {
     return finalMembers.filter(
-      // @ts-expect-error - the types are wrong
-      (member) => member.permissionLevel === "Admin",
+      (member) => member.permissionLevel === PermissionLevel.Admin,
     );
   }, [finalMembers]);
 
   const members = useMemo(() => {
     return finalMembers.filter(
-      // @ts-expect-error - the types are wrong
-      (member) => member.permissionLevel === "Member",
+      (member) => member.permissionLevel === PermissionLevel.Member,
     );
   }, [finalMembers]);
 

--- a/apps/xmtp.chat/src/components/Conversation/MembersList.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/MembersList.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Badge, Group, Stack, Text, Tooltip } from "@mantine/core";
-import { Dm } from "@xmtp/browser-sdk";
+import { Dm, PermissionLevel } from "@xmtp/browser-sdk";
 import { useMemo, type ComponentProps } from "react";
 import { Virtuoso } from "react-virtuoso";
 import { MemberListItem } from "@/components/Conversation/MemberListItem";
@@ -68,8 +68,7 @@ export const MembersList: React.FC<MembersListProps> = ({
     const items: (MembersListTitle | MemberProfile)[] = [];
 
     const superAdmins = memberProfiles.filter(
-      // @ts-expect-error - the types are wrong
-      (profile) => profile.permissionLevel === "SuperAdmin",
+      (profile) => profile.permissionLevel === PermissionLevel.SuperAdmin,
     );
 
     if (superAdmins.length > 0) {
@@ -78,8 +77,7 @@ export const MembersList: React.FC<MembersListProps> = ({
     }
 
     const admins = memberProfiles.filter(
-      // @ts-expect-error - the types are wrong
-      (profile) => profile.permissionLevel === "Admin",
+      (profile) => profile.permissionLevel === PermissionLevel.Admin,
     );
 
     if (admins.length > 0) {
@@ -88,8 +86,7 @@ export const MembersList: React.FC<MembersListProps> = ({
     }
 
     const regulars = memberProfiles.filter(
-      // @ts-expect-error - TODO: the types are wrong
-      (profile) => profile.permissionLevel === "Member",
+      (profile) => profile.permissionLevel === PermissionLevel.Member,
     );
 
     if (regulars.length > 0) {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Fix member categorization in `Members` and `MembersList` by using `PermissionLevel` enum values from `@xmtp/browser-sdk` in [Members.tsx](https://github.com/xmtp/xmtp-js/pull/1632/files#diff-1377b5d1f290862e7f5610326427ec2700f20440a5ce1981cacb3418faece742) and [MembersList.tsx](https://github.com/xmtp/xmtp-js/pull/1632/files#diff-6455d33c0e9e31b6957ec97553eb86f6ee42603851283564591e76cef4462cd6)
Replace string permission checks with `PermissionLevel` enum comparisons in member filtering and list item grouping.

#### 📍Where to Start
Start with the permission filtering logic in [Members.tsx](https://github.com/xmtp/xmtp-js/pull/1632/files#diff-1377b5d1f290862e7f5610326427ec2700f20440a5ce1981cacb3418faece742), then review list grouping in [MembersList.tsx](https://github.com/xmtp/xmtp-js/pull/1632/files#diff-6455d33c0e9e31b6957ec97553eb86f6ee42603851283564591e76cef4462cd6).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 5640278.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->