### PR TITLE
Bugfix: pass gatewayHost through inbox ID resolution for D14N support

### DIFF
--- a/apps/xmtp.chat/src/helpers/names.ts
+++ b/apps/xmtp.chat/src/helpers/names.ts
@@ -64,10 +64,11 @@ export const resolveName = async (name: string, force: boolean = false) => {
 export const getInboxIdForAddressQuery = async (
   address: string,
   environment: XmtpEnv,
+  gatewayHost?: string,
 ) => {
   return queryClient.fetchQuery({
-    queryKey: ["getInboxIdForAddress", address, environment],
-    queryFn: () => getInboxIdForAddress(address, environment),
+    queryKey: ["getInboxIdForAddress", address, environment, gatewayHost],
+    queryFn: () => getInboxIdForAddress(address, environment, gatewayHost),
     // do not re-query the address for this session
     staleTime: Infinity,
     gcTime: Infinity,
@@ -77,6 +78,7 @@ export const getInboxIdForAddressQuery = async (
 export const getInboxIdForAddress = async (
   address: string,
   environment: XmtpEnv,
+  gatewayHost?: string,
 ): Promise<string | null> => {
   if (!isValidEthereumAddress(address)) {
     return null;
@@ -88,6 +90,7 @@ export const getInboxIdForAddress = async (
       identifierKind: IdentifierKind.Ethereum,
     },
     environment,
+    gatewayHost,
   );
 
   return inboxId ?? null;

--- a/apps/xmtp.chat/src/hooks/useMemberId.ts
+++ b/apps/xmtp.chat/src/hooks/useMemberId.ts
@@ -17,7 +17,7 @@ export const useMemberId = () => {
   const [description, setDescription] = useState<string | null>(null);
   const [avatar, setAvatar] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { environment } = useSettings();
+  const { environment, gatewayHost } = useSettings();
 
   useEffect(() => {
     const checkMemberId = async () => {
@@ -45,6 +45,7 @@ export const useMemberId = () => {
           const inboxId = await getInboxIdForAddressQuery(
             memberId.toLowerCase(),
             environment,
+            gatewayHost,
           );
 
           if (!inboxId) {
@@ -76,6 +77,7 @@ export const useMemberId = () => {
               const inboxId = await getInboxIdForAddressQuery(
                 profile.address,
                 environment,
+                gatewayHost,
               );
               if (!inboxId) {
                 setError(
@@ -103,7 +105,7 @@ export const useMemberId = () => {
     };
 
     void checkMemberId();
-  }, [memberId, environment]);
+  }, [memberId, environment, gatewayHost]);
 
   return {
     memberId,


### PR DESCRIPTION
getInboxIdForAddress() was not forwarding the gatewayHost parameter to getInboxIdForIdentifier(), causing address-to-inbox-ID lookups to hit the V3 backend instead of D14N when a gateway host was configured. This resulted in a split-brain where identity resolution went to V3 while the rest of the client operated on D14N, leading to "mismatched key packages" errors when creating groups.