### PR TITLE
Fix flaky stream retry tests by polling instead of fixed sleep

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+ENV NVM_DIR=/usr/local/share/nvm
+
+# Install nvm, Node.js from .node-version, and enable corepack
+COPY .node-version /tmp/.node-version
+RUN mkdir -p "$NVM_DIR" \
+    && curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash \
+    && bash -c '. "$NVM_DIR/nvm.sh" && nvm install "$(cat /tmp/.node-version)" && nvm alias default "$(cat /tmp/.node-version)"' \
+    && NODE_PATH="$(ls -d $NVM_DIR/versions/node/v*/bin | head -1)" \
+    && echo "export PATH=$NODE_PATH:\$PATH" >> /etc/profile.d/node.sh \
+    && ln -sf "$NODE_PATH/node" /usr/local/bin/node \
+    && ln -sf "$NODE_PATH/npm" /usr/local/bin/npm \
+    && ln -sf "$NODE_PATH/npx" /usr/local/bin/npx \
+    && ln -sf "$NODE_PATH/corepack" /usr/local/bin/corepack \
+    && rm /tmp/.node-version \
+    && corepack enable
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "xmtp-js",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "moby": false,
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers-extra/features/graphite-cli:1": {}
+  },
+  "postCreateCommand": "corepack install && yarn install",
+  "containerEnv": {
+    "COREPACK_ENABLE_STRICT": "0"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/sdks/browser-sdk/test/helpers.ts
+++ b/sdks/browser-sdk/test/helpers.ts
@@ -22,6 +22,19 @@ type TestClientOptions = NetworkOptions &
 export const sleep = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+export const waitFor = async (
+  condition: () => boolean,
+  { timeout = 2000, interval = 10 } = {},
+) => {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeout) {
+      throw new Error(`waitFor timed out after ${timeout}ms`);
+    }
+    await sleep(interval);
+  }
+};
+
 export const createSigner = () => {
   const signer = createEOASigner();
   const identifier = signer.getIdentifier() as Identifier;

--- a/sdks/browser-sdk/test/streams.test.ts
+++ b/sdks/browser-sdk/test/streams.test.ts
@@ -10,7 +10,7 @@ import {
   type StreamCallback,
   type StreamFunction,
 } from "@/utils/streams";
-import { sleep } from "@test/helpers";
+import { sleep, waitFor } from "@test/helpers";
 
 describe("createStream", () => {
   describe("basic functionality", () => {
@@ -658,11 +658,11 @@ describe("createStream", () => {
         retryAttempts: 3,
       });
 
-      await sleep(100);
+      // Wait for all retries to complete instead of using a fixed sleep
+      await waitFor(() => onRetrySpy.mock.calls.length >= 3);
       await stream.end();
 
       // onRetry should be called with (currentAttempt, maxAttempts)
-      // At minimum, the first 3 attempts should have occurred
       expect(onRetrySpy).toHaveBeenCalledWith(1, 3);
       expect(onRetrySpy).toHaveBeenCalledWith(2, 3);
       expect(onRetrySpy).toHaveBeenCalledWith(3, 3);
@@ -690,7 +690,8 @@ describe("createStream", () => {
         retryAttempts: 2,
       });
 
-      await sleep(200);
+      // Wait for retries to exhaust and StreamFailedError to be reported
+      await waitFor(() => onErrorSpy.mock.calls.length > 1);
       await stream.end();
 
       // onError should be called multiple times


### PR DESCRIPTION
Replace fixed `sleep()` calls with a `waitFor()` polling helper in
stream retry tests that were failing intermittently in CI due to
timing sensitivity in the Playwright browser environment.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky stream retry tests by polling for spy call conditions instead of fixed sleep
> Replaces fixed-duration `sleep()` calls in [streams.test.ts](https://github.com/xmtp/xmtp-js/pull/1775/files#diff-54e8822ac9c5635479aa9c77e2fa9f1cb0f97cb06840f7a75de927bc6b29c5b6) with a new `waitFor` polling utility that waits until specific spy conditions are met. The `waitFor` helper in [helpers.ts](https://github.com/xmtp/xmtp-js/pull/1775/files#diff-e9f146cbb2814dddded46cdba9f207521d0fdd8ce5f5da35a4a0f1d29709e7bb) polls a condition every 10ms and throws if it isn't satisfied within a 2000ms timeout. Also adds a devcontainer configuration for the browser SDK.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0b5a3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->