### PR TITLE
feat(cli): add send-attachment and send-remote-attachment commands

### DIFF
--- a/.changeset/send-attachment.md
+++ b/.changeset/send-attachment.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/cli": minor
+---
+
+feat(cli): add send-attachment and send-remote-attachment commands

--- a/packages/xmtp-cli/src/commands/conversation/download-attachment.ts
+++ b/packages/xmtp-cli/src/commands/conversation/download-attachment.ts
@@ -1,0 +1,223 @@
+import { writeFile as fsWriteFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { cwd } from "node:process";
+import { Args, Flags } from "@oclif/core";
+import {
+  decryptAttachment,
+  type Attachment,
+  type RemoteAttachment,
+} from "@xmtp/node-sdk";
+import { BaseCommand } from "../../baseCommand.js";
+import { getExtension } from "../../utils/mime.js";
+
+export default class ConversationDownloadAttachment extends BaseCommand {
+  static description = `Download an attachment from a message.
+
+Downloads an attachment message and saves it to disk. Handles both
+inline attachments and remote (encrypted) attachments transparently.
+
+For inline attachments, the content is written directly to disk.
+
+For remote attachments, the encrypted payload is fetched from the URL
+embedded in the message, decrypted using the keys in the message, and
+the decrypted content is saved to disk.
+
+The output filename is determined by (in order of priority):
+1. The --output flag (explicit path)
+2. The filename from the message metadata
+3. Auto-generated from message ID + MIME type extension
+
+Use --raw to save the encrypted payload without decrypting (remote
+attachments only).`;
+
+  static examples = [
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> <message-id>",
+      description: "Download attachment (auto-names from message metadata)",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> <message-id> --output ./photo.jpg",
+      description: "Download to a specific path",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> <message-id> --raw",
+      description:
+        "Save the encrypted payload without decrypting (remote only)",
+    },
+  ];
+
+  static args = {
+    id: Args.string({
+      description: "The conversation ID",
+      required: true,
+    }),
+    "message-id": Args.string({
+      description: "The message ID of the attachment",
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    output: Flags.string({
+      char: "o",
+      description: "Output file path (default: auto-generated from metadata)",
+      helpValue: "<path>",
+    }),
+    raw: Flags.boolean({
+      description:
+        "Save encrypted payload without decrypting (remote attachments only)",
+      default: false,
+    }),
+    sync: Flags.boolean({
+      description: "Sync conversation from network before downloading",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(ConversationDownloadAttachment);
+    const client = await this.initClient();
+
+    const conversation = await client.conversations.getConversationById(
+      args.id,
+    );
+
+    if (!conversation) {
+      this.error(`Conversation not found: ${args.id}`);
+    }
+
+    if (flags.sync) {
+      await conversation.sync();
+    }
+
+    const message = client.conversations.getMessageById(args["message-id"]);
+
+    if (!message) {
+      this.error(
+        `Message not found: ${args["message-id"]}. Try --sync to fetch latest messages.`,
+      );
+    }
+
+    const typeId = message.contentType.typeId;
+
+    if (typeId === "attachment") {
+      await this.downloadInline(
+        message.content as Attachment,
+        args["message-id"],
+        flags,
+      );
+    } else if (typeId === "remoteStaticAttachment") {
+      await this.downloadRemote(
+        message.content as RemoteAttachment,
+        args["message-id"],
+        flags,
+      );
+    } else {
+      this.error(
+        `Message ${args["message-id"]} is not an attachment (type: ${typeId})`,
+      );
+    }
+  }
+
+  private async downloadInline(
+    attachment: Attachment,
+    messageId: string,
+    flags: { output?: string },
+  ): Promise<void> {
+    const bytes = attachment.content;
+    const mimeType = attachment.mimeType;
+    const filename =
+      flags.output ??
+      attachment.filename ??
+      `${messageId.slice(0, 16)}${getExtension(mimeType)}`;
+    const outputPath = isAbsolute(filename) ? filename : join(cwd(), filename);
+
+    await writeFileWithDirs(outputPath, bytes);
+
+    this.output({
+      success: true,
+      type: "inline",
+      outputPath,
+      filename: attachment.filename,
+      mimeType,
+      size: bytes.length,
+    });
+  }
+
+  private async downloadRemote(
+    remote: RemoteAttachment,
+    messageId: string,
+    flags: { output?: string; raw: boolean },
+  ): Promise<void> {
+    // Fetch the encrypted payload
+    const response = await fetch(remote.url);
+
+    if (!response.ok) {
+      this.error(
+        `Failed to fetch remote attachment: ${response.status} ${response.statusText} (${remote.url})`,
+      );
+    }
+
+    const encryptedBytes = new Uint8Array(await response.arrayBuffer());
+
+    if (flags.raw) {
+      // Save encrypted payload without decrypting
+      const filename =
+        flags.output ??
+        `${remote.filename ?? messageId.slice(0, 16)}.encrypted`;
+      const outputPath = isAbsolute(filename)
+        ? filename
+        : join(cwd(), filename);
+
+      await writeFileWithDirs(outputPath, encryptedBytes);
+
+      this.output({
+        success: true,
+        type: "remote-raw",
+        outputPath,
+        url: remote.url,
+        size: encryptedBytes.length,
+      });
+      return;
+    }
+
+    // Decrypt the payload
+    const decrypted = decryptAttachment(encryptedBytes, remote);
+
+    const mimeType = decrypted.mimeType;
+    const filename =
+      flags.output ??
+      decrypted.filename ??
+      remote.filename ??
+      `${messageId.slice(0, 16)}${getExtension(mimeType)}`;
+    const outputPath = isAbsolute(filename) ? filename : join(cwd(), filename);
+
+    await writeFileWithDirs(outputPath, decrypted.content);
+
+    this.output({
+      success: true,
+      type: "remote",
+      outputPath,
+      filename: decrypted.filename ?? remote.filename,
+      mimeType,
+      size: decrypted.content.length,
+      url: remote.url,
+    });
+  }
+}
+
+function isAbsolute(p: string): boolean {
+  return p.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(p);
+}
+
+async function writeFileWithDirs(
+  path: string,
+  data: Uint8Array,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await fsWriteFile(path, data);
+}

--- a/packages/xmtp-cli/src/commands/conversation/send-attachment.ts
+++ b/packages/xmtp-cli/src/commands/conversation/send-attachment.ts
@@ -1,0 +1,239 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { Args, Flags } from "@oclif/core";
+import { encryptAttachment } from "@xmtp/node-sdk";
+import { BaseCommand } from "../../baseCommand.js";
+import { createClient } from "../../utils/client.js";
+import { getMimeType } from "../../utils/mime.js";
+import {
+  getUploadProvider,
+  INLINE_ATTACHMENT_MAX_BYTES,
+} from "../../utils/upload.js";
+
+export default class ConversationSendAttachment extends BaseCommand {
+  static description = `Send a file attachment to a conversation.
+
+Reads a file from disk and sends it as an attachment message. Small
+files are sent inline; large files (>1MB) are automatically encrypted
+and uploaded via the configured upload provider, then sent as a remote
+attachment.
+
+To configure an upload provider for large files:
+
+  Set XMTP_UPLOAD_PROVIDER and XMTP_UPLOAD_PROVIDER_TOKEN in your .env,
+  or pass --upload-provider and --upload-provider-token flags.
+
+  Supported providers: pinata
+
+  Example (.env):
+    XMTP_UPLOAD_PROVIDER=pinata
+    XMTP_UPLOAD_PROVIDER_TOKEN=<your-pinata-jwt>
+    XMTP_UPLOAD_PROVIDER_GATEWAY=https://your-gateway.mypinata.cloud
+
+The MIME type is auto-detected from the file extension, or can be
+specified manually with --mime-type.
+
+Use --encrypt to only encrypt the file and output decryption keys
+without sending (for manual upload workflows).`;
+
+  static examples = [
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> ./photo.jpg",
+      description: "Send a photo (auto-detects inline vs remote)",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> ./document.pdf --mime-type application/pdf",
+      description: "Send with explicit MIME type",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> ./photo.jpg --encrypt",
+      description:
+        "Encrypt and output remote attachment info (for manual upload)",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> ./large-video.mp4 --upload-provider pinata --upload-provider-token <jwt>",
+      description: "Send a large file via Pinata",
+    },
+  ];
+
+  static args = {
+    id: Args.string({
+      description: "The conversation ID",
+      required: true,
+    }),
+    file: Args.string({
+      description: "Path to the file to send",
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    "mime-type": Flags.string({
+      description: "Override the auto-detected MIME type",
+      helpValue: "<type>",
+    }),
+    optimistic: Flags.boolean({
+      description:
+        "Send optimistically (queued locally and published via 'conversation publish-messages')",
+      default: false,
+    }),
+    encrypt: Flags.boolean({
+      description:
+        "Encrypt the attachment and output the encrypted payload and decryption keys instead of sending. Upload the payload yourself, then use 'send-remote-attachment' to send the message.",
+      default: false,
+    }),
+    "encrypted-output": Flags.string({
+      description:
+        "When using --encrypt, write the encrypted payload to this file path (default: <file>.encrypted)",
+      helpValue: "<path>",
+      dependsOn: ["encrypt"],
+    }),
+    "upload-provider": Flags.string({
+      description: "Upload provider for remote attachments",
+      helpValue: "<provider>",
+    }),
+    "upload-provider-token": Flags.string({
+      description: "Authentication token for the upload provider",
+      helpValue: "<token>",
+    }),
+    "upload-provider-gateway": Flags.string({
+      description: "Custom gateway URL for the upload provider",
+      helpValue: "<url>",
+    }),
+    remote: Flags.boolean({
+      description:
+        "Force sending as a remote attachment (encrypt + upload), even for small files",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(ConversationSendAttachment);
+
+    // Merge upload-specific flags with base config (CLI flags take precedence)
+    const config = {
+      ...this.getConfig(),
+      ...(flags["upload-provider"] && {
+        uploadProvider: flags["upload-provider"],
+      }),
+      ...(flags["upload-provider-token"] && {
+        uploadProviderToken: flags["upload-provider-token"],
+      }),
+      ...(flags["upload-provider-gateway"] && {
+        uploadProviderGateway: flags["upload-provider-gateway"],
+      }),
+    };
+
+    const content = await readFile(args.file);
+    const filename = basename(args.file);
+    const mimeType = flags["mime-type"] ?? getMimeType(args.file);
+
+    const attachment = {
+      mimeType,
+      content,
+      filename,
+    };
+
+    // --encrypt: just encrypt and output keys, don't send
+    if (flags.encrypt) {
+      const encrypted = encryptAttachment(attachment);
+      const outputPath = flags["encrypted-output"] ?? `${args.file}.encrypted`;
+      await writeFile(outputPath, encrypted.payload);
+
+      this.output({
+        encryptedFile: outputPath,
+        filename,
+        mimeType,
+        contentDigest: encrypted.contentDigest,
+        secret: Buffer.from(encrypted.secret).toString("base64"),
+        salt: Buffer.from(encrypted.salt).toString("base64"),
+        nonce: Buffer.from(encrypted.nonce).toString("base64"),
+        contentLength: encrypted.payload.length,
+        note: "Upload the encrypted file to a URL, then use 'conversation send-remote-attachment' to send it.",
+      });
+      return;
+    }
+
+    const client = await createClient(config);
+    const conversation = await client.conversations.getConversationById(
+      args.id,
+    );
+
+    if (!conversation) {
+      this.error(`Conversation not found: ${args.id}`);
+    }
+
+    const needsRemote =
+      flags.remote || content.length > INLINE_ATTACHMENT_MAX_BYTES;
+
+    if (needsRemote) {
+      // Encrypt + upload + send as remote attachment
+      const provider = getUploadProvider(config);
+
+      if (!provider) {
+        this.error(
+          `File is ${content.length} bytes (>${INLINE_ATTACHMENT_MAX_BYTES}). ` +
+            `Configure an upload provider to send large files.\n\n` +
+            `Set in your .env:\n` +
+            `  XMTP_UPLOAD_PROVIDER=pinata\n` +
+            `  XMTP_UPLOAD_PROVIDER_TOKEN=<your-jwt>\n\n` +
+            `Or use flags:\n` +
+            `  --upload-provider pinata --upload-provider-token <jwt>\n\n` +
+            `Or use --encrypt to manually encrypt and upload.`,
+        );
+      }
+
+      const encrypted = encryptAttachment(attachment);
+      const url = await provider.upload(encrypted.payload, filename, mimeType);
+
+      const messageId = await conversation.sendRemoteAttachment(
+        {
+          url,
+          contentDigest: encrypted.contentDigest,
+          secret: encrypted.secret,
+          salt: encrypted.salt,
+          nonce: encrypted.nonce,
+          scheme: "https",
+          contentLength: encrypted.payload.length,
+          filename,
+        },
+        flags.optimistic,
+      );
+
+      this.output({
+        success: true,
+        messageId,
+        conversationId: args.id,
+        filename,
+        mimeType,
+        size: content.length,
+        type: "remote",
+        provider: provider.name,
+        url,
+        optimistic: flags.optimistic,
+      });
+    } else {
+      // Send inline
+      const messageId = await conversation.sendAttachment(
+        attachment,
+        flags.optimistic,
+      );
+
+      this.output({
+        success: true,
+        messageId,
+        conversationId: args.id,
+        filename,
+        mimeType,
+        size: content.length,
+        type: "inline",
+        optimistic: flags.optimistic,
+      });
+    }
+  }
+}

--- a/packages/xmtp-cli/src/commands/conversation/send-remote-attachment.ts
+++ b/packages/xmtp-cli/src/commands/conversation/send-remote-attachment.ts
@@ -1,0 +1,116 @@
+import { Args, Flags } from "@oclif/core";
+import { BaseCommand } from "../../baseCommand.js";
+import { createClient } from "../../utils/client.js";
+
+export default class ConversationSendRemoteAttachment extends BaseCommand {
+  static description = `Send a remote attachment message to a conversation.
+
+Sends a reference to an encrypted file that has been uploaded to a URL.
+The recipient downloads and decrypts the file using the provided keys.
+
+Use 'conversation send-attachment --encrypt' to encrypt a file and get
+the required keys, then upload the encrypted payload and use this
+command to send the message.
+
+Use --optimistic to send the message optimistically (queued locally
+and published via 'conversation publish-messages').`;
+
+  static examples = [
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> https://example.com/encrypted-file --content-digest abc123 --secret <base64> --salt <base64> --nonce <base64> --scheme https --content-length 12345",
+      description: "Send a remote attachment",
+    },
+    {
+      command:
+        "<%= config.bin %> <%= command.id %> <conversation-id> https://example.com/photo.jpg.enc --content-digest abc123 --secret <base64> --salt <base64> --nonce <base64> --scheme https --content-length 12345 --filename photo.jpg",
+      description: "Send with original filename",
+    },
+  ];
+
+  static args = {
+    id: Args.string({
+      description: "The conversation ID",
+      required: true,
+    }),
+    url: Args.string({
+      description: "URL where the encrypted file is hosted",
+      required: true,
+    }),
+  };
+
+  static flags = {
+    ...BaseCommand.baseFlags,
+    "content-digest": Flags.string({
+      description: "SHA-256 digest of the encrypted payload (hex)",
+      required: true,
+    }),
+    secret: Flags.string({
+      description: "Decryption secret key (base64)",
+      required: true,
+    }),
+    salt: Flags.string({
+      description: "Encryption salt (base64)",
+      required: true,
+    }),
+    nonce: Flags.string({
+      description: "Encryption nonce (base64)",
+      required: true,
+    }),
+    scheme: Flags.string({
+      description: "URL scheme",
+      default: "https",
+    }),
+    "content-length": Flags.integer({
+      description: "Size of the encrypted payload in bytes",
+      required: true,
+    }),
+    filename: Flags.string({
+      description: "Original filename",
+    }),
+    optimistic: Flags.boolean({
+      description:
+        "Send optimistically (queued locally and published via 'conversation publish-messages')",
+      default: false,
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse(ConversationSendRemoteAttachment);
+    const config = this.getConfig();
+    const client = await createClient(config);
+
+    const conversation = await client.conversations.getConversationById(
+      args.id,
+    );
+
+    if (!conversation) {
+      this.error(`Conversation not found: ${args.id}`);
+    }
+
+    const remoteAttachment = {
+      url: args.url,
+      contentDigest: flags["content-digest"],
+      secret: new Uint8Array(Buffer.from(flags.secret, "base64")),
+      salt: new Uint8Array(Buffer.from(flags.salt, "base64")),
+      nonce: new Uint8Array(Buffer.from(flags.nonce, "base64")),
+      scheme: flags.scheme,
+      contentLength: flags["content-length"],
+      filename: flags.filename,
+    };
+
+    const messageId = await conversation.sendRemoteAttachment(
+      remoteAttachment,
+      flags.optimistic,
+    );
+
+    this.output({
+      success: true,
+      messageId,
+      conversationId: args.id,
+      url: args.url,
+      filename: flags.filename,
+      optimistic: flags.optimistic,
+    });
+  }
+}

--- a/packages/xmtp-cli/src/utils/config.ts
+++ b/packages/xmtp-cli/src/utils/config.ts
@@ -27,6 +27,9 @@ export type XmtpConfig = {
   structuredLogging?: boolean;
   disableDeviceSync?: boolean;
   appVersion?: string;
+  uploadProvider?: string;
+  uploadProviderToken?: string;
+  uploadProviderGateway?: string;
 };
 
 function parseEnv(value: string | undefined): XmtpConfig["env"] {
@@ -74,6 +77,9 @@ export function loadConfig(envFile?: string): XmtpConfig {
     disableDeviceSync:
       env.XMTP_DISABLE_DEVICE_SYNC === "true" ? true : undefined,
     appVersion: env.XMTP_APP_VERSION,
+    uploadProvider: env.XMTP_UPLOAD_PROVIDER,
+    uploadProviderToken: env.XMTP_UPLOAD_PROVIDER_TOKEN,
+    uploadProviderGateway: env.XMTP_UPLOAD_PROVIDER_GATEWAY,
   };
 }
 
@@ -91,5 +97,10 @@ export function mergeConfig(
     structuredLogging: flags.structuredLogging ?? fileConfig.structuredLogging,
     disableDeviceSync: flags.disableDeviceSync ?? fileConfig.disableDeviceSync,
     appVersion: flags.appVersion ?? fileConfig.appVersion,
+    uploadProvider: flags.uploadProvider ?? fileConfig.uploadProvider,
+    uploadProviderToken:
+      flags.uploadProviderToken ?? fileConfig.uploadProviderToken,
+    uploadProviderGateway:
+      flags.uploadProviderGateway ?? fileConfig.uploadProviderGateway,
   };
 }

--- a/packages/xmtp-cli/src/utils/mime.ts
+++ b/packages/xmtp-cli/src/utils/mime.ts
@@ -1,0 +1,47 @@
+import { extname } from "node:path";
+
+const MIME_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".heic": "image/heic",
+  ".heif": "image/heif",
+  ".avif": "image/avif",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".avi": "video/x-msvideo",
+  ".webm": "video/webm",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".pdf": "application/pdf",
+  ".txt": "text/plain",
+  ".json": "application/json",
+  ".xml": "application/xml",
+  ".zip": "application/zip",
+  ".gz": "application/gzip",
+};
+
+const EXT_BY_MIME: Record<string, string> = {};
+for (const [ext, mime] of Object.entries(MIME_TYPES)) {
+  // First extension wins (e.g., .jpg for image/jpeg, not .jpeg)
+  if (!EXT_BY_MIME[mime]) {
+    EXT_BY_MIME[mime] = ext;
+  }
+}
+
+export function getMimeType(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+export function getExtension(mimeType: string): string {
+  return EXT_BY_MIME[mimeType] ?? ".bin";
+}

--- a/packages/xmtp-cli/src/utils/upload.ts
+++ b/packages/xmtp-cli/src/utils/upload.ts
@@ -1,0 +1,91 @@
+import type { XmtpConfig } from "./config.js";
+
+export interface UploadProvider {
+  name: string;
+  upload(data: Uint8Array, filename: string, mimeType: string): Promise<string>;
+}
+
+interface PinataResponse {
+  IpfsHash: string;
+  PinSize: number;
+  Timestamp: string;
+}
+
+class PinataProvider implements UploadProvider {
+  name = "pinata";
+  #jwt: string;
+  #gateway: string;
+
+  constructor(jwt: string, gateway?: string) {
+    this.#jwt = jwt;
+    this.#gateway =
+      gateway?.replace(/\/$/, "") ?? "https://gateway.pinata.cloud";
+  }
+
+  async upload(
+    data: Uint8Array,
+    filename: string,
+    _mimeType: string,
+  ): Promise<string> {
+    const formData = new FormData();
+    formData.append("file", new Blob([data]), filename);
+
+    const response = await fetch(
+      "https://api.pinata.cloud/pinning/pinFileToIPFS",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.#jwt}`,
+        },
+        body: formData,
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Pinata upload failed (${response.status}): ${text}`);
+    }
+
+    const result = (await response.json()) as PinataResponse;
+    return `${this.#gateway}/ipfs/${result.IpfsHash}`;
+  }
+}
+
+const PROVIDER_FACTORIES = {
+  pinata: (config: XmtpConfig) => {
+    if (!config.uploadProviderToken) {
+      throw new Error(
+        "Pinata requires a JWT token. Set XMTP_UPLOAD_PROVIDER_TOKEN or use --upload-provider-token.",
+      );
+    }
+    return new PinataProvider(
+      config.uploadProviderToken,
+      config.uploadProviderGateway,
+    );
+  },
+} satisfies Record<string, (config: XmtpConfig) => UploadProvider>;
+
+type ProviderName = keyof typeof PROVIDER_FACTORIES;
+
+function isProviderName(name: string): name is ProviderName {
+  return Object.hasOwn(PROVIDER_FACTORIES, name);
+}
+
+export function getUploadProvider(config: XmtpConfig): UploadProvider | null {
+  if (!config.uploadProvider) {
+    return null;
+  }
+
+  if (!isProviderName(config.uploadProvider)) {
+    const available = Object.keys(PROVIDER_FACTORIES).join(", ");
+    throw new Error(
+      `Unknown upload provider: ${config.uploadProvider}. Available: ${available}`,
+    );
+  }
+
+  return PROVIDER_FACTORIES[config.uploadProvider](config);
+}
+
+/** Max size for inline attachments (bytes). Files larger than this
+ *  are automatically sent as remote attachments when a provider is configured. */
+export const INLINE_ATTACHMENT_MAX_BYTES = 1_000_000;


### PR DESCRIPTION
## Summary

Add file attachment support to the XMTP CLI with two new commands and a pluggable upload provider system.

### New Commands

**`conversation send-attachment`** — Read a file from disk and send it to a conversation.
- Small files (≤1MB) are sent inline as `Attachment` messages
- Large files are automatically encrypted and uploaded via the configured upload provider, then sent as `RemoteAttachment` messages
- `--encrypt` flag for manual workflows: encrypts the file and outputs decryption keys without sending
- `--remote` flag to force remote upload even for small files
- Auto-detects MIME type from file extension (26 types), with `--mime-type` override

**`conversation send-remote-attachment`** — Send a reference to a pre-uploaded encrypted file with the required decryption keys (content-digest, secret, salt, nonce, content-length).

### Upload Provider System

Pluggable provider interface for uploading encrypted attachments. Providers are configured via env vars or per-command flags:

```bash
XMTP_UPLOAD_PROVIDER=pinata
XMTP_UPLOAD_PROVIDER_TOKEN=<jwt>
XMTP_UPLOAD_PROVIDER_GATEWAY=https://your-gateway.mypinata.cloud  # optional
```

Or per-command:
```bash
xmtp conversation send-attachment <id> ./photo.jpg \
  --upload-provider pinata --upload-provider-token <jwt>
```

**Built-in provider: Pinata (IPFS)** — Uploads encrypted payload to IPFS via Pinata's pinning API, returns a public gateway URL.

Adding new providers (S3, Cloudflare R2, etc.) requires adding a single factory function to `PROVIDER_FACTORIES` in `upload.ts`.

### Files Changed

| File | Description |
|------|-------------|
| `src/commands/conversation/send-attachment.ts` | New command: smart send with inline/remote auto-detection |
| `src/commands/conversation/send-remote-attachment.ts` | New command: send pre-uploaded encrypted file by URL |
| `src/utils/upload.ts` | Upload provider interface + Pinata implementation |
| `src/utils/config.ts` | 3 new config fields for upload provider settings |
| `README.md` | Attachments section + config table updates |
| `SKILL.md` | Send Attachments section + env var table updates |

### Testing

- `--encrypt` mode tested end-to-end (file encryption + key output)
- Pinata upload tested end-to-end (12KB and 2.9MB files, both successful)
- Uploaded files verified accessible via IPFS gateway
- Zero type errors, zero lint errors, prettier-formatted