### PR TITLE
Demo slow Agent responses

### DIFF
--- a/sdks/agent-sdk/src/demo/main.ts
+++ b/sdks/agent-sdk/src/demo/main.ts
@@ -21,8 +21,14 @@ const agent = process.env.XMTP_WALLET_KEY
 
 const performanceMonitor = new PerformanceMonitor({
   healthReportInterval: 10_000,
+  criticalThresholdInterval: 5_000,
   onResponse: (duration) => {
     console.log(`[PerformanceMonitor] Message loop completed in ${duration}ms`);
+  },
+  onCriticalResponse: (duration) => {
+    console.warn(
+      `[PerformanceMonitor] Slow response detected: ${duration.toFixed(0)}ms (threshold: 5000ms)`,
+    );
   },
 });
 const commandRouter = new CommandRouter({ helpCommand: "/help" });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Flag slow Agent demo responses by constructing `PerformanceMonitor` with `criticalThresholdInterval` set to 5000 ms and wiring `onCriticalResponse` in [main.ts](https://github.com/xmtp/xmtp-js/pull/1722/files#diff-c3b864722198c2614ca564927af501b60a3e40ff0817b9b64e5fefd1967f9ed1)
Set `criticalThresholdInterval: 5000` on `PerformanceMonitor` and add an `onCriticalResponse` callback that emits `console.warn` with the rounded duration and 5000 ms threshold in [main.ts](https://github.com/xmtp/xmtp-js/pull/1722/files#diff-c3b864722198c2614ca564927af501b60a3e40ff0817b9b64e5fefd1967f9ed1).

#### 📍Where to Start
Start in the demo entrypoint where `PerformanceMonitor` is instantiated in [main.ts](https://github.com/xmtp/xmtp-js/pull/1722/files#diff-c3b864722198c2614ca564927af501b60a3e40ff0817b9b64e5fefd1967f9ed1).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdba7eb.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->