### PR TITLE
render read receipts as inline status messages

### DIFF
--- a/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/Conversation.tsx
@@ -39,6 +39,7 @@ export const Conversation: React.FC<ConversationProps> = ({
   useEffect(() => {
     const loadMessages = async () => {
       await sync(true);
+      await conversation.sendReadReceipt();
     };
     void loadMessages();
   }, [conversationId]);

--- a/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
+++ b/apps/xmtp.chat/src/components/Messages/MessageContentWithWrapper.tsx
@@ -6,6 +6,7 @@ import {
   MessageContentWrapper,
   type MessageContentAlign,
 } from "@/components/Messages/MessageContentWrapper";
+import { ReadReceiptContent } from "@/components/Messages/ReadReceiptContent";
 
 export type MessageContentWithWrapperProps = {
   align: MessageContentAlign;
@@ -30,6 +31,15 @@ export const MessageContentWithWrapper: React.FC<
     return (
       <IntentContent
         content={message.content as Intent}
+        sentAtNs={message.sentAtNs}
+        senderInboxId={senderInboxId}
+      />
+    );
+  }
+
+  if (message.contentType.typeId === "readReceipt") {
+    return (
+      <ReadReceiptContent
         sentAtNs={message.sentAtNs}
         senderInboxId={senderInboxId}
       />

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,0 +1,35 @@
+import { Group, Text } from "@mantine/core";
+import { DateLabel } from "@/components/DateLabel";
+import { IdentityBadge } from "@/components/IdentityBadge";
+import { useConversationContext } from "@/contexts/ConversationContext";
+import { nsToDate } from "@/helpers/date";
+import { MEMBER_NO_LONGER_IN_GROUP } from "@/helpers/strings";
+import { getMemberAddress } from "@/helpers/xmtp";
+import { useConversation } from "@/hooks/useConversation";
+
+export type ReadReceiptContentProps = {
+  sentAtNs: bigint;
+  senderInboxId: string;
+};
+
+export const ReadReceiptContent: React.FC<ReadReceiptContentProps> = ({
+  senderInboxId,
+  sentAtNs,
+}) => {
+  const { conversationId } = useConversationContext();
+  const { members } = useConversation(conversationId);
+  const senderMember = members.get(senderInboxId);
+  return (
+    <>
+      <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+      <Group gap="4" wrap="wrap" justify="center">
+        <IdentityBadge
+          address={senderMember ? getMemberAddress(senderMember) : ""}
+          displayName={senderInboxId}
+          tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
+        />
+        <Text size="sm">sent a read receipt</Text>
+      </Group>
+    </>
+  );
+};

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,8 +1,6 @@
 import { Text } from "@mantine/core";
 import { DateLabel } from "@/components/DateLabel";
-import { useConversationContext } from "@/contexts/ConversationContext";
 import { nsToDate } from "@/helpers/date";
-import { useConversation } from "@/hooks/useConversation";
 
 export type ReadReceiptContentProps = {
   sentAtNs: bigint;
@@ -12,12 +10,12 @@ export type ReadReceiptContentProps = {
 export const ReadReceiptContent: React.FC<ReadReceiptContentProps> = ({
   sentAtNs,
 }) => {
-  const { conversationId } = useConversationContext();
-  const { members } = useConversation(conversationId);
   return (
     <>
       <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
-      <Text size="sm">received read receipt</Text>
+      <Text size="sm" ta="center">
+        received read receipt
+      </Text>
     </>
   );
 };

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,10 +1,7 @@
-import { Group, Text } from "@mantine/core";
+import { Text } from "@mantine/core";
 import { DateLabel } from "@/components/DateLabel";
-import { IdentityBadge } from "@/components/IdentityBadge";
 import { useConversationContext } from "@/contexts/ConversationContext";
 import { nsToDate } from "@/helpers/date";
-import { MEMBER_NO_LONGER_IN_GROUP } from "@/helpers/strings";
-import { getMemberAddress } from "@/helpers/xmtp";
 import { useConversation } from "@/hooks/useConversation";
 
 export type ReadReceiptContentProps = {
@@ -13,23 +10,14 @@ export type ReadReceiptContentProps = {
 };
 
 export const ReadReceiptContent: React.FC<ReadReceiptContentProps> = ({
-  senderInboxId,
   sentAtNs,
 }) => {
   const { conversationId } = useConversationContext();
   const { members } = useConversation(conversationId);
-  const senderMember = members.get(senderInboxId);
   return (
     <>
       <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
-      <Group gap="4" wrap="wrap" justify="center">
-        <IdentityBadge
-          address={senderMember ? getMemberAddress(senderMember) : ""}
-          displayName={senderInboxId}
-          tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
-        />
-        <Text size="sm">sent a read receipt</Text>
-      </Group>
+      <Text size="sm">received read receipt</Text>
     </>
   );
 };

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,4 +1,5 @@
-import { Group, Text } from "@mantine/core";
+import { Popover, Stack, Text, UnstyledButton } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import { DateLabel } from "@/components/DateLabel";
 import { IdentityBadge } from "@/components/IdentityBadge";
 import { useConversationContext } from "@/contexts/ConversationContext";
@@ -16,20 +17,29 @@ export const ReadReceiptContent: React.FC<ReadReceiptContentProps> = ({
   senderInboxId,
   sentAtNs,
 }) => {
+  const [opened, { toggle }] = useDisclosure(false);
   const { conversationId } = useConversationContext();
   const { members } = useConversation(conversationId);
   const senderMember = members.get(senderInboxId);
   return (
-    <>
-      <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
-      <Group gap="4" wrap="wrap" justify="center">
-        <IdentityBadge
-          address={senderMember ? getMemberAddress(senderMember) : ""}
-          displayName={senderInboxId}
-          tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
-        />
-        <Text size="sm">sent a read receipt</Text>
-      </Group>
-    </>
+    <Popover opened={opened} position="bottom" withArrow>
+      <Popover.Target>
+        <UnstyledButton onClick={toggle}>
+          <Text size="sm" c="dimmed" ta="center">
+            received read receipt
+          </Text>
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <Stack gap="xs" align="center">
+          <IdentityBadge
+            address={senderMember ? getMemberAddress(senderMember) : ""}
+            displayName={senderInboxId}
+            tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
+          />
+          <DateLabel date={nsToDate(sentAtNs)} align="center" />
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
   );
 };

--- a/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/ReadReceiptContent.tsx
@@ -1,5 +1,4 @@
-import { Popover, Stack, Text, UnstyledButton } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
+import { Group, Text } from "@mantine/core";
 import { DateLabel } from "@/components/DateLabel";
 import { IdentityBadge } from "@/components/IdentityBadge";
 import { useConversationContext } from "@/contexts/ConversationContext";
@@ -17,29 +16,20 @@ export const ReadReceiptContent: React.FC<ReadReceiptContentProps> = ({
   senderInboxId,
   sentAtNs,
 }) => {
-  const [opened, { toggle }] = useDisclosure(false);
   const { conversationId } = useConversationContext();
   const { members } = useConversation(conversationId);
   const senderMember = members.get(senderInboxId);
   return (
-    <Popover opened={opened} position="bottom" withArrow>
-      <Popover.Target>
-        <UnstyledButton onClick={toggle}>
-          <Text size="sm" c="dimmed" ta="center">
-            received read receipt
-          </Text>
-        </UnstyledButton>
-      </Popover.Target>
-      <Popover.Dropdown>
-        <Stack gap="xs" align="center">
-          <IdentityBadge
-            address={senderMember ? getMemberAddress(senderMember) : ""}
-            displayName={senderInboxId}
-            tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
-          />
-          <DateLabel date={nsToDate(sentAtNs)} align="center" />
-        </Stack>
-      </Popover.Dropdown>
-    </Popover>
+    <>
+      <DateLabel date={nsToDate(sentAtNs)} align="center" padding="sm" />
+      <Group gap="4" wrap="wrap" justify="center">
+        <IdentityBadge
+          address={senderMember ? getMemberAddress(senderMember) : ""}
+          displayName={senderInboxId}
+          tooltip={senderMember ? undefined : MEMBER_NO_LONGER_IN_GROUP}
+        />
+        <Text size="sm">sent a read receipt</Text>
+      </Group>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
- Display read receipts as visible centered status messages in the conversation list (following the `IntentContent`/`GroupUpdatedContent` pattern), showing sender identity and timestamp
- Send a read receipt when opening a conversation
- Designed for xmtp.chat as a debugging tool — read receipts are shown as events rather than decorating messages with checkmarks

## Test plan
- [ ] Open a conversation and verify a read receipt is sent
- [ ] Receive a read receipt from another participant and verify it appears as an inline status message with sender identity and timestamp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render read receipts as inline status messages in xmtp.chat conversations
> - Adds a new [`ReadReceiptContent`](https://github.com/xmtp/xmtp-js/pull/1740/files#diff-542c6e7f5aad5f32e95fce918c9b63306d8157ad50ec8f1d8198ced3f6645a97) component that displays a date label and a centered "received read receipt" indicator for read receipt messages.
> - [`MessageContentWithWrapper`](https://github.com/xmtp/xmtp-js/pull/1740/files#diff-a53ff22661ac52ca32c409869af09dad7b31d4083caaafcc78f488ee250ed9b2) now routes messages with `contentType.typeId === "readReceipt"` to this new component instead of the default renderer.
> - [`Conversation`](https://github.com/xmtp/xmtp-js/pull/1740/files#diff-9ef483f6f17229928a31eed31f06e3a44070937510afc9796f8d57b65cceac1b) calls `conversation.sendReadReceipt()` after the initial sync completes when a conversation is opened.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62c0042.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->