### PR TITLE
Fix type error in api-service resolve router

### DIFF
--- a/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts
+++ b/apps/xmtp.chat-api-service/src/api/v2/resolve.router.ts
@@ -4,7 +4,10 @@ import { fetchProfilesFromName } from "../../helpers/web3.bio.js";
 
 export const resolveNameSchema = z.string().endsWith(".eth");
 
-export async function resolveName(req: Request, res: Response) {
+export async function resolveName(
+  req: Request<{ name: string }>,
+  res: Response,
+) {
   try {
     const { name } = req.params;
     const normalizedName = name.toLowerCase();


### PR DESCRIPTION
## Summary
- Fix TypeScript error where `req.params.name` has type `string | string[]` but code assumed `string`
- Add type assertion since route parameters are always strings

## Test plan
- [x] `yarn turbo run typecheck --filter='./apps/xmtp.chat-api-service'` passes

🤖 Generated with [Claude Code](https://claude.ai/code)