### PR TITLE
Fix display of content fallback

### DIFF
--- a/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
@@ -44,6 +44,7 @@ export const MessageContentWithWrapper: React.FC<
       <MessageContent
         content={message.content}
         contentType={message.contentType}
+        fallback={message.fallback}
         align={align}
         scrollToMessage={scrollToMessage}
       />


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Pass `message.fallback` to `MessageContent` via `MessageContentWithWrapper` in [MessageContentWithWrapper.tsx](https://github.com/xmtp/xmtp-js/pull/1692/files#diff-a53ff22661ac52ca32c409869af09dad7b31d4083caaafcc78f488ee250ed9b2) to fix display of content fallback
Add a `fallback` prop passthrough from `message.fallback` to the `MessageContent` child in [MessageContentWithWrapper.tsx](https://github.com/xmtp/xmtp-js/pull/1692/files#diff-a53ff22661ac52ca32c409869af09dad7b31d4083caaafcc78f488ee250ed9b2).

#### 📍Where to Start
Start with the `MessageContentWithWrapper` component in [MessageContentWithWrapper.tsx](https://github.com/xmtp/xmtp-js/pull/1692/files#diff-a53ff22661ac52ca32c409869af09dad7b31d4083caaafcc78f488ee250ed9b2).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0ab2432.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->