### PR TITLE
Add /new route to xmtp.chat

### DIFF
--- a/apps/xmtp.chat/src/components/App/App.tsx
+++ b/apps/xmtp.chat/src/components/App/App.tsx
@@ -3,6 +3,7 @@ import { AppLayout } from "@/components/App/AppLayout";
 import { BasicLayout } from "@/components/App/BasicLayout";
 import { Disconnect } from "@/components/App/Disconnect";
 import { ErrorModal } from "@/components/App/ErrorModal";
+import { New } from "@/components/App/New";
 import { SelectConversation } from "@/components/App/SelectConversation";
 import { Welcome } from "@/components/App/Welcome";
 import { LoadConversation } from "@/components/Conversation/LoadConversation";
@@ -38,6 +39,7 @@ export const App: React.FC = () => {
         </Route>
         <Route path="/disconnect" element={<Disconnect />} />
         <Route path="/dm/:address" element={<LoadDMLegacy />} />
+        <Route path="/new" element={<New />} />
         <Route path="/:environment" element={<AppLayout />}>
           <Route
             index

--- a/apps/xmtp.chat/src/components/App/New.tsx
+++ b/apps/xmtp.chat/src/components/App/New.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+import { LoadingMessage } from "@/components/LoadingMessage";
+import { useXMTP } from "@/contexts/XMTPContext";
+import { useConnectWallet } from "@/hooks/useConnectWallet";
+import { useConnectXmtp } from "@/hooks/useConnectXmtp";
+import { useSettings } from "@/hooks/useSettings";
+
+export const New = () => {
+  const { isConnected } = useConnectWallet();
+  const {
+    environment,
+    ephemeralAccountEnabled,
+    setEphemeralAccountEnabled,
+    autoConnect,
+    setUseSCW,
+  } = useSettings();
+  // if autoConnect is true, this hook will automatically connect to XMTP
+  // once a wallet is connected
+  const { connect } = useConnectXmtp();
+  const { client } = useXMTP();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // redirect if there's already a client
+    if (client) {
+      void navigate(`/${environment}`);
+      return;
+    }
+
+    // wallet is already connected without autoConnect, connect to XMTP
+    if (isConnected && !autoConnect) {
+      connect();
+      return;
+    }
+
+    // wallet is not connected, ensure ephemeral account is enabled
+    if (!isConnected && !ephemeralAccountEnabled) {
+      setEphemeralAccountEnabled(true);
+      // disable SCW if enabled
+      setUseSCW(false);
+      return;
+    }
+
+    if (!autoConnect) {
+      // connect to XMTP
+      connect();
+    }
+  }, [
+    autoConnect,
+    client,
+    connect,
+    environment,
+    ephemeralAccountEnabled,
+    isConnected,
+    navigate,
+  ]);
+
+  return <LoadingMessage message="Connecting to XMTP..." />;
+};


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add '/new' route in `App` to render `New` for XMTP connection setup and redirect to `/{environment}`
Introduce a top-level `'/new'` route in [apps/xmtp.chat/src/components/App/App.tsx](https://github.com/xmtp/xmtp-js/pull/1638/files#diff-b9e02bfb94bc72dd8e56f99a17137708c479ac80cb68b7f7972b6685f28dd7e5) that renders `New`, which manages XMTP client detection, optional wallet connect, ephemeral account toggling, SCW disabling, and redirects when a client exists.

#### 📍Where to Start
Start with the `New` component logic in [apps/xmtp.chat/src/components/App/New.tsx](https://github.com/xmtp/xmtp-js/pull/1638/files#diff-72efae8bc3aa08c33f479e08063d93f961235b445f9e9b6678c890fe73df27f4), then see its route registration in [apps/xmtp.chat/src/components/App/App.tsx](https://github.com/xmtp/xmtp-js/pull/1638/files#diff-b9e02bfb94bc72dd8e56f99a17137708c479ac80cb68b7f7972b6685f28dd7e5).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized bae78ed.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->