### PR TITLE
Add processStreamedMessage to Conversation

### DIFF
--- a/sdks/browser-sdk/CHANGELOG.md
+++ b/sdks/browser-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/browser-sdk
 
+## 6.5.0
+
+### Minor Changes
+
+- Added `processStreamedMessage` method to `Conversation` for decoding, decrypting, and persisting raw envelope bytes from a group message stream
+
 ## 6.4.1
 
 ### Patch Changes

--- a/sdks/browser-sdk/src/Conversation.ts
+++ b/sdks/browser-sdk/src/Conversation.ts
@@ -141,6 +141,19 @@ export class Conversation<ContentTypes = unknown> {
   }
 
   /**
+   * Decodes, decrypts, and persists a raw envelope from a group message stream.
+   *
+   * @param envelopeBytes - Raw protobuf-encoded envelope bytes from the stream
+   * @returns The processed and stored messages
+   */
+  async processStreamedMessage(envelopeBytes: Uint8Array) {
+    return this.#worker.action("conversation.processStreamedMessage", {
+      id: this.#id,
+      envelopeBytes,
+    });
+  }
+
+  /**
    * Sends a message
    *
    * @param content - The encoded content to send

--- a/sdks/browser-sdk/src/WorkerConversation.ts
+++ b/sdks/browser-sdk/src/WorkerConversation.ts
@@ -188,6 +188,10 @@ export class WorkerConversation {
     return this.#group.publishMessages();
   }
 
+  async processStreamedMessage(envelopeBytes: Uint8Array) {
+    return this.#group.processStreamedGroupMessage(envelopeBytes);
+  }
+
   async send(encodedContent: EncodedContent, opts?: SendMessageOpts) {
     return this.#group.send(encodedContent, opts ?? { shouldPush: true });
   }

--- a/sdks/browser-sdk/src/types/actions/conversation.ts
+++ b/sdks/browser-sdk/src/types/actions/conversation.ts
@@ -8,6 +8,7 @@ import type {
   GroupMember,
   Intent,
   ListMessagesOptions,
+  Message,
   MessageDisappearingSettings,
   MultiRemoteAttachment,
   Reaction,
@@ -48,6 +49,15 @@ export type ConversationAction =
       result: undefined;
       data: {
         id: string;
+      };
+    }
+  | {
+      action: "conversation.processStreamedMessage";
+      id: string;
+      result: Message[];
+      data: {
+        id: string;
+        envelopeBytes: Uint8Array;
       };
     }
   | {

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -778,6 +778,12 @@ self.onmessage = async (
         postMessage({ id, action, result: undefined });
         break;
       }
+      case "conversation.processStreamedMessage": {
+        const group = getGroup(data.id);
+        const result = await group.processStreamedMessage(data.envelopeBytes);
+        postMessage({ id, action, result });
+        break;
+      }
       case "conversation.messages": {
         const group = getGroup(data.id);
         const messages = await group.messages(data.options);

--- a/sdks/node-sdk/CHANGELOG.md
+++ b/sdks/node-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @xmtp/node-sdk
 
+## 5.5.0
+
+### Minor Changes
+
+- Added `processStreamedMessage` method to `Conversation` for decoding, decrypting, and persisting raw envelope bytes from a group message stream
+
 ## 5.4.0
 
 ### Minor Changes

--- a/sdks/node-sdk/src/Conversation.ts
+++ b/sdks/node-sdk/src/Conversation.ts
@@ -167,6 +167,16 @@ export class Conversation<ContentTypes = unknown> {
   }
 
   /**
+   * Decodes, decrypts, and persists a raw envelope from a group message stream.
+   *
+   * @param envelopeBytes - Raw protobuf-encoded envelope bytes from the stream
+   * @returns The processed and stored messages
+   */
+  async processStreamedMessage(envelopeBytes: Uint8Array) {
+    return this.#conversation.processStreamedGroupMessage(envelopeBytes);
+  }
+
+  /**
    * Publishes pending messages that were sent optimistically
    *
    * @returns Promise that resolves when publishing is complete


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `processStreamedMessage` to `Conversation` in browser and Node SDKs
Adds a `processStreamedMessage(envelopeBytes: Uint8Array)` method to `Conversation` in both the browser and Node SDKs. The method decodes, decrypts, and persists raw envelope bytes from a group message stream, returning the resulting `Message[]`.

- In the browser SDK, the method forwards envelope bytes to the worker via a new `conversation.processStreamedMessage` action handled in [client.ts](https://github.com/xmtp/xmtp-js/pull/1735/files#diff-b926d6c9b5b94a9c838a230dd9fdf6f0d3c15b73e1120bedb91fbde594f1efc3).
- In the Node SDK, the method delegates directly to the underlying `processStreamedGroupMessage` call in [Conversation.ts](https://github.com/xmtp/xmtp-js/pull/1735/files#diff-88be862a6501dd06623529cecebf1fb68b69ecb13dd49a6cb709ca7c5532c117).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b80adcf.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->