### PR TITLE
Build Agent SDK on macOS

### DIFF
--- a/.github/workflows/agent-sdk.yml
+++ b/.github/workflows/agent-sdk.yml
@@ -58,8 +58,16 @@ jobs:
         run: yarn turbo run test --filter='./sdks/agent-sdk'
 
   build:
-    name: Build
-    runs-on: warp-ubuntu-latest-x64-8x
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu
+            runner: warp-ubuntu-latest-x64-8x
+          - os: macos
+            runner: macos-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Build Agent SDK on macOS in CI
Extends the [agent-sdk.yml](https://github.com/xmtp/xmtp-js/pull/1763/files#diff-e1247640270477280bedc19abfbde01b856911dc3a0d79cea5867bab56bf6a60) build job to run on both Ubuntu and macOS using a matrix strategy. The job name now reflects the OS for each matrix entry, and `fail-fast: true` is set so a failure on either platform stops the other.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ac1c5c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->