### PR TITLE
Refactor wallet connect

### DIFF
--- a/apps/xmtp.chat/src/components/App/Connect.tsx
+++ b/apps/xmtp.chat/src/components/App/Connect.tsx
@@ -1,21 +1,16 @@
 import { Stepper } from "@mantine/core";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { ConnectXMTP } from "@/components/App/ConnectXMTP";
 import { WalletConnect } from "@/components/App/WalletConnect";
 import { useXMTP } from "@/contexts/XMTPContext";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useRedirect } from "@/hooks/useRedirect";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 
 export const Connect = () => {
-  const { isConnected, disconnect, loading } = useConnectWallet();
-  const {
-    environment,
-    ephemeralAccountEnabled,
-    setEphemeralAccountEnabled,
-    setAutoConnect,
-  } = useSettings();
+  const { isConnected, loading } = useWallet();
+  const { environment, ephemeralAccountEnabled } = useSettings();
   const { client } = useXMTP();
   const navigate = useNavigate();
   const { redirectUrl, setRedirectUrl } = useRedirect();
@@ -41,15 +36,6 @@ export const Connect = () => {
     }
   }, [isConnected, ephemeralAccountEnabled]);
 
-  const handleDisconnectWallet = useCallback(() => {
-    if (isConnected) {
-      disconnect();
-    } else {
-      setEphemeralAccountEnabled(false);
-    }
-    setAutoConnect(false);
-  }, [isConnected, disconnect]);
-
   return (
     <Stepper active={active} onStepClick={setActive}>
       <Stepper.Step
@@ -59,7 +45,7 @@ export const Connect = () => {
         <WalletConnect />
       </Stepper.Step>
       <Stepper.Step label="Connect to XMTP" allowStepSelect={false}>
-        <ConnectXMTP onDisconnectWallet={handleDisconnectWallet} />
+        <ConnectXMTP />
       </Stepper.Step>
     </Stepper>
   );

--- a/apps/xmtp.chat/src/components/App/ConnectWallet.tsx
+++ b/apps/xmtp.chat/src/components/App/ConnectWallet.tsx
@@ -1,19 +1,19 @@
 import { Button } from "@mantine/core";
 import { useCallback } from "react";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 
 export const ConnectWallet: React.FC = () => {
-  const { connect, disconnect, loading, isConnected } = useConnectWallet();
-  const { connector, ephemeralAccountEnabled } = useSettings();
+  const { connect, disconnect, loading, isConnected } = useWallet();
+  const { ephemeralAccountEnabled } = useSettings();
 
   const handleConnect = useCallback(() => {
     if (isConnected) {
       disconnect();
     } else {
-      connect(connector)();
+      connect();
     }
-  }, [connect, connector, isConnected, disconnect]);
+  }, [connect, isConnected, disconnect]);
 
   return (
     <Button

--- a/apps/xmtp.chat/src/components/App/ConnectXMTP.tsx
+++ b/apps/xmtp.chat/src/components/App/ConnectXMTP.tsx
@@ -3,25 +3,29 @@ import { useCallback } from "react";
 import { ConnectedAddress } from "@/components/App/ConnectedAddress";
 import { LoggingSelect } from "@/components/App/LoggingSelect";
 import { NetworkSelect } from "@/components/App/NetworkSelect";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useConnectXmtp } from "@/hooks/useConnectXmtp";
 import { useEphemeralSigner } from "@/hooks/useEphemeralSigner";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 import classes from "./ConnectXMTP.module.css";
 
