### PR TITLE
fix(agent-sdk): preserve original message content in CommandRouter.handle()

### DIFF
--- a/.changeset/commandrouter-content-restore.md
+++ b/.changeset/commandrouter-content-restore.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/agent-sdk": patch
+---
+
+Restore original message content after CommandRouter handler completes

--- a/sdks/agent-sdk/src/middleware/CommandRouter.ts
+++ b/sdks/agent-sdk/src/middleware/CommandRouter.ts
@@ -105,10 +105,16 @@ export class CommandRouter<ContentTypes = unknown> {
     if (command.startsWith("/")) {
       const entry = this.#commandMap.get(command);
       if (entry) {
-        // Create a new context with modified content (everything after the command)
+        // Pass only the arguments (everything after the command) to the handler,
+        // then restore the original content so downstream middleware sees the full message.
         const argsText = parts.slice(1).join(" ");
+        const originalContent = ctx.message.content;
         ctx.message.content = argsText;
-        await entry.handler(ctx);
+        try {
+          await entry.handler(ctx);
+        } finally {
+          ctx.message.content = originalContent;
+        }
         return true;
       }
     }


### PR DESCRIPTION
## Summary

Fixes `CommandRouter.handle()` to restore the original message content after the command handler completes, preventing content mutation from leaking to downstream middleware.

## Why this matters

In `CommandRouter.ts:108-112`, the comment says "Create a new context with modified content" but the code mutates `ctx.message.content` in-place instead:

```typescript
// Create a new context with modified content (everything after the command)
const argsText = parts.slice(1).join(" ");
ctx.message.content = argsText;  // mutates the shared context
await entry.handler(ctx);
// original content is now permanently lost
```

This causes two problems:

1. **Middleware chaining:** When `CommandRouter` is used as middleware via `middleware()` (L125-136), and the message isn't handled (`!handled`), `next()` is called - but by that point, `ctx.message.content` has already been truncated for any previously matched-then-failed path. More importantly, if a downstream middleware or listener runs after the router, it sees args instead of the full message.

2. **Error recovery:** If the handler throws, the original content is permanently lost with no way to restore it.

## Changes

Saves `ctx.message.content` before mutation and restores it in a `finally` block after the handler completes. Handlers still receive the parsed args as `ctx.message.content` (backward compatible), but the mutation doesn't persist after `handle()` returns.

## Testing

- `yarn format:check` passes
- `yarn typecheck` passes
- Existing `CommandRouter.test.ts` tests continue to pass (handlers still receive args correctly)

This contribution was developed with AI assistance (Claude Code). I have reviewed all changes and can discuss implementation decisions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore original message content in `CommandRouter.handle()` after handler completes
> Saves `ctx.message.content` before replacing it with the arguments text, then restores it in a `try/finally` block after the command handler returns. This ensures the original full message content is always restored even if the handler throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04f2c7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->