### PR TITLE
Add waitForRegistrationVisible

### DIFF
--- a/content-types/content-type-primitives/package.json
+++ b/content-types/content-type-primitives/package.json
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@xmtp/node-bindings": "1.10.0-dev.2334796"
+    "@xmtp/node-bindings": "1.10.0-dev.ae5ffba"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-primitives": "3.0.0",
-    "@xmtp/wasm-bindings": "1.10.0"
+    "@xmtp/wasm-bindings": "1.10.0-dev.ae5ffba"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -459,6 +459,7 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     return this.#worker.action("client.registerIdentity", {
       signer,
       signatureRequestId,
+      waitForRegistrationVisible: this.#options?.waitForRegistrationVisible,
     });
   }
 

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -9,7 +9,11 @@ import {
   type KeyPackageStatus,
   type SignatureRequestHandle,
 } from "@xmtp/wasm-bindings";
-import type { ClientOptions, XmtpEnv } from "@/types/options";
+import type {
+  ClientOptions,
+  VisibilityConfirmationOptions,
+  XmtpEnv,
+} from "@/types/options";
 import { createClient } from "@/utils/createClient";
 import type { SafeSigner } from "@/utils/signer";
 import { WorkerConversations } from "@/WorkerConversations";
@@ -148,9 +152,13 @@ export class WorkerClient {
   async registerIdentity(
     signer: SafeSigner,
     signatureRequest: SignatureRequestHandle,
+    visibilityConfirmationOptions?: VisibilityConfirmationOptions,
   ) {
     await this.addSignature(signatureRequest, signer);
-    await this.#client.registerIdentity(signatureRequest);
+    await this.#client.registerIdentity(
+      signatureRequest,
+      visibilityConfirmationOptions,
+    );
   }
 
   async getInboxIdByIdentifier(identifier: Identifier) {

--- a/sdks/browser-sdk/src/types/actions/client.ts
+++ b/sdks/browser-sdk/src/types/actions/client.ts
@@ -6,7 +6,10 @@ import type {
   Identifier,
   KeyPackageStatus,
 } from "@xmtp/wasm-bindings";
-import type { ClientOptions } from "@/types/options";
+import type {
+  ClientOptions,
+  VisibilityConfirmationOptions,
+} from "@/types/options";
 import type { SafeSigner } from "@/utils/signer";
 
 export type ClientAction =
@@ -112,6 +115,7 @@ export type ClientAction =
       data: {
         signer: SafeSigner;
         signatureRequestId: string;
+        waitForRegistrationVisible?: VisibilityConfirmationOptions;
       };
     }
   | {

--- a/sdks/browser-sdk/src/types/options.ts
+++ b/sdks/browser-sdk/src/types/options.ts
@@ -17,8 +17,11 @@ import type {
   RemoteAttachment,
   TransactionReference,
   WalletSendCalls,
+  WasmVisibilityConfirmationOptions,
 } from "@xmtp/wasm-bindings";
 import type { DecodedMessage } from "@/DecodedMessage";
+
+export type VisibilityConfirmationOptions = WasmVisibilityConfirmationOptions;
 
 export type XmtpEnv =
   | "local"
@@ -119,6 +122,13 @@ export type OtherOptions = {
    * Disable automatic registration when creating a client
    */
   disableAutoRegister?: boolean;
+  /**
+   * Options for waiting until client registration is visible on the network.
+   *
+   * When set, `registerIdentity` will wait for the specified quorum of nodes
+   * to confirm the registration before resolving.
+   */
+  waitForRegistrationVisible?: VisibilityConfirmationOptions;
 };
 
 export type ClientOptions = (NetworkOptions | { backend: Backend }) &

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -235,7 +235,11 @@ self.onmessage = async (
         if (!signatureRequest) {
           throw new Error("Signature request not found");
         }
-        await client.registerIdentity(data.signer, signatureRequest);
+        await client.registerIdentity(
+          data.signer,
+          signatureRequest,
+          data.waitForRegistrationVisible,
+        );
         signatureRequests.delete(data.signatureRequestId);
         postMessage({ id, action, result: undefined });
         break;

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-primitives": "3.0.0",
-    "@xmtp/node-bindings": "1.10.0"
+    "@xmtp/node-bindings": "1.10.0-dev.ae5ffba"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -508,7 +508,10 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     }
 
     await this.unsafe_addSignature(signatureRequest);
-    await this.#client?.registerIdentity(signatureRequest);
+    await this.#client?.registerIdentity(
+      signatureRequest,
+      this.#options?.waitForRegistrationVisible,
+    );
   }
 
   /**

--- a/sdks/node-sdk/src/index.ts
+++ b/sdks/node-sdk/src/index.ts
@@ -63,6 +63,7 @@ export type {
   TransactionMetadata,
   TransactionReference,
   UserPreferenceUpdate,
+  VisibilityConfirmationOptions,
   WalletCall,
   WalletSendCalls,
 } from "@xmtp/node-bindings";

--- a/sdks/node-sdk/src/types.ts
+++ b/sdks/node-sdk/src/types.ts
@@ -14,6 +14,7 @@ import {
   type ReadReceipt,
   type RemoteAttachment,
   type TransactionReference,
+  type VisibilityConfirmationOptions,
   type WalletSendCalls,
 } from "@xmtp/node-bindings";
 import type { DecodedMessage } from "@/DecodedMessage";
@@ -136,6 +137,13 @@ export type OtherOptions = {
    * (default: undefined = 1)
    */
   nonce?: bigint;
