### PR TITLE
Remove flaky expectation

### DIFF
--- a/sdks/browser-sdk/test/DebugInformation.test.ts
+++ b/sdks/browser-sdk/test/DebugInformation.test.ts
@@ -28,7 +28,6 @@ describe("DebugInformation", () => {
     const apiStats2 = await client.debugInformation.apiStatistics();
     expect(apiStats2.uploadKeyPackage).toBe(0n);
     expect(apiStats2.fetchKeyPackage).toBe(0n);
-    expect(apiStats2.sendGroupMessages).toBe(0n);
     expect(apiStats2.sendWelcomeMessages).toBe(0n);
     expect(apiStats2.queryGroupMessages).toBe(0n);
     expect(apiStats2.queryWelcomeMessages).toBe(0n);


### PR DESCRIPTION
It seems the `expect(apiStats2.sendGroupMessages).toBe(0n)` expression is being flaky up again! You can check it out here: https://github.com/xmtp/xmtp-js/actions/runs/21078443006/job/60626054561?pr=1652

Interestingly, it also had issues in October 2025, even though I had removed it back then: https://github.com/xmtp/xmtp-js/commit/08ba4562