-export type ConnectXMTPProps = {
-  onDisconnectWallet: () => void;
-};
-
-export const ConnectXMTP = ({ onDisconnectWallet }: ConnectXMTPProps) => {
-  const { isConnected, address } = useConnectWallet();
+export const ConnectXMTP: React.FC = () => {
+  const { isConnected, address, disconnect } = useWallet();
   const { address: ephemeralAddress } = useEphemeralSigner();
   const { connect, loading } = useConnectXmtp();
-  const { ephemeralAccountEnabled } = useSettings();
+  const { ephemeralAccountEnabled, setEphemeralAccountEnabled } = useSettings();
 
   const handleConnectClick = useCallback(() => {
     connect();
   }, [connect]);
+
+  const handleDisconnectClick = useCallback(() => {
+    if (isConnected) {
+      disconnect();
+    } else {
+      setEphemeralAccountEnabled(false);
+    }
+  }, [isConnected, disconnect]);
 
   return (
     <Paper withBorder radius="md">
@@ -38,7 +42,7 @@ export const ConnectXMTP = ({ onDisconnectWallet }: ConnectXMTPProps) => {
           <ConnectedAddress
             size="sm"
             address={address ?? ephemeralAddress}
-            onClick={onDisconnectWallet}
+            onClick={handleDisconnectClick}
           />
           <Group gap="xs" align="center">
             <Button

--- a/apps/xmtp.chat/src/components/App/ConnectorSelect.tsx
+++ b/apps/xmtp.chat/src/components/App/ConnectorSelect.tsx
@@ -1,10 +1,7 @@
 import { Grid } from "@mantine/core";
 import { AccountCard } from "@/components/App/AccountCard";
-import {
-  useConnectWallet,
-  type ConnectorString,
-} from "@/hooks/useConnectWallet";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet, type ConnectorString } from "@/hooks/useWallet";
 import { CoinbaseWallet } from "@/icons/CoinbaseWallet";
 import { InjectedWallet } from "@/icons/InjectedWallet";
 import { MetamaskWallet } from "@/icons/MetamaskWallet";
@@ -12,7 +9,7 @@ import { WalletConnectWallet } from "@/icons/WalletConnectWallet";
 import classes from "./ConnectorSelect.module.css";
 
 export const ConnectorSelect: React.FC = () => {
-  const { isConnected, loading } = useConnectWallet();
+  const { isConnected, loading } = useWallet();
   const { connector, setConnector, ephemeralAccountEnabled, useSCW } =
     useSettings();
 

--- a/apps/xmtp.chat/src/components/App/Disconnect.tsx
+++ b/apps/xmtp.chat/src/components/App/Disconnect.tsx
@@ -2,24 +2,18 @@ import { LoadingOverlay } from "@mantine/core";
 import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { useXMTP } from "@/contexts/XMTPContext";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
-import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 import { CenteredLayout } from "@/layouts/CenteredLayout";
 
 export const Disconnect: React.FC = () => {
   const navigate = useNavigate();
-  const { disconnect } = useConnectWallet();
-  const { setAutoConnect, setEphemeralAccountEnabled } = useSettings();
+  const { disconnect } = useWallet();
   const { disconnect: disconnectClient } = useXMTP();
 
   useEffect(() => {
-    disconnect(undefined, {
-      onSuccess: () => {
-        disconnectClient();
-        setEphemeralAccountEnabled(false);
-        setAutoConnect(false);
-        void navigate("/");
-      },
+    disconnect(() => {
+      disconnectClient();
+      void navigate("/");
     });
   }, []);
 

--- a/apps/xmtp.chat/src/components/App/New.tsx
+++ b/apps/xmtp.chat/src/components/App/New.tsx
@@ -2,12 +2,12 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router";
 import { LoadingMessage } from "@/components/LoadingMessage";
 import { useXMTP } from "@/contexts/XMTPContext";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useConnectXmtp } from "@/hooks/useConnectXmtp";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 
 export const New = () => {
-  const { isConnected } = useConnectWallet();
+  const { isConnected } = useWallet();
   const {
     environment,
     ephemeralAccountEnabled,

--- a/apps/xmtp.chat/src/components/App/UseEphemeral.tsx
+++ b/apps/xmtp.chat/src/components/App/UseEphemeral.tsx
@@ -1,10 +1,10 @@
 import { Button, Group, Switch, Text, Tooltip } from "@mantine/core";
 import { useCallback } from "react";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 
 export const UseEphemeral: React.FC = () => {
-  const { isConnected } = useConnectWallet();
+  const { isConnected } = useWallet();
   const {
     ephemeralAccountEnabled,
     setEphemeralAccountEnabled,

--- a/apps/xmtp.chat/src/components/App/UseSCW.tsx
+++ b/apps/xmtp.chat/src/components/App/UseSCW.tsx
@@ -1,10 +1,10 @@
 import { Group, Switch, Text, Tooltip } from "@mantine/core";
 import React from "react";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 
 export const UseSCW: React.FC = () => {
-  const { isConnected } = useConnectWallet();
+  const { isConnected } = useWallet();
   const { useSCW, setUseSCW, ephemeralAccountEnabled, connector } =
     useSettings();
 

--- a/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
+++ b/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
@@ -17,10 +17,10 @@ import { InstallationTable } from "@/components/InboxTools/InstallationTable";
 import { NetworkSelect } from "@/components/InboxTools/NetworkSelect";
 import { createEOASigner, createSCWSigner } from "@/helpers/createSigner";
 import { isValidInboxId } from "@/helpers/strings";
-import { useConnectWallet } from "@/hooks/useConnectWallet";
 import { useEphemeralSigner } from "@/hooks/useEphemeralSigner";
 import { useMemberId } from "@/hooks/useMemberId";
 import { useSettings } from "@/hooks/useSettings";
+import { useWallet } from "@/hooks/useWallet";
 import { ContentLayout } from "@/layouts/ContentLayout";
 
 export const InboxTools: React.FC = () => {
@@ -29,7 +29,7 @@ export const InboxTools: React.FC = () => {
     isConnected,
     disconnect,
     loading: walletLoading,
-  } = useConnectWallet();
+  } = useWallet();
   const { address: ephemeralAddress, signer: ephemeralSigner } =
     useEphemeralSigner();
   const { signMessageAsync } = useSignMessage();

--- a/apps/xmtp.chat/src/hooks/useSettings.ts
+++ b/apps/xmtp.chat/src/hooks/useSettings.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from "@mantine/hooks";
 import { LogLevel, type ClientOptions, type XmtpEnv } from "@xmtp/browser-sdk";
 import { useEffect } from "react";
 import type { Hex } from "viem";
-import type { ConnectorString } from "@/hooks/useConnectWallet";
+import type { ConnectorString } from "@/hooks/useWallet";
 
 const loggingLevelStringToEnum = {
   off: LogLevel.Off,

--- a/apps/xmtp.chat/src/hooks/useWallet.ts
+++ b/apps/xmtp.chat/src/hooks/useWallet.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useAccount, useConnect, useConnectors, useDisconnect } from "wagmi";
+import { useSettings } from "@/hooks/useSettings";
 
 export type ConnectorString =
   | "Injected"
@@ -7,27 +8,45 @@ export type ConnectorString =
   | "MetaMask"
   | "WalletConnect";
 
-export const useConnectWallet = () => {
+export const useWallet = () => {
   const account = useAccount();
   const { connect, isPending: connectLoading } = useConnect();
   const connectors = useConnectors();
   const { disconnect, isPending: disconnectLoading } = useDisconnect();
+  const {
+    setAutoConnect,
+    setEphemeralAccountEnabled,
+    connector: connectorString,
+  } = useSettings();
 
   const connectWallet = useCallback(
-    (connectorString: ConnectorString) => () => {
+    () => () => {
       const connector = connectors.find((c) => c.name === connectorString);
       if (!connector) {
         throw new Error(`Connector ${connectorString} not found`);
       }
       connect({ connector });
     },
-    [connectors, connect],
+    [connectors, connect, connectorString],
+  );
+
+  const disconnectWallet = useCallback(
+    (onSuccess?: () => void) => {
+      setAutoConnect(false);
+      setEphemeralAccountEnabled(false);
+      disconnect(undefined, {
+        onSuccess: () => {
+          onSuccess?.();
+        },
+      });
+    },
+    [disconnect, setAutoConnect, setEphemeralAccountEnabled],
   );
 
   return {
     account,
     connect: connectWallet,
-    disconnect,
+    disconnect: disconnectWallet,
     isConnected: !!account.address,
     loading: connectLoading || disconnectLoading,
     address: account.address,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Refactor wallet connect by replacing `apps/xmtp.chat/src/hooks/useConnectWallet` with `apps/xmtp.chat/src/hooks/useWallet` and delegate disconnect/reset logic to the hook across App components
Introduce `useWallet` that reads connector from settings, exposes zero-arg `connect()` and `disconnect(onSuccess?)` that resets autoConnect and ephemeral, and update App components to use it, removing local disconnect and settings handling. Key entry points are updated in Connect, ConnectWallet, ConnectXMTP, and Disconnect.

#### 📍Where to Start
Start with the `useWallet` hook in [useWallet.ts](https://github.com/xmtp/xmtp-js/pull/1665/files#diff-ef27aa3103fdf50ce87d5cca1389654eec909b4e9ecfd526d99c8ca554664415), then review its usage in [Connect.tsx](https://github.com/xmtp/xmtp-js/pull/1665/files#diff-5501d523753a8d6e79f823d0e9d86ae81b9f38148208c66aae3dcf42d2ca592c) and [ConnectXMTP.tsx](https://github.com/xmtp/xmtp-js/pull/1665/files#diff-b7b581b23b09e8ac2835a4123b8d8c5de16fef54549068f2c4b92700999a8caf).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 52edb5c.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->