### PR TITLE
Fix condition check for prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Update npm to latest
         run: npm install -g npm@latest
       - name: Update dependency version
-        if: ${{ inputs.prerelease_dependency_version != '' }}
+        if: ${{ github.event.inputs.prerelease_dependency_version != '' }}
         working-directory: ./sdks/${{ inputs.prerelease_sdk }}
         run: yarn add ${{ fromJSON(env.SDK_DEPS)[inputs.prerelease_sdk] }}@${{ inputs.prerelease_dependency_version }}
       - name: Install dependencies


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Guard the release workflow’s `Update dependency version` step in [release.yml](https://github.com/xmtp/xmtp-js/pull/1659/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) using `github.event.inputs.prerelease_dependency_version` to fix prerelease condition check
Update the step condition in [release.yml](https://github.com/xmtp/xmtp-js/pull/1659/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to reference `github.event.inputs.prerelease_dependency_version` instead of `inputs.prerelease_dependency_version`.

#### 📍Where to Start
Start with the conditional for the `Update dependency version` step in [release.yml](https://github.com/xmtp/xmtp-js/pull/1659/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized d8e52c3.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->