### PR TITLE
Fix D14N routing: use apiUrl instead of SDK-level host override

### DIFF
--- a/apps/xmtp.chat/src/contexts/XMTPContext.tsx
+++ b/apps/xmtp.chat/src/contexts/XMTPContext.tsx
@@ -18,6 +18,7 @@ import { useActions } from "@/stores/inbox/hooks";
 export type ContentTypes = BuiltInContentTypes;
 
 export type InitializeClientOptions = {
+  apiUrl?: string;
   dbEncryptionKey?: Uint8Array;
   env?: ClientOptions["env"];
   loggingLevel?: ClientOptions["loggingLevel"];
@@ -86,6 +87,7 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
    */
   const initialize = useCallback(
     async ({
+      apiUrl,
       dbEncryptionKey,
       env,
       loggingLevel,
@@ -114,6 +116,7 @@ export const XMTPProvider: React.FC<XMTPProviderProps> = ({
         try {
           // create a new XMTP client
           xmtpClient = await Client.create(signer, {
+            apiUrl,
             env,
             loggingLevel,
             dbEncryptionKey,

--- a/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
+++ b/apps/xmtp.chat/src/hooks/useConnectXmtp.ts
@@ -37,6 +37,7 @@ export const useConnectXmtp = () => {
     // connect ephemeral account if enabled
     if (ephemeralAccountEnabled) {
       initialize({
+        apiUrl: gatewayHost,
         dbEncryptionKey: encryptionKey
           ? hexToUint8Array(encryptionKey)
           : undefined,
@@ -62,6 +63,7 @@ export const useConnectXmtp = () => {
     }
 
     initialize({
+      apiUrl: gatewayHost,
       dbEncryptionKey: encryptionKey
         ? hexToUint8Array(encryptionKey)
         : undefined,

--- a/apps/xmtp.chat/vite.config.ts
+++ b/apps/xmtp.chat/vite.config.ts
@@ -10,6 +10,9 @@ const viteConfig = defineConfig({
   optimizeDeps: {
     exclude: ["@xmtp/wasm-bindings"],
   },
+  server: {
+    allowedHosts: true,
+  },
   build: {
     sourcemap: true,
   },

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -13,9 +13,8 @@ export const createClient = async (
   options?: Omit<ClientOptions, "codecs">,
 ) => {
   const env = options?.env || "dev";
+  const host = options?.apiUrl || ApiUrls[env];
   const gatewayHost = options?.gatewayHost || undefined;
-  // When gatewayHost is set, use it as the primary host (for D14N)
-  const host = gatewayHost || options?.apiUrl || ApiUrls[env];
   const isSecure = host.startsWith("https");
   const inboxId =
     (await getInboxIdForIdentifier(host, gatewayHost, isSecure, identifier)) ||


### PR DESCRIPTION
Pass gatewayHost as apiUrl at the app layer so the WASM client uses the correct primary endpoint for D14N environments. Reverts the SDK-level createClient.ts change that injected gatewayHost into the host calculation, keeping the SDK completely unmodified.

- V3 (Dev/Production): apiUrl is undefined, host resolves to ApiUrls[env]
- D14N (Staging/Testnet): apiUrl is the gateway URL, host resolves to gateway

Also adds allowedHosts to vite dev server config for external access.