+  /**
+   * Options for waiting until client registration is visible on the network.
+   *
+   * When set, `registerIdentity` will wait for the specified quorum of nodes
+   * to confirm the registration before resolving.
+   */
+  waitForRegistrationVisible?: VisibilityConfirmationOptions;
 };
 
 export type ClientOptions = (NetworkOptions | { backend: Backend }) &

--- a/yarn.lock
+++ b/yarn.lock
@@ -6414,7 +6414,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.0.18"
     "@web/rollup-plugin-copy": "npm:^0.5.1"
     "@xmtp/content-type-primitives": "npm:3.0.0"
-    "@xmtp/wasm-bindings": "npm:1.10.0"
+    "@xmtp/wasm-bindings": "npm:1.10.0-dev.ae5ffba"
     playwright: "npm:^1.58.0"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.3.0"
@@ -6506,7 +6506,7 @@ __metadata:
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@rollup/plugin-typescript": "npm:^12.3.0"
     "@types/node": "npm:^24.10.9"
-    "@xmtp/node-bindings": "npm:1.10.0-dev.2334796"
+    "@xmtp/node-bindings": "npm:1.10.0-dev.ae5ffba"
     rimraf: "npm:^6.1.2"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.3.0"
@@ -6657,17 +6657,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@xmtp/node-bindings@npm:1.10.0"
-  checksum: 10/63ab1b66c0f837f030d12a7c6ead06ee68cdf48cca091aaea35614d6d61fd6b86d11562dc553444de4641f0b970098a74b0f01c9501dd64160c9f975b6dec601
-  languageName: node
-  linkType: hard
-
-"@xmtp/node-bindings@npm:1.10.0-dev.2334796":
-  version: 1.10.0-dev.2334796
-  resolution: "@xmtp/node-bindings@npm:1.10.0-dev.2334796"
-  checksum: 10/8f9a7c1c6b75a5c84ee104b82b8e14513fd7fb4a07353b04eb5cb4f7d1f9c63fbd9d10e3d6575d4716ebd1380b7b078b583d4c2cc95baebb723568496cee51c6
+"@xmtp/node-bindings@npm:1.10.0-dev.ae5ffba":
+  version: 1.10.0-dev.ae5ffba
+  resolution: "@xmtp/node-bindings@npm:1.10.0-dev.ae5ffba"
+  checksum: 10/dc53b1673a3f26a0c06387a788084edcad3e5fedda9e903eddbd6ff701e753e55049033fb64ab0d2a609aef1f417d8f6c31684da4059d9e303c6013e20a844a2
   languageName: node
   linkType: hard
 
@@ -6706,7 +6699,7 @@ __metadata:
     "@types/node": "npm:^24.10.9"
     "@vitest/coverage-v8": "npm:^4.0.18"
     "@xmtp/content-type-primitives": "npm:3.0.0"
-    "@xmtp/node-bindings": "npm:1.10.0"
+    "@xmtp/node-bindings": "npm:1.10.0-dev.ae5ffba"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.1.2"
     rollup: "npm:^4.59.0"
@@ -6747,10 +6740,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@xmtp/wasm-bindings@npm:1.10.0"
-  checksum: 10/09e5767fb46387195524f7299255c08745a283c97a00b88a91278de34f63893f35a6b98f5b22d634782eca67345558c1927d433078f8e34b8946db1132d5cf26
+"@xmtp/wasm-bindings@npm:1.10.0-dev.ae5ffba":
+  version: 1.10.0-dev.ae5ffba
+  resolution: "@xmtp/wasm-bindings@npm:1.10.0-dev.ae5ffba"
+  checksum: 10/3c42f835bd6357b5fca3c9d6972b152cea4300c91c8394e47e23d5ccbef7a71602d18e2e07cf30df64972f3001cc4defa286a06d14a1437be4c6f54d9d33fee4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `waitForRegistrationVisible` option to `Client.register` in browser and node SDKs
- Adds a new `waitForRegistrationVisible` field (typed as `VisibilityConfirmationOptions`) to `OtherOptions` in both the browser and node SDKs, causing `registerIdentity` to block until a quorum confirms registration when set.
- Threads the option through the browser SDK worker pipeline: `Client.register` → worker action payload → `WorkerClient.registerIdentity` → WASM `client.registerIdentity`.
- Exports `VisibilityConfirmationOptions` from the node SDK's public index, sourced from `@xmtp/node-bindings`.
- Updates `@xmtp/node-bindings` and `@xmtp/wasm-bindings` to dev snapshot `1.10.0-dev.ae5ffba` to pick up the underlying binding support.
- Behavioral Change: when `waitForRegistrationVisible` is set, `Client.register` becomes a blocking call that waits for network-level visibility confirmation before resolving.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f105c0.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->