### PR TITLE
Add prerelease details to GitHub job summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,10 @@ jobs:
       - name: Log prerelease details
         run: |
           echo "### Prerelease Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **SDK**: ${{ inputs.prerelease_sdk }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: ${{ inputs.prerelease_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Prerelease Tag**: ${{ inputs.prerelease_tag }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Dependency**: ${{ fromJSON(env.SDK_DEPS)[inputs.prerelease_sdk] }}@${{ inputs.prerelease_dependency_version || 'unchanged' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Target SDK**: ${{ inputs.prerelease_sdk }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Based on**: ${{ fromJSON(env.SDK_DEPS)[inputs.prerelease_sdk] }}@${{ inputs.prerelease_dependency_version || 'unchanged' }}" >> $GITHUB_STEP_SUMMARY          
+          echo "- **Target Version**: ${{ inputs.prerelease_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version Tag**: ${{ inputs.prerelease_tag }}" >> $GITHUB_STEP_SUMMARY
       - name: Update dependency version
         if: ${{ github.event.inputs.prerelease_dependency_version != '' }}
         working-directory: ./sdks/${{ inputs.prerelease_sdk }}


### PR DESCRIPTION
## Summary
- Log prerelease inputs (SDK, version, tag, dependency) to the job summary early in the workflow so they're visible even if later steps fail
- Log the resolved dependency version (via `yarn why`) after install so the actual installed version is recorded

## Test plan
- [ ] Trigger a prerelease workflow dispatch and verify the summary card appears on the run page
- [ ] Trigger a prerelease with an intentional failure (e.g., bad dependency version) and confirm the summary is still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prerelease details to GitHub job summary in release workflow
> Two new steps are added to the `release` job in [release.yml](.github/workflows/release.yml) that write structured output to `$GITHUB_STEP_SUMMARY`.
>
> - The first step logs a 'Prerelease Summary' section with the target SDK, dependency name, optional version override, target version, and version tag.
> - The second step runs `yarn why` for the resolved dependency and appends the output (wrapped in code fences) under a 'Resolved Dependency' section, with color output disabled via `YARN_ENABLE_COLORS=false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25600f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->