### PR TITLE
Allow setting the gateway host

### DIFF
--- a/apps/xmtp.chat/src/contexts/XMTPContext.tsx
+++ b/apps/xmtp.chat/src/contexts/XMTPContext.tsx
@@ -21,6 +21,7 @@ export type InitializeClientOptions = {
   env?: ClientOptions["env"];
   loggingLevel?: ClientOptions["loggingLevel"];
   signer: Signer;
+  gatewayHost?: string;
 };
 
 export type XMTPContextValue = {
@@ -74,6 +75,7 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
       env,
       loggingLevel,
       signer,
+      gatewayHost,
     }: InitializeClientOptions) => {
       // only initialize a client if one doesn't already exist
       if (!client) {
@@ -99,6 +101,7 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
             loggingLevel,
             dbEncryptionKey,
             appVersion: "xmtp.chat/0",
+            gatewayHost,
           });
           setClient(xmtpClient);
         } catch (e) {

--- a/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
+++ b/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
@@ -24,6 +24,7 @@ export const useConnectXmtp = () => {
     useSCW,
     autoConnect,
     setAutoConnect,
+    gatewayHost,
   } = useSettings();
 
   const connect = useCallback(() => {
@@ -41,6 +42,7 @@ export const useConnectXmtp = () => {
         env: environment,
         loggingLevel,
         signer: ephemeralSigner,
+        gatewayHost,
       });
       setAutoConnect(true);
       return;
@@ -57,6 +59,7 @@ export const useConnectXmtp = () => {
         : undefined,
       env: environment,
       loggingLevel,
+      gatewayHost,
       signer: useSCW
         ? createSCWSigner(
             account.address,

--- a/apps/xmtp.chat/src/hooks/useSettings.ts
+++ b/apps/xmtp.chat/src/hooks/useSettings.ts
@@ -74,6 +74,11 @@ export const useSettings = () => {
     defaultValue: true,
     getInitialValueInEffect: false,
   });
+  const [gatewayHost, setGatewayHost] = useLocalStorage({
+    key: "XMTP_GATEWAY_HOST",
+    defaultValue: "",
+    getInitialValueInEffect: false,
+  });
 
   // fix for old logging level values
   useEffect(() => {
@@ -92,6 +97,7 @@ export const useSettings = () => {
     ephemeralAccountEnabled,
     ephemeralAccountKey,
     forceSCW,
+    gatewayHost,
     loggingLevel,
     useSCW,
     showDisclaimer,
@@ -103,6 +109,7 @@ export const useSettings = () => {
     setEphemeralAccountEnabled,
     setEphemeralAccountKey,
     setForceSCW,
+    setGatewayHost,
     setLoggingLevel,
     setUseSCW,
     setShowDisclaimer,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `gatewayHost` setting and pass it through `XMTPContext.InitializeClientOptions` to `XMTPProvider.initialize` and `Client.create` in [XMTPContext.tsx](https://github.com/xmtp/xmtp-js/pull/1640/files#diff-3f85f8bbcc919a25261978a5ef34f53d1929bda0d4019a04ce8629ed0d7b494e)
Introduce a `gatewayHost` option in `XMTPContext.InitializeClientOptions`, propagate it via `XMTPProvider.initialize` to `Client.create`, and source it from `useSettings` with local storage persistence.

#### 📍Where to Start
Start with `XMTPProvider.initialize` in [XMTPContext.tsx](https://github.com/xmtp/xmtp-js/pull/1640/files#diff-3f85f8bbcc919a25261978a5ef34f53d1929bda0d4019a04ce8629ed0d7b494e), then trace how `gatewayHost` flows from `useSettings` in [useSettings.ts](https://github.com/xmtp/xmtp-js/pull/1640/files#diff-3352baf8ab72df764886915121861c43c08a6c8127be64e615d9b6b3f5a2c287) through `useConnectXmtp` in [useConnectXmtp.ts](https://github.com/xmtp/xmtp-js/pull/1640/files#diff-4c0c89e572b419d9ae25ad4badb542d5d4a7a3f57d6bdbd6080e5d80422e3ee8).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca29d01. 3 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/xmtp.chat/src/hooks/useConnectXmtp.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>

- [line 74](https://github.com/xmtp/xmtp-js/blob/ca29d01b773b1e2e2f99afccaaa9994cc5d9f833/apps/xmtp.chat/src/hooks/useConnectXmtp.ts#L74): The `gatewayHost` variable is used inside the `connect` callback (lines 45 and 62) but is missing from the dependency array (lines 74-88). This causes a stale closure bug where if `gatewayHost` changes after the initial render, the `connect` function will still use the old value when called. <b>[ Out of scope ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->