### PR TITLE
Catching content type errors

### DIFF
--- a/apps/xmtp.chat/src/components/Messages/Message.tsx
+++ b/apps/xmtp.chat/src/components/Messages/Message.tsx
@@ -44,7 +44,7 @@ export const Message: React.FC<MessageProps> = ({
             `/${environment}/conversations/${message.conversationId}/message/${message.id}`,
           )
         }>
-        <ErrorBoundary>
+        <ErrorBoundary key={message.id}>
           <MessageContentWithWrapper
             message={message}
             align={align}


### PR DESCRIPTION
This error boundary catches potential errors with message content types:

<img width="1279" height="1164" alt="image" src="https://github.com/user-attachments/assets/9b9a4bd5-db09-4e0e-963f-0a080c0abe94" />
