### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+ENV NVM_DIR=/usr/local/share/nvm
+
+# Install nvm, Node.js from .node-version, and enable corepack
+COPY .node-version /tmp/.node-version
+RUN mkdir -p "$NVM_DIR" \
+    && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+    && bash -c '. "$NVM_DIR/nvm.sh" && nvm install "$(cat /tmp/.node-version)" && nvm alias default "$(cat /tmp/.node-version)"' \
+    && NODE_PATH="$(ls -d $NVM_DIR/versions/node/v*/bin | head -1)" \
+    && echo "export PATH=$NODE_PATH:\$PATH" >> /etc/profile.d/node.sh \
+    && ln -sf "$NODE_PATH/node" /usr/local/bin/node \
+    && ln -sf "$NODE_PATH/npm" /usr/local/bin/npm \
+    && ln -sf "$NODE_PATH/npx" /usr/local/bin/npx \
+    && ln -sf "$NODE_PATH/corepack" /usr/local/bin/corepack \
+    && rm /tmp/.node-version \
+    && corepack enable
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "xmtp-js",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false,
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers-extra/features/graphite-cli:1": {}
+  },
+  "postCreateCommand": "corepack install && yarn install",
+  "containerEnv": {
+    "COREPACK_ENABLE_STRICT": "0"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.github/workflows/noop.yml
+++ b/.github/workflows/noop.yml
@@ -13,6 +13,7 @@ on:
       - ".changeset/*.md"
       - ".cursor/**"
       - ".github/**"
+      - ".devcontainer/**"
       - "!.github/workflows/node-sdk.yml"
       - "!.github/workflows/content-types.yml"
       - ".vscode/**"


### PR DESCRIPTION
## Summary

Adds a devcontainer configuration for use with Coder (via Envbuilder) and other devcontainer-compatible environments.

### What's included

- **Node.js** — version read directly from `.nvmrc` at build time (no hardcoded version to keep in sync)
- **Corepack + Yarn 4** — version resolved from the `packageManager` field in `package.json`
- **Docker CLI** — Docker outside of Docker (no Moby), with Docker Compose v2
- **Native module build tools** — `build-essential` and `python3` for node-gyp

### How it works

The Dockerfile uses a custom image based on `mcr.microsoft.com/devcontainers/base:ubuntu`. Node.js is installed via nvm from the repo's `.nvmrc`, and symlinked into `/usr/local/bin` so it's available without sourcing nvm. Dependencies are installed via `postCreateCommand` after the workspace is mounted.

## Test plan

- [x] `devcontainer build` succeeds
- [x] `devcontainer up` starts the container and runs `postCreateCommand` (corepack install + yarn install)
- [x] Verified inside container: Node.js v24.11.0, Yarn 4.10.3, Docker CLI, Docker Compose v2, gcc, python3, make

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add devcontainer configuration for development environment setup
> - Adds [.devcontainer/Dockerfile](https://github.com/xmtp/xmtp-js/pull/1773/files#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6) based on `mcr.microsoft.com/devcontainers/base:ubuntu`, installing Node.js from `.node-version` via nvm, enabling corepack, and including `build-essential` and `python3`.
> - Adds [.devcontainer/devcontainer.json](https://github.com/xmtp/xmtp-js/pull/1773/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686) with Docker-outside-of-Docker and graphite-cli features, sets `COREPACK_ENABLE_STRICT=0`, and runs `corepack install && yarn install` on container creation.
> - Updates [.github/workflows/noop.yml](https://github.com/xmtp/xmtp-js/pull/1773/files#diff-a540aa2c6a1af0a62b91bfca2254dc4cc0e13013fe04038c9f4708a6bc05aa67) to trigger on changes under `.devcontainer/**`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1bf836.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->