### PR TITLE
Upgrade primitives with latest bindings

### DIFF
--- a/content-types/content-type-primitives/CHANGELOG.md
+++ b/content-types/content-type-primitives/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/content-type-primitives
 
+## 3.0.1
+
+### Patch Changes
+
+- Upgraded `@xmtp/node-bindings` dependency to `1.9.1`
+
 ## 3.0.0
 
 This release introduces breaking changes and new features to replace previous functionality. If you've been building on a previous release, this one will require an update to your existing code.

--- a/content-types/content-type-primitives/package.json
+++ b/content-types/content-type-primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xmtp/content-type-primitives",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Primitives for building custom XMTP content types",
   "keywords": [
     "xmtp",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,7 +4709,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/content-type-primitives@npm:3.0.0, @xmtp/content-type-primitives@npm:^3.0.0, @xmtp/content-type-primitives@workspace:^, @xmtp/content-type-primitives@workspace:content-types/content-type-primitives":
+"@xmtp/content-type-primitives@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@xmtp/content-type-primitives@npm:3.0.0"
+  dependencies:
+    "@xmtp/node-bindings": "npm:1.8.0"
+  checksum: 10/b70fccaad3e9192de10f7a0838feb28feb6c919aca42da9b0b7b5a003a69f1078cec4b3bb56a07ead824471f928144931494b3f88da24af4538165aa92b1ced2
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-primitives@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@xmtp/content-type-primitives@npm:2.0.3"
+  dependencies:
+    "@xmtp/proto": "npm:3.78.0"
+  checksum: 10/effd1a6790acb01093a497ac55f34281e3f60b75f7289375da2abb0cd764f791fb58a040a00b40a125b857e4174e985bb92d83454d0de78c52a4e711cece9f1e
+  languageName: node
+  linkType: hard
+
+"@xmtp/content-type-primitives@npm:^3.0.0, @xmtp/content-type-primitives@workspace:^, @xmtp/content-type-primitives@workspace:content-types/content-type-primitives":
   version: 0.0.0-use.local
   resolution: "@xmtp/content-type-primitives@workspace:content-types/content-type-primitives"
   dependencies:
@@ -4725,15 +4743,6 @@ __metadata:
     vitest: "npm:^4.0.16"
   languageName: unknown
   linkType: soft
-
-"@xmtp/content-type-primitives@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "@xmtp/content-type-primitives@npm:2.0.3"
-  dependencies:
-    "@xmtp/proto": "npm:3.78.0"
-  checksum: 10/effd1a6790acb01093a497ac55f34281e3f60b75f7289375da2abb0cd764f791fb58a040a00b40a125b857e4174e985bb92d83454d0de78c52a4e711cece9f1e
-  languageName: node
-  linkType: hard
 
 "@xmtp/content-type-reaction@npm:^2.0.2, @xmtp/content-type-reaction@workspace:content-types/content-type-reaction":
   version: 0.0.0-use.local
@@ -4878,6 +4887,13 @@ __metadata:
   version: 1.6.8
   resolution: "@xmtp/node-bindings@npm:1.6.8"
   checksum: 10/5391dc987e63cc0fac5b114f743c955689822fef0df44ed038f54aa19e673624cfb7a72dcf9abd2e7afaca9710bf37d5793698956912fe5cb678c50b211b6ca2
+  languageName: node
+  linkType: hard
+
+"@xmtp/node-bindings@npm:1.8.0":
+  version: 1.8.0
+  resolution: "@xmtp/node-bindings@npm:1.8.0"
+  checksum: 10/bd9678d21f5e2ab12350ad12f500d2e7d9b4b7c479e38d4ddc45c5691d226460b2aa024c1eed21934d63ea600103dd0e267d04a4b25972b6c7cb68bc2045a892
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Bump `content-types/content-type-primitives` to 3.0.1 to upgrade `@xmtp/node-bindings` to 1.9.1
Update the package version to 3.0.1 and align dependencies with `@xmtp/node-bindings` 1.9.1; refresh the lockfile accordingly.

#### 📍Where to Start
Start with the version change in [package.json](https://github.com/xmtp/xmtp-js/pull/1677/files#diff-7ce2f46eba0229f13aba8eae548cc7ad4794ddbcfaeab6626fe6c36429965cc7), then verify the entry in [CHANGELOG.md](https://github.com/xmtp/xmtp-js/pull/1677/files#diff-463e367929da000562c0d7a327d43d28d5d54f1e97364cdcb9a49333720ff3c4).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 76c2020.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->