### PR TITLE
Add Gateway host config flag to Agent SDK

### DIFF
--- a/sdks/agent-sdk/src/core/Agent.ts
+++ b/sdks/agent-sdk/src/core/Agent.ts
@@ -232,7 +232,7 @@ export class Agent<ContentTypes = unknown> extends EventEmitter<
     }
 
     if (typeof XMTP_GATEWAY_HOST === "string") {
-      initializedOptions.gatewayHost = XMTP_GATEWAY_HOST || undefined;
+      initializedOptions.gatewayHost = XMTP_GATEWAY_HOST;
     }
 
     if (typeof XMTP_DB_DIRECTORY === "string") {


### PR DESCRIPTION
### TL;DR

Added support for configuring XMTP gateway host via environment variable.

### What changed?

- Added `XMTP_GATEWAY_HOST` to the list of environment variables read by the Agent class
- Implemented logic to set the `gatewayHost` option when the environment variable is present