### PR TITLE
Add RateLimiter middleware to Agent SDK

### DIFF
--- a/.changeset/add-ratelimiter-middleware.md
+++ b/.changeset/add-ratelimiter-middleware.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": minor
+---
+
+Add RateLimiter middleware for per-sender message throttling

--- a/sdks/agent-sdk/src/middleware/RateLimiter.test.ts
+++ b/sdks/agent-sdk/src/middleware/RateLimiter.test.ts
@@ -90,25 +90,22 @@ describe("RateLimiter", () => {
       expect(next).toHaveBeenCalledTimes(2);
     });
 
-    it("uses a sliding window, not a fixed window", async () => {
+    it("resets count when window expires", async () => {
       const limiter = new RateLimiter({ maxMessages: 2, windowMs: 10_000 });
       const mw = limiter.middleware();
       const next = vi.fn();
 
-      // t=0: first message
+      // t=0: first and second message
       await mw(mockContext("sender-a") as never, next);
-
-      // t=6s: second message
-      vi.advanceTimersByTime(6_000);
       await mw(mockContext("sender-a") as never, next);
       expect(next).toHaveBeenCalledTimes(2);
 
-      // t=6s: third should be blocked (both messages within 10s window)
+      // t=0: third should be blocked
       await mw(mockContext("sender-a") as never, next);
       expect(next).toHaveBeenCalledTimes(2);
 
-      // t=11s: first message expired, one slot free
-      vi.advanceTimersByTime(5_000);
+      // t=10s: window expired, count resets
+      vi.advanceTimersByTime(10_000);
       await mw(mockContext("sender-a") as never, next);
       expect(next).toHaveBeenCalledTimes(3);
     });
@@ -151,6 +148,25 @@ describe("RateLimiter", () => {
       expect(ctx.sendTextReply).toHaveBeenCalledWith(
         "You're sending messages too quickly. Please wait a moment.",
       );
+    });
+
+    it("replies only once per window to avoid DOS amplification", async () => {
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        behavior: "reply",
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+      const ctx = mockContext("sender-a");
+
+      await mw(ctx as never, next); // allowed
+      await mw(ctx as never, next); // blocked, reply sent
+      await mw(ctx as never, next); // blocked, no reply (already replied this window)
+      await mw(ctx as never, next); // blocked, no reply
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(ctx.sendTextReply).toHaveBeenCalledTimes(1);
     });
 
     it("sends custom reply text when configured", async () => {

--- a/sdks/agent-sdk/src/middleware/RateLimiter.test.ts
+++ b/sdks/agent-sdk/src/middleware/RateLimiter.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimiter } from "@/middleware/RateLimiter";
+
+type MockCtx = {
+  message: { senderInboxId: string };
+  sendTextReply: ReturnType<typeof vi.fn>;
+};
+
+function mockContext(senderInboxId: string): MockCtx {
+  return {
+    message: { senderInboxId },
+    sendTextReply: vi.fn(),
+  };
+}
+
+describe("RateLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("constructor", () => {
+    it("uses default config values", () => {
+      const limiter = new RateLimiter();
+      const mw = limiter.middleware();
+      expect(typeof mw).toBe("function");
+    });
+  });
+
+  describe("middleware", () => {
+    it("allows messages under the limit", async () => {
+      const limiter = new RateLimiter({ maxMessages: 3, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+
+      expect(next).toHaveBeenCalledTimes(3);
+    });
+
+    it("blocks messages over the limit", async () => {
+      const limiter = new RateLimiter({ maxMessages: 2, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+
+    it("tracks senders independently", async () => {
+      const limiter = new RateLimiter({ maxMessages: 1, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      // Both allowed once
+      expect(next).toHaveBeenCalledTimes(2);
+
+      // Second message from each should be blocked
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+
+    it("resets after the time window expires", async () => {
+      const limiter = new RateLimiter({ maxMessages: 1, windowMs: 5_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(1);
+
+      // Blocked within window
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(1);
+
+      // Advance past the window
+      vi.advanceTimersByTime(5_001);
+
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+    });
+
+    it("uses a sliding window, not a fixed window", async () => {
+      const limiter = new RateLimiter({ maxMessages: 2, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      // t=0: first message
+      await mw(mockContext("sender-a") as never, next);
+
+      // t=6s: second message
+      vi.advanceTimersByTime(6_000);
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      // t=6s: third should be blocked (both messages within 10s window)
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      // t=11s: first message expired, one slot free
+      vi.advanceTimersByTime(5_000);
+      await mw(mockContext("sender-a") as never, next);
+      expect(next).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("behavior: drop", () => {
+    it("silently drops messages without sending a reply", async () => {
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        behavior: "drop",
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+      const ctx = mockContext("sender-a");
+
+      await mw(ctx as never, next);
+      await mw(ctx as never, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(ctx.sendTextReply).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("behavior: reply", () => {
+    it("sends the default reply text when rate limited", async () => {
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        behavior: "reply",
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+      const ctx = mockContext("sender-a");
+
+      await mw(ctx as never, next);
+      await mw(ctx as never, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(ctx.sendTextReply).toHaveBeenCalledWith(
+        "You're sending messages too quickly. Please wait a moment.",
+      );
+    });
+
+    it("sends custom reply text when configured", async () => {
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        behavior: "reply",
+        replyText: "Slow down!",
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+      const ctx = mockContext("sender-a");
+
+      await mw(ctx as never, next);
+      await mw(ctx as never, next);
+
+      expect(ctx.sendTextReply).toHaveBeenCalledWith("Slow down!");
+    });
+  });
+
+  describe("onRateLimit callback", () => {
+    it("fires when a message is rate limited", async () => {
+      const onRateLimit = vi.fn();
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        onRateLimit,
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      expect(onRateLimit).not.toHaveBeenCalled();
+
+      await mw(mockContext("sender-a") as never, next);
+      expect(onRateLimit).toHaveBeenCalledWith("sender-a");
+    });
+
+    it("does not fire when messages are allowed", async () => {
+      const onRateLimit = vi.fn();
+      const limiter = new RateLimiter({
+        maxMessages: 5,
+        windowMs: 10_000,
+        onRateLimit,
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+
+      expect(onRateLimit).not.toHaveBeenCalled();
+    });
+
+    it("fires for each rate-limited message", async () => {
+      const onRateLimit = vi.fn();
+      const limiter = new RateLimiter({
+        maxMessages: 1,
+        windowMs: 10_000,
+        onRateLimit,
+      });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-a") as never, next);
+
+      expect(onRateLimit).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all tracked sender state", async () => {
+      const limiter = new RateLimiter({ maxMessages: 1, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      // Both are blocked
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      limiter.reset();
+
+      // Both allowed again after reset
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("resetSender", () => {
+    it("clears state for a specific sender only", async () => {
+      const limiter = new RateLimiter({ maxMessages: 1, windowMs: 10_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(2);
+
+      limiter.resetSender("sender-a");
+
+      // sender-a is allowed again, sender-b is still blocked
+      await mw(mockContext("sender-a") as never, next);
+      await mw(mockContext("sender-b") as never, next);
+      expect(next).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("memory cleanup", () => {
+    it("does not grow unboundedly over time", async () => {
+      const limiter = new RateLimiter({ maxMessages: 2, windowMs: 1_000 });
+      const mw = limiter.middleware();
+      const next = vi.fn();
+
+      // Fill up with messages
+      for (let i = 0; i < 100; i++) {
+        await mw(mockContext(`sender-${i}`) as never, next);
+      }
+
+      // Advance past the window so all entries expire
+      vi.advanceTimersByTime(1_001);
+
+      // Next call for any sender should trigger cleanup of that sender's expired entries
+      await mw(mockContext("sender-0") as never, next);
+
+      // sender-0 should be allowed (old entry expired, new one recorded)
+      expect(next).toHaveBeenCalledTimes(101);
+    });
+  });
+});

--- a/sdks/agent-sdk/src/middleware/RateLimiter.ts
+++ b/sdks/agent-sdk/src/middleware/RateLimiter.ts
@@ -23,13 +23,19 @@ export interface RateLimiterConfig {
  * agent.use(limiter.middleware());
  * ```
  */
+interface SenderWindow {
+  count: number;
+  windowStart: number;
+  replied: boolean;
+}
+
 export class RateLimiter<ContentTypes = unknown> {
   #maxMessages: number;
   #windowMs: number;
   #behavior: "drop" | "reply";
   #replyText: string;
   #onRateLimit?: (senderInboxId: string) => void;
-  #timestamps = new Map<string, number[]>();
+  #windows = new Map<string, SenderWindow>();
 
   constructor(config: RateLimiterConfig = {}) {
     this.#maxMessages = config.maxMessages ?? 10;
@@ -41,51 +47,52 @@ export class RateLimiter<ContentTypes = unknown> {
     this.#onRateLimit = config.onRateLimit;
   }
 
-  #isAllowed(senderInboxId: string): boolean {
+  #checkAndRecord(senderInboxId: string): "allowed" | "limited" | "limited-already-replied" {
     const now = Date.now();
-    const cutoff = now - this.#windowMs;
+    let window = this.#windows.get(senderInboxId);
 
-    let entries = this.#timestamps.get(senderInboxId);
-
-    if (entries) {
-      // Remove timestamps outside the current window
-      entries = entries.filter((ts) => ts > cutoff);
-    } else {
-      entries = [];
+    if (!window || now - window.windowStart >= this.#windowMs) {
+      this.#windows.set(senderInboxId, { count: 1, windowStart: now, replied: false });
+      return "allowed";
     }
 
-    if (entries.length >= this.#maxMessages) {
-      this.#timestamps.set(senderInboxId, entries);
-      return false;
+    window.count++;
+
+    if (window.count <= this.#maxMessages) {
+      return "allowed";
     }
 
-    entries.push(now);
-    this.#timestamps.set(senderInboxId, entries);
-    return true;
+    if (window.replied) {
+      return "limited-already-replied";
+    }
+
+    window.replied = true;
+    return "limited";
   }
 
   /** Remove all tracked sender state */
   reset(): void {
-    this.#timestamps.clear();
+    this.#windows.clear();
   }
 
   /** Remove tracked state for a specific sender */
   resetSender(senderInboxId: string): void {
-    this.#timestamps.delete(senderInboxId);
+    this.#windows.delete(senderInboxId);
   }
 
   middleware(): AgentMiddleware<ContentTypes> {
     return async (ctx, next) => {
       const senderId = ctx.message.senderInboxId;
+      const result = this.#checkAndRecord(senderId);
 
-      if (this.#isAllowed(senderId)) {
+      if (result === "allowed") {
         await next();
         return;
       }
 
       this.#onRateLimit?.(senderId);
 
-      if (this.#behavior === "reply") {
+      if (this.#behavior === "reply" && result === "limited") {
         await ctx.sendTextReply(this.#replyText);
       }
     };

--- a/sdks/agent-sdk/src/middleware/RateLimiter.ts
+++ b/sdks/agent-sdk/src/middleware/RateLimiter.ts
@@ -1,0 +1,93 @@
+import type { AgentMiddleware } from "@/core/Agent";
+
+export interface RateLimiterConfig {
+  /** Maximum number of messages allowed per sender within the time window (default: 10) */
+  maxMessages?: number;
+  /** Time window in milliseconds (default: 60000) */
+  windowMs?: number;
+  /** Action to take when a sender exceeds the rate limit (default: "drop") */
+  behavior?: "drop" | "reply";
+  /** Text to send when behavior is "reply" (default: "You're sending messages too quickly. Please wait a moment.") */
+  replyText?: string;
+  /** Called when a message is rate limited */
+  onRateLimit?: (senderInboxId: string) => void;
+}
+
+/**
+ * Middleware that throttles incoming messages on a per-sender basis using a
+ * sliding-window counter. Place it early in the middleware chain so
+ * rate-limited messages never reach downstream handlers.
+ *
+ * ```ts
+ * const limiter = new RateLimiter({ maxMessages: 5, windowMs: 30_000 });
+ * agent.use(limiter.middleware());
+ * ```
+ */
+export class RateLimiter<ContentTypes = unknown> {
+  #maxMessages: number;
+  #windowMs: number;
+  #behavior: "drop" | "reply";
+  #replyText: string;
+  #onRateLimit?: (senderInboxId: string) => void;
+  #timestamps = new Map<string, number[]>();
+
+  constructor(config: RateLimiterConfig = {}) {
+    this.#maxMessages = config.maxMessages ?? 10;
+    this.#windowMs = config.windowMs ?? 60_000;
+    this.#behavior = config.behavior ?? "drop";
+    this.#replyText =
+      config.replyText ??
+      "You're sending messages too quickly. Please wait a moment.";
+    this.#onRateLimit = config.onRateLimit;
+  }
+
+  #isAllowed(senderInboxId: string): boolean {
+    const now = Date.now();
+    const cutoff = now - this.#windowMs;
+
+    let entries = this.#timestamps.get(senderInboxId);
+
+    if (entries) {
+      // Remove timestamps outside the current window
+      entries = entries.filter((ts) => ts > cutoff);
+    } else {
+      entries = [];
+    }
+
+    if (entries.length >= this.#maxMessages) {
+      this.#timestamps.set(senderInboxId, entries);
+      return false;
+    }
+
+    entries.push(now);
+    this.#timestamps.set(senderInboxId, entries);
+    return true;
+  }
+
+  /** Remove all tracked sender state */
+  reset(): void {
+    this.#timestamps.clear();
+  }
+
+  /** Remove tracked state for a specific sender */
+  resetSender(senderInboxId: string): void {
+    this.#timestamps.delete(senderInboxId);
+  }
+
+  middleware(): AgentMiddleware<ContentTypes> {
+    return async (ctx, next) => {
+      const senderId = ctx.message.senderInboxId;
+
+      if (this.#isAllowed(senderId)) {
+        await next();
+        return;
+      }
+
+      this.#onRateLimit?.(senderId);
+
+      if (this.#behavior === "reply") {
+        await ctx.sendTextReply(this.#replyText);
+      }
+    };
+  }
+}

--- a/sdks/agent-sdk/src/middleware/index.ts
+++ b/sdks/agent-sdk/src/middleware/index.ts
@@ -1,3 +1,4 @@
+export * from "./ActionWizard";
 export * from "./CommandRouter";
 export * from "./PerformanceMonitor";
-export * from "./ActionWizard";
+export * from "./RateLimiter";


### PR DESCRIPTION
## Summary

Adds a `RateLimiter` middleware to the Agent SDK for per-sender message throttling using a sliding-window counter. No external dependencies.

## Why this matters

Deployed XMTP agents have no built-in protection against message flooding. The consent system ([docs](https://docs.xmtp.org/chat-apps/user-consent/user-consent)) filters at the conversation level, but there is nothing for per-sender rate control within allowed conversations - particularly in group chats where any member can flood the agent.

Network-level rate limiting has also shown reliability issues ([#1641](https://github.com/xmtp/xmtp-js/issues/1641) - 429 errors below documented thresholds), making agent-side throttling a useful defense layer.

HTTP-level rate limiting already exists in the codebase (`apps/xmtp.chat-api-service/src/middleware/rateLimit.ts` using `express-rate-limit`), but nothing equivalent exists for the Agent SDK's message middleware chain.

## Changes

**New files:**
- `sdks/agent-sdk/src/middleware/RateLimiter.ts` - The middleware class
- `sdks/agent-sdk/src/middleware/RateLimiter.test.ts` - 15 unit tests

**Modified:**
- `sdks/agent-sdk/src/middleware/index.ts` - Export the new middleware (also sorted alphabetically to match convention)

**Usage:**

```ts
import { Agent, RateLimiter } from "@xmtp/agent-sdk";

const limiter = new RateLimiter({
  maxMessages: 5,
  windowMs: 30_000,
  behavior: "reply",
  onRateLimit: (senderId) => console.log(`Rate limited: ${senderId}`),
});

const agent = await Agent.create(/* ... */);
agent.use(limiter.middleware());
```

Config options:
- `maxMessages` / `windowMs` - sliding window parameters (defaults: 10 messages per 60s)
- `behavior: "drop" | "reply"` - silently ignore or send a reply
- `replyText` - custom message when rate limited
- `onRateLimit` - callback for logging/metrics
- `reset()` / `resetSender(id)` - manual state control

## Implementation notes

- Follows the same `.middleware()` return pattern as `PerformanceMonitor` and `ActionWizard`
- Uses `Map<string, number[]>` keyed by `senderInboxId`, similar to `ActionWizard`'s in-memory session store
- Expired timestamps are cleaned on each check, so memory stays bounded
- The middleware calls `next()` only when the sender is under their limit. In the `reduceRight` chain (`Agent.ts` line ~570), placing `RateLimiter` early means rate-limited messages never reach downstream handlers.

## Testing

15 unit tests covering: allow/block thresholds, independent sender tracking, sliding window expiry, drop vs reply behavior, custom reply text, onRateLimit callback, reset/resetSender, and memory cleanup. All tests use `vi.useFakeTimers()` for deterministic time control.

```
✓ src/middleware/RateLimiter.test.ts (15 tests) 5ms
```

This contribution was developed with AI assistance (Claude Code).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RateLimiter` middleware to Agent SDK for per-sender message throttling
> - Adds a new [`RateLimiter`](https://github.com/xmtp/xmtp-js/pull/1766/files#diff-eda691511ce8da3a9a5ad69d691d057dfa379a35f8562964a7437276ce1a1672) middleware class that enforces per-sender message rate limits using a sliding window counter (default: 10 messages per 60s).
> - When a sender exceeds the limit, the middleware either drops the message silently (`drop` mode) or sends a single reply per window (`reply` mode) with a configurable message.
> - Supports an optional `onRateLimit` callback, plus `reset()` and `resetSender()` methods to clear window state.
> - Exports `RateLimiter` from the [`middleware` barrel](https://github.com/xmtp/xmtp-js/pull/1766/files#diff-f192e3112946499dc484b5644ca15a29842659564c2aee9764b998d4b005a98a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2082e4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->