### PR TITLE
Fix useAppLock re-renders

### DIFF
--- a/apps/xmtp.chat/src/hooks/useAppLock.ts
+++ b/apps/xmtp.chat/src/hooks/useAppLock.ts
@@ -42,6 +42,9 @@ export const useAppLock = (onLockLost?: () => void) => {
     defaultValue: null,
     getInitialValueInEffect: false,
   });
+  // lastActive ref to avoid re-renders
+  const lastActiveRef = useRef(lastActive);
+  lastActiveRef.current = lastActive;
 
   const lockState: AppLockState = useMemo(() => {
     if (lockId === null) {
@@ -66,7 +69,7 @@ export const useAppLock = (onLockLost?: () => void) => {
       // if the lock is not stale and acquired by another session, don't acquire it
       // unless force is true
       if (
-        !isLockStale(lastActive) &&
+        !isLockStale(lastActiveRef.current) &&
         lockId !== null &&
         lockId !== lockIdRef.current &&
         !force
@@ -80,7 +83,7 @@ export const useAppLock = (onLockLost?: () => void) => {
       hadLockRef.current = true;
       return true;
     },
-    [lastActive, lockId, setLockId, setLastActive],
+    [lockId, setLockId, setLastActive],
   );
 
   const releaseLock = useCallback((): void => {


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Reduce `useAppLock` re-renders by caching `lastActive` in a ref and updating `useAppLock.acquireLock` to read `lastActiveRef.current` in apps/xmtp.chat/src/hooks/useAppLock.ts
Introduce `lastActiveRef` to mirror local storage and assign on each render; update `useAppLock.acquireLock` to use `lastActiveRef.current` for staleness checks and remove `lastActive` from the callback dependencies in [useAppLock.ts](https://github.com/xmtp/xmtp-js/pull/1684/files#diff-29ad4a94a9ba9a99a2c71216973127ca34bfa290ca958388f842ebb2899922f4).

#### 📍Where to Start
Start with the `useAppLock` hook and the `acquireLock` callback in [apps/xmtp.chat/src/hooks/useAppLock.ts](https://github.com/xmtp/xmtp-js/pull/1684/files#diff-29ad4a94a9ba9a99a2c71216973127ca34bfa290ca958388f842ebb2899922f4).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a639b17.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->