### PR TITLE
Fix legacy logging level values

### DIFF
--- a/apps/xmtp.chat/src/hooks/useSettings.ts
+++ b/apps/xmtp.chat/src/hooks/useSettings.ts
@@ -1,7 +1,17 @@
 import { useLocalStorage } from "@mantine/hooks";
 import { LogLevel, type ClientOptions, type XmtpEnv } from "@xmtp/browser-sdk";
+import { useEffect } from "react";
 import type { Hex } from "viem";
 import type { ConnectorString } from "@/hooks/useConnectWallet";
+
+const loggingLevelStringToEnum = {
+  off: LogLevel.Off,
+  error: LogLevel.Error,
+  warn: LogLevel.Warn,
+  info: LogLevel.Info,
+  debug: LogLevel.Debug,
+  trace: LogLevel.Trace,
+};
 
 export const useSettings = () => {
   const [environment, setEnvironment] = useLocalStorage<XmtpEnv>({
@@ -64,6 +74,14 @@ export const useSettings = () => {
     defaultValue: true,
     getInitialValueInEffect: false,
   });
+
+  // fix for old logging level values
+  useEffect(() => {
+    if (typeof loggingLevel === "string") {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      setLoggingLevel(loggingLevelStringToEnum[loggingLevel] ?? LogLevel.Off);
+    }
+  }, [loggingLevel]);
 
   return {
     autoConnect,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Coerce legacy string logging levels to `LogLevel` enum in `apps/xmtp.chat/src/hooks/useSettings.ts` to fix legacy logging level values
Add `loggingLevelStringToEnum` and a `useEffect` in `useSettings` to map string levels (`off`, `error`, `warn`, `info`, `debug`, `trace`) to `LogLevel`, defaulting to `LogLevel.Off` when unmapped.

#### 📍Where to Start
Start with the `useSettings` hook and its `useEffect` in [useSettings.ts](https://github.com/xmtp/xmtp-js/pull/1634/files#diff-3352baf8ab72df764886915121861c43c08a6c8127be64e615d9b6b3f5a2c287).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a420344.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->