### PR TITLE
Support multiple command strings

### DIFF
--- a/sdks/agent-sdk/src/demo/main.ts
+++ b/sdks/agent-sdk/src/demo/main.ts
@@ -33,9 +33,13 @@ const performanceMonitor = new PerformanceMonitor({
 });
 const commandRouter = new CommandRouter({ helpCommand: "/help" });
 
-commandRouter.command("/version", "Show Agent SDK version", async (ctx) => {
-  await ctx.conversation.sendText(`v${process.env.npm_package_version}`);
-});
+commandRouter.command(
+  ["/v", "/version"],
+  "Show Agent SDK version",
+  async (ctx) => {
+    await ctx.conversation.sendText(`v${process.env.npm_package_version}`);
+  },
+);
 
 commandRouter.command("/test-actions", async (ctx) => {
   await ctx.conversation.sendActions({

--- a/sdks/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/agent-sdk/src/middleware/CommandRouter.ts
@@ -50,19 +50,26 @@ export class CommandRouter<ContentTypes = unknown> {
     return Array.from(this.#commandMap.keys());
   }
 
-  command(command: string, handler: AgentMessageHandler<SupportedType>): this;
   command(
-    command: string,
+    command: string | string[],
+    handler: AgentMessageHandler<SupportedType>,
+  ): this;
+  command(
+    command: string | string[],
     description: string,
     handler: AgentMessageHandler<SupportedType>,
   ): this;
   command(
-    command: string,
+    command: string | string[],
     handlerOrDescription: AgentMessageHandler<SupportedType> | string,
     handler?: AgentMessageHandler<SupportedType>,
   ): this {
-    if (!command.startsWith("/")) {
-      throw new Error('Command must start with "/"');
+    const commands = Array.isArray(command) ? command : [command];
+
+    for (const cmd of commands) {
+      if (!cmd.startsWith("/")) {
+        throw new Error('Command must start with "/"');
+      }
     }
 
     let resolvedHandler: AgentMessageHandler<SupportedType>;
@@ -80,10 +87,15 @@ export class CommandRouter<ContentTypes = unknown> {
       resolvedHandler = handler;
     }
 
-    this.#commandMap.set(command.toLowerCase(), {
+    const entry: CommandEntry = {
       handler: resolvedHandler,
       description,
-    });
+    };
+
+    for (const cmd of commands) {
+      this.#commandMap.set(cmd.toLowerCase(), entry);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Support multiple command strings by updating `CommandRouter.command` in [ LOLE ] module
Update `CommandRouter.command` to accept an array of command aliases, validate each alias starts with `/`, register a single handler under all lowercased aliases, and surface all aliases in `commandList`. Add tests for alias registration, listing, descriptions, and validation. Update the demo to register `/v` and `/version` for the version reply.

#### 📍Where to Start
Start with the `command` method in [CommandRouter.ts](https://github.com/xmtp/xmtp-js/pull/1723/files#diff-ac9129c00bbc8485b30821a60ec909785fdec42df3bcf2f7a9a3ec7978935f4c), then review the new tests in [CommandRouter.test.ts](https://github.com/xmtp/xmtp-js/pull/1723/files#diff-e42fb61317746bc69fb817c9e73a9e0de72ffdf63f4a3e6792a748555e4a99a5), and finally the demo change in [main.ts](https://github.com/xmtp/xmtp-js/pull/1723/files#diff-c3b864722198c2614ca564927af501b60a3e40ff0817b9b64e5fefd1967f9ed1).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fa3a6d.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->