### PR TITLE
Set default gateway value to undefined

### DIFF
--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -14,7 +14,7 @@ export const createClient = async (
 ) => {
   const env = options?.env || "dev";
   const host = options?.apiUrl || ApiUrls[env];
-  const gatewayHost = options?.gatewayHost || null;
+  const gatewayHost = options?.gatewayHost ?? null;
   const isSecure = host.startsWith("https");
   const inboxId =
     (await getInboxIdForIdentifier(host, gatewayHost, isSecure, identifier)) ||


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Normalize empty `gatewayHost` values to undefined in `apps/xmtp.chat/src/hooks/useSettings.ts` and to null in `sdks/browser-sdk/src/utils/createClient.ts` to set the default gateway value to null
`useSettings` now returns `gatewayHost` as `undefined` when the stored value is empty, and `createClient` passes `null` for `gatewayHost` when the option is an empty string. See [useSettings.ts](https://github.com/xmtp/xmtp-js/pull/1648/files#diff-3352baf8ab72df764886915121861c43c08a6c8127be64e615d9b6b3f5a2c287) and [createClient.ts](https://github.com/xmtp/xmtp-js/pull/1648/files#diff-951fe7cb5e12d9675ad04feb421f9fbfe4789e7810078125d388f7b71b52be05).

#### 📍Where to Start
Start with the normalization in `useSettings` in [useSettings.ts](https://github.com/xmtp/xmtp-js/pull/1648/files#diff-3352baf8ab72df764886915121861c43c08a6c8127be64e615d9b6b3f5a2c287), then review the `gatewayHost` derivation in [createClient.ts](https://github.com/xmtp/xmtp-js/pull/1648/files#diff-951fe7cb5e12d9675ad04feb421f9fbfe4789e7810078125d388f7b71b52be05).

<!-- Macroscope's changelog starts here -->
#### Changes since #1648 opened

- Changed `gatewayHost` parameter defaulting in `createClient` function from logical OR operator to nullish coalescing operator [6c4c30c]
<!-- Macroscope's changelog ends here -->

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 4a348e3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->