### PR TITLE
Fix single line break rendering in xmtp.chat markdown

### DIFF
--- a/apps/xmtp.chat/package.json
+++ b/apps/xmtp.chat/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.2.3",
     "react-markdown": "^10.1.0",
     "react-router": "^7.12.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "uint8array-extras": "^1.5.0",
     "viem": "^2.44.4",

--- a/apps/xmtp.chat/src/components/Markdown.tsx
+++ b/apps/xmtp.chat/src/components/Markdown.tsx
@@ -8,6 +8,7 @@ import {
   Title,
 } from "@mantine/core";
 import ReactMarkdown, { type Components } from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
 export type MarkdownProps = {
@@ -52,7 +53,7 @@ export const Markdown: React.FC<MarkdownProps> = ({ markdown }) => {
       disallowedElements={["input", "img", "hr"]}
       components={components}
       skipHtml
-      remarkPlugins={[remarkGfm]}>
+      remarkPlugins={[remarkBreaks, remarkGfm]}>
       {markdown}
     </ReactMarkdown>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6777,6 +6777,7 @@ __metadata:
     react-dom: "npm:^19.2.3"
     react-markdown: "npm:^10.1.0"
     react-router: "npm:^7.12.0"
+    remark-breaks: "npm:^4.0.0"
     remark-gfm: "npm:^4.0.1"
     typescript: "npm:^5.9.3"
     uint8array-extras: "npm:^1.5.0"
@@ -10906,6 +10907,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-newline-to-break@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-newline-to-break@npm:2.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-find-and-replace: "npm:^3.0.0"
+  checksum: 10/2300312c02501458854129e776cbbf6daafa6b7675a54a634f9a3c76055b0466081ad9eebde6bc655030e868fd7c183352acd856bcd265b3ea96f214c4f7fd7b
+  languageName: node
+  linkType: hard
+
 "mdast-util-phrasing@npm:^4.0.0":
   version: 4.1.0
   resolution: "mdast-util-phrasing@npm:4.1.0"
@@ -13138,6 +13149,17 @@ __metadata:
   dependencies:
     "@pnpm/npm-conf": "npm:^3.0.2"
   checksum: 10/36cf27fca6419e4d92c27419c5a333aea1d9dec62f7fb812fa8d8d95dcfa4124e57f22bb944512f5f97ae0e0cda90c28b3a5f0e7ace0b5620d84a8b6b2cab862
+  languageName: node
+  linkType: hard
+
+"remark-breaks@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "remark-breaks@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-newline-to-break: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10/6841b88ea4995ec9d469bb10f8272ce264466ffd706a85a931fd6d451dc81440916bd62118d62f10b7c61704b740e7eda4c0c8bee62dc27e8a02ee2766af1bf2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Single newlines (`\n`) in markdown messages were not rendering as line breaks — only double newlines (`\n\n`) produced visible breaks
- Added the `remark-breaks` plugin to convert single newlines into `<br>` elements
- This matches the behavior users expect from chat applications (e.g. WhatsApp, Telegram, Slack)

## Changes
- `apps/xmtp.chat/src/components/Markdown.tsx` — import and add `remark-breaks` to `remarkPlugins`
- `apps/xmtp.chat/package.json` — add `remark-breaks` dependency

## Test plan
- [x] Send a message with single line breaks and verify they render visually
- [x] Verify double line breaks still work as paragraph separators
- [x] Verify other markdown features (bold, links, lists, code blocks) still render correctly

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix single line break rendering in xmtp.chat Markdown component
> Adds the `remark-breaks` plugin to the `ReactMarkdown` component in [Markdown.tsx](https://github.com/xmtp/xmtp-js/pull/1744/files#diff-b49d27f87c4ee73339475a7a917da478b7a3e52e0e8b82f96b0c379a9ace4d6d), inserting it before `remarkGfm`. This causes single newlines in message content to render as hard line breaks instead of being collapsed into spaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de3ede8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->