### PR TITLE
adds fetchLatestInboxUpdatesCount to sdks and xmtp.chat

### DIFF
--- a/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
+++ b/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
@@ -204,7 +204,7 @@ export const InboxTools: React.FC = () => {
         }
         footer={
           <Group justify="flex-end" p="md" flex={1}>
-            {!(address || ephemeralAddress) && (
+            {!(address || ephemeralAccountEnabled) && (
               <Text size="sm" c="dimmed">
                 Wallet connection required
               </Text>
@@ -232,7 +232,7 @@ export const InboxTools: React.FC = () => {
           </Stepper.Step>
           <Stepper.Step label="Manage installations" allowStepSelect={false}>
             <Stack gap="md" py="md">
-              {address || ephemeralAddress ? (
+              {address || ephemeralAccountEnabled ? (
                 <Group justify="space-between" align="center">
                   <ConnectedAddress
                     size="sm"

--- a/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
+++ b/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx
@@ -40,6 +40,9 @@ export const InboxTools: React.FC = () => {
     error: memberIdError,
   } = useMemberId();
   const [installations, setInstallations] = useState<Installation[]>([]);
+  const [inboxUpdatesCount, setInboxUpdatesCount] = useState<number | null>(
+    null,
+  );
   const [selectedInstallationIds, setSelectedInstallationIds] = useState<
     string[]
   >([]);
@@ -52,7 +55,7 @@ export const InboxTools: React.FC = () => {
     ephemeralAccountEnabled,
     setEphemeralAccountEnabled,
   } = useSettings();
-  const [active, setActive] = useState(0);
+  const [active, setActive] = useState(1);
 
   const handleFindInstallations = useCallback(async () => {
     if (!isValidInboxId(inboxId)) {
@@ -73,6 +76,26 @@ export const InboxTools: React.FC = () => {
             Number(b.clientTimestampNs ?? 0) - Number(a.clientTimestampNs ?? 0),
         ),
       );
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [inboxId, sdkEnv, gatewayHost]);
+
+  const handleFetchInboxUpdatesCount = useCallback(async () => {
+    if (!isValidInboxId(inboxId)) {
+      return;
+    }
+    setLoading(true);
+    setInboxUpdatesCount(null);
+    try {
+      const inboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
+        [inboxId],
+        sdkEnv,
+        gatewayHost,
+      );
+      setInboxUpdatesCount(inboxUpdatesCounts.get(inboxId) ?? 0);
     } catch (error) {
       console.error(error);
     } finally {
@@ -141,11 +164,13 @@ export const InboxTools: React.FC = () => {
       setEphemeralAccountEnabled(false);
     }
     setMemberId("");
+    setInboxUpdatesCount(null);
     setInstallations([]);
     setSelectedInstallationIds([]);
   }, [
     isConnected,
     disconnect,
+    setInboxUpdatesCount,
     setEphemeralAccountEnabled,
     setMemberId,
     setInstallations,
@@ -154,23 +179,17 @@ export const InboxTools: React.FC = () => {
 
   useEffect(() => {
     if (!isValidInboxId(inboxId)) {
+      setInboxUpdatesCount(null);
       setInstallations([]);
       setSelectedInstallationIds([]);
     }
   }, [inboxId]);
 
   useEffect(() => {
+    setInboxUpdatesCount(null);
     setInstallations([]);
     setSelectedInstallationIds([]);
   }, [sdkEnv]);
-
-  useEffect(() => {
-    if (isConnected || ephemeralAccountEnabled) {
-      setActive(1);
-    } else {
-      setActive(0);
-    }
-  }, [isConnected, ephemeralAccountEnabled]);
 
   return (
     <>
@@ -213,14 +232,21 @@ export const InboxTools: React.FC = () => {
           </Stepper.Step>
           <Stepper.Step label="Manage installations" allowStepSelect={false}>
             <Stack gap="md" py="md">
-              <Group justify="space-between" align="center">
-                <ConnectedAddress
-                  size="sm"
-                  address={address ?? ephemeralAddress}
-                  onClick={handleDisconnectWallet}
-                />
-                <NetworkSelect />
-              </Group>
+              {address || ephemeralAddress ? (
+                <Group justify="space-between" align="center">
+                  <ConnectedAddress
+                    size="sm"
+                    address={address ?? ephemeralAddress}
+                    onClick={handleDisconnectWallet}
+                  />
+                  <NetworkSelect />
+                </Group>
+              ) : (
+                <Group justify="space-between" align="flex-start">
+                  <WalletConnect />
+                  <NetworkSelect />
+                </Group>
+              )}
               <Stack gap="xs" mb="md">
                 <Group justify="space-between" align="center">
                   <Text size="sm" pl={4}>
@@ -248,15 +274,31 @@ export const InboxTools: React.FC = () => {
                     }}>
                     Use wallet address
                   </Button>
-                  <Button
-                    disabled={!isValidInboxId(inboxId)}
-                    onClick={() => {
-                      void handleFindInstallations();
-                    }}>
-                    Find installations
-                  </Button>
+                  <Group gap="xs">
+                    <Button
+                      variant="default"
+                      disabled={!isValidInboxId(inboxId)}
+                      onClick={() => {
+                        void handleFetchInboxUpdatesCount();
+                      }}>
+                      Check updates count
+                    </Button>
+                    <Button
+                      disabled={!isValidInboxId(inboxId)}
+                      onClick={() => {
+                        void handleFindInstallations();
+                      }}>
+                      Find installations
+                    </Button>
+                  </Group>
                 </Group>
               </Stack>
+              <Title order={4}>Inbox updates count</Title>
+              <Text>
+                {inboxUpdatesCount === null
+                  ? "No count fetched"
+                  : inboxUpdatesCount.toString()}
+              </Text>
               <Title order={4}>Installations</Title>
               <Stack gap="md">
                 {installations.length === 0 && (

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -850,12 +850,19 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
       dbPath: null,
       disableDeviceSync: true,
     });
-    const result = (await client.fetchLatestInboxUpdatesCount(
-      true,
-      inboxIds,
-    )) as Record<string, number> | Map<string, number>;
+    // The wasm-bindings Client holds WASM-linear-memory allocations that are
+    // not reclaimed by the JS GC. Free the ephemeral client in finally so the
+    // allocation is released even if the fetch rejects.
+    try {
+      const result = (await client.fetchLatestInboxUpdatesCount(
+        true,
+        inboxIds,
+      )) as Record<string, number> | Map<string, number>;
 
-    return toInboxUpdatesCountMap(result);
+      return toInboxUpdatesCountMap(result);
+    } finally {
+      client.free();
+    }
   }
 
   /**

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -2,6 +2,7 @@ import { type ContentCodec } from "@xmtp/content-type-primitives";
 import {
   Backend,
   BackupElementSelectionOption,
+  IdentifierKind,
   LogLevel,
   type ArchiveMetadata,
   type ArchiveOptions,
@@ -22,6 +23,7 @@ import type {
   XmtpEnv,
 } from "@/types/options";
 import { createBackend } from "@/utils/createBackend";
+import { createClient as createLowLevelClient } from "@/utils/createClient";
 import {
   AccountAlreadyAssociatedError,
   InboxReassignError,
@@ -49,6 +51,28 @@ const resolveBackend = async (
     return envOrBackend;
   }
   return createBackend({ env: envOrBackend, gatewayHost });
+};
+
+const createEphemeralIdentifier = (): Identifier => {
+  const bytes = new Uint8Array(20);
+  globalThis.crypto.getRandomValues(bytes);
+
+  return {
+    identifier: `0x${Array.from(bytes, (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("")}`,
+    identifierKind: IdentifierKind.Ethereum,
+  };
+};
+
+const toInboxUpdatesCountMap = (
+  value: Map<string, number> | Record<string, number>,
+) => {
+  if (value instanceof Map) {
+    return value;
+  }
+
+  return new Map(Object.entries(value));
 };
 
 /**
@@ -720,6 +744,40 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   }
 
   /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   */
+  async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    _refreshFromNetwork = true,
+  ) {
+    const result = await this.#worker.action(
+      "client.fetchLatestInboxUpdatesCount",
+      {
+        inboxIds,
+        refreshFromNetwork: true,
+      },
+    );
+
+    return toInboxUpdatesCountMap(result);
+  }
+
+  /**
+   * Fetches the latest inbox updates count for the client's inbox
+   *
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns The latest inbox updates count
+   */
+  async fetchOwnInboxUpdatesCount(_refreshFromNetwork = true) {
+    return this.#worker.action("client.fetchOwnInboxUpdatesCount", {
+      refreshFromNetwork: true,
+    });
+  }
+
+  /**
    * Checks if the specified identifiers can be messaged
    *
    * @param identifiers - The identifiers to check
@@ -759,6 +817,62 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
       );
     }
     return canMessageMap;
+  }
+
+  /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   * without a client
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param backend - Optional `Backend` instance created with `createBackend()`
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   */
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    backendOrEnv?: Backend | XmtpEnv,
+    refreshFromNetwork?: boolean,
+  ): Promise<Map<string, number>>;
+  /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   * without a client
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param env - Optional XMTP environment
+   * @param gatewayHost - Optional gateway host
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   * @deprecated Pass a `Backend` instance created with `createBackend()` instead
+   * of `XmtpEnv` and `gatewayHost`.
+   */
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    env?: XmtpEnv,
+    gatewayHost?: string,
+    refreshFromNetwork?: boolean,
+  ): Promise<Map<string, number>>;
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    envOrBackend?: XmtpEnv | Backend,
+    gatewayHostOrRefresh?: string | boolean,
+    _refreshFromNetwork = true,
+  ) {
+    const gatewayHost =
+      typeof gatewayHostOrRefresh === "string"
+        ? gatewayHostOrRefresh
+        : undefined;
+    const backend = await resolveBackend(envOrBackend, gatewayHost);
+    const { client } = await createLowLevelClient(createEphemeralIdentifier(), {
+      backend,
+      dbPath: null,
+      disableDeviceSync: true,
+    });
+    const result = (await client.fetchLatestInboxUpdatesCount(
+      true,
+      inboxIds,
+    )) as Record<string, number> | Map<string, number>;
+
+    return toInboxUpdatesCountMap(result);
   }
 
   /**

--- a/sdks/browser-sdk/src/Client.ts
+++ b/sdks/browser-sdk/src/Client.ts
@@ -747,18 +747,13 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * Fetches the latest inbox updates count for the specified inbox IDs
    *
    * @param inboxIds - The inbox IDs to check
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    */
-  async fetchLatestInboxUpdatesCount(
-    inboxIds: string[],
-    _refreshFromNetwork = true,
-  ) {
+  async fetchLatestInboxUpdatesCount(inboxIds: string[]) {
     const result = await this.#worker.action(
       "client.fetchLatestInboxUpdatesCount",
       {
         inboxIds,
-        refreshFromNetwork: true,
       },
     );
 
@@ -768,13 +763,10 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   /**
    * Fetches the latest inbox updates count for the client's inbox
    *
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns The latest inbox updates count
    */
-  async fetchOwnInboxUpdatesCount(_refreshFromNetwork = true) {
-    return this.#worker.action("client.fetchOwnInboxUpdatesCount", {
-      refreshFromNetwork: true,
-    });
+  async fetchOwnInboxUpdatesCount() {
+    return this.#worker.action("client.fetchOwnInboxUpdatesCount", {});
   }
 
   /**
@@ -825,13 +817,11 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    *
    * @param inboxIds - The inbox IDs to check
    * @param backend - Optional `Backend` instance created with `createBackend()`
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    */
   static async fetchLatestInboxUpdatesCount(
     inboxIds: string[],
     backendOrEnv?: Backend | XmtpEnv,
-    refreshFromNetwork?: boolean,
   ): Promise<Map<string, number>>;
   /**
    * Fetches the latest inbox updates count for the specified inbox IDs
@@ -840,7 +830,6 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * @param inboxIds - The inbox IDs to check
    * @param env - Optional XMTP environment
    * @param gatewayHost - Optional gateway host
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    * @deprecated Pass a `Backend` instance created with `createBackend()` instead
    * of `XmtpEnv` and `gatewayHost`.
@@ -849,18 +838,12 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     inboxIds: string[],
     env?: XmtpEnv,
     gatewayHost?: string,
-    refreshFromNetwork?: boolean,
   ): Promise<Map<string, number>>;
   static async fetchLatestInboxUpdatesCount(
     inboxIds: string[],
     envOrBackend?: XmtpEnv | Backend,
-    gatewayHostOrRefresh?: string | boolean,
-    _refreshFromNetwork = true,
+    gatewayHost?: string,
   ) {
-    const gatewayHost =
-      typeof gatewayHostOrRefresh === "string"
-        ? gatewayHostOrRefresh
-        : undefined;
     const backend = await resolveBackend(envOrBackend, gatewayHost);
     const { client } = await createLowLevelClient(createEphemeralIdentifier(), {
       backend,

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -94,20 +94,17 @@ export class WorkerClient {
     >;
   }
 
-  async fetchLatestInboxUpdatesCount(
-    refreshFromNetwork: boolean,
-    inboxIds: string[],
-  ) {
+  async fetchLatestInboxUpdatesCount(inboxIds: string[]) {
     const result = (await this.#client.fetchLatestInboxUpdatesCount(
-      refreshFromNetwork,
+      true,
       inboxIds,
     )) as Map<string, number> | Record<string, number>;
 
     return result instanceof Map ? Object.fromEntries(result) : result;
   }
 
-  async fetchOwnInboxUpdatesCount(refreshFromNetwork: boolean) {
-    return this.#client.fetchOwnInboxUpdatesCount(refreshFromNetwork);
+  async fetchOwnInboxUpdatesCount() {
+    return this.#client.fetchOwnInboxUpdatesCount(true);
   }
 
   async addSignature(

--- a/sdks/browser-sdk/src/WorkerClient.ts
+++ b/sdks/browser-sdk/src/WorkerClient.ts
@@ -94,6 +94,22 @@ export class WorkerClient {
     >;
   }
 
+  async fetchLatestInboxUpdatesCount(
+    refreshFromNetwork: boolean,
+    inboxIds: string[],
+  ) {
+    const result = (await this.#client.fetchLatestInboxUpdatesCount(
+      refreshFromNetwork,
+      inboxIds,
+    )) as Map<string, number> | Record<string, number>;
+
+    return result instanceof Map ? Object.fromEntries(result) : result;
+  }
+
+  async fetchOwnInboxUpdatesCount(refreshFromNetwork: boolean) {
+    return this.#client.fetchOwnInboxUpdatesCount(refreshFromNetwork);
+  }
+
   async addSignature(
     signatureRequest: SignatureRequestHandle,
     signer: SafeSigner,

--- a/sdks/browser-sdk/src/types/actions/client.ts
+++ b/sdks/browser-sdk/src/types/actions/client.ts
@@ -187,16 +187,13 @@ export type ClientAction =
       result: Record<string, number>;
       data: {
         inboxIds: string[];
-        refreshFromNetwork: boolean;
       };
     }
   | {
       action: "client.fetchOwnInboxUpdatesCount";
       id: string;
       result: number;
-      data: {
-        refreshFromNetwork: boolean;
-      };
+      data: Record<string, never>;
     }
   | {
       action: "client.getInboxIdByIdentifier";

--- a/sdks/browser-sdk/src/types/actions/client.ts
+++ b/sdks/browser-sdk/src/types/actions/client.ts
@@ -182,6 +182,23 @@ export type ClientAction =
       };
     }
   | {
+      action: "client.fetchLatestInboxUpdatesCount";
+      id: string;
+      result: Record<string, number>;
+      data: {
+        inboxIds: string[];
+        refreshFromNetwork: boolean;
+      };
+    }
+  | {
+      action: "client.fetchOwnInboxUpdatesCount";
+      id: string;
+      result: number;
+      data: {
+        refreshFromNetwork: boolean;
+      };
+    }
+  | {
       action: "client.getInboxIdByIdentifier";
       id: string;
       result: string | undefined;

--- a/sdks/browser-sdk/src/utils/createClient.ts
+++ b/sdks/browser-sdk/src/utils/createClient.ts
@@ -9,6 +9,12 @@ import {
 import type { ClientOptions, NetworkOptions } from "@/types/options";
 import { createBackend, envToString } from "@/utils/createBackend";
 
+type CreateClientOptions = ClientOptions extends infer T
+  ? T extends ClientOptions
+    ? Omit<T, "codecs">
+    : never
+  : never;
+
 const networkOptionKeys = [
   "env",
   "apiUrl",
@@ -21,7 +27,7 @@ const hasBackend = (options: object): options is { backend: Backend } => {
 };
 
 const resolveBackend = async (
-  options?: Omit<ClientOptions, "codecs">,
+  options?: CreateClientOptions,
 ): Promise<Backend> => {
   if (!options) {
     return createBackend();
@@ -48,7 +54,7 @@ const resolveBackend = async (
 
 export const createClient = async (
   identifier: Identifier,
-  options?: Omit<ClientOptions, "codecs">,
+  options?: CreateClientOptions,
 ) => {
   const backend = await resolveBackend(options);
 

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -304,6 +304,21 @@ self.onmessage = async (
         postMessage({ id, action, result });
         break;
       }
+      case "client.fetchLatestInboxUpdatesCount": {
+        const result = await client.fetchLatestInboxUpdatesCount(
+          data.refreshFromNetwork,
+          data.inboxIds,
+        );
+        postMessage({ id, action, result });
+        break;
+      }
+      case "client.fetchOwnInboxUpdatesCount": {
+        const result = await client.fetchOwnInboxUpdatesCount(
+          data.refreshFromNetwork,
+        );
+        postMessage({ id, action, result });
+        break;
+      }
       case "client.getInboxIdByIdentifier": {
         const result = await client.getInboxIdByIdentifier(data.identifier);
         postMessage({ id, action, result });

--- a/sdks/browser-sdk/src/workers/client.ts
+++ b/sdks/browser-sdk/src/workers/client.ts
@@ -305,17 +305,12 @@ self.onmessage = async (
         break;
       }
       case "client.fetchLatestInboxUpdatesCount": {
-        const result = await client.fetchLatestInboxUpdatesCount(
-          data.refreshFromNetwork,
-          data.inboxIds,
-        );
+        const result = await client.fetchLatestInboxUpdatesCount(data.inboxIds);
         postMessage({ id, action, result });
         break;
       }
       case "client.fetchOwnInboxUpdatesCount": {
-        const result = await client.fetchOwnInboxUpdatesCount(
-          data.refreshFromNetwork,
-        );
+        const result = await client.fetchOwnInboxUpdatesCount();
         postMessage({ id, action, result });
         break;
       }

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -457,13 +457,6 @@ describe("Client", () => {
       "local",
     );
     expect(inboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf("number");
-
-    const freshInboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
-      [client.inboxId!],
-      "local",
-      true,
-    );
-    expect(freshInboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf("number");
   });
 
   it("should get own inbox updates count from a client", async () => {
@@ -474,15 +467,7 @@ describe("Client", () => {
     ]);
     const ownInboxUpdatesCount = await client.fetchOwnInboxUpdatesCount();
     expect(inboxUpdatesCounts.get(client.inboxId!)).toBe(ownInboxUpdatesCount);
-
-    const explicitFreshInboxUpdatesCounts =
-      await client.fetchLatestInboxUpdatesCount([client.inboxId!], true);
-    expect(explicitFreshInboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf(
-      "number",
-    );
-
-    const explicitFreshOwnInboxUpdatesCount =
-      await client.fetchOwnInboxUpdatesCount(true);
-    expect(explicitFreshOwnInboxUpdatesCount).toBeTypeOf("number");
+    expect(inboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf("number");
+    expect(ownInboxUpdatesCount).toBeTypeOf("number");
   });
 });

--- a/sdks/browser-sdk/test/Client.test.ts
+++ b/sdks/browser-sdk/test/Client.test.ts
@@ -448,4 +448,41 @@ describe("Client", () => {
       await signer.getIdentifier(),
     ]);
   });
+
+  it("should get latest inbox updates count from inbox IDs without a client", async () => {
+    const { signer } = createSigner();
+    const client = await createRegisteredClient(signer);
+    const inboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
+      [client.inboxId!],
+      "local",
+    );
+    expect(inboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf("number");
+
+    const freshInboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
+      [client.inboxId!],
+      "local",
+      true,
+    );
+    expect(freshInboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf("number");
+  });
+
+  it("should get own inbox updates count from a client", async () => {
+    const { signer } = createSigner();
+    const client = await createRegisteredClient(signer);
+    const inboxUpdatesCounts = await client.fetchLatestInboxUpdatesCount([
+      client.inboxId!,
+    ]);
+    const ownInboxUpdatesCount = await client.fetchOwnInboxUpdatesCount();
+    expect(inboxUpdatesCounts.get(client.inboxId!)).toBe(ownInboxUpdatesCount);
+
+    const explicitFreshInboxUpdatesCounts =
+      await client.fetchLatestInboxUpdatesCount([client.inboxId!], true);
+    expect(explicitFreshInboxUpdatesCounts.get(client.inboxId!)).toBeTypeOf(
+      "number",
+    );
+
+    const explicitFreshOwnInboxUpdatesCount =
+      await client.fetchOwnInboxUpdatesCount(true);
+    expect(explicitFreshOwnInboxUpdatesCount).toBeTypeOf("number");
+  });
 });

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -1,9 +1,11 @@
+import { randomBytes } from "node:crypto";
 import { type ContentCodec } from "@xmtp/content-type-primitives";
 import {
   applySignatureRequest,
   Backend,
   BackupElementSelectionOption,
   fetchInboxStatesByInboxIds,
+  IdentifierKind,
   isAddressAuthorized as isAddressAuthorizedBinding,
   isInstallationAuthorized as isInstallationAuthorizedBinding,
   revokeInstallationsSignatureRequest,
@@ -49,6 +51,21 @@ const resolveBackend = async (
     return envOrBackend;
   }
   return createBackend({ env: envOrBackend, gatewayHost });
+};
+
+const createEphemeralIdentifier = (): Identifier => ({
+  identifier: `0x${randomBytes(20).toString("hex")}`,
+  identifierKind: IdentifierKind.Ethereum,
+});
+
+const toInboxUpdatesCountMap = (
+  value: Map<string, number> | Record<string, number>,
+) => {
+  if (value instanceof Map) {
+    return value;
+  }
+
+  return new Map(Object.entries(value));
 };
 
 /**
@@ -709,6 +726,42 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   }
 
   /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   * @throws {ClientNotInitializedError} if the client is not initialized
+   */
+  async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    _refreshFromNetwork = true,
+  ) {
+    if (!this.#client) {
+      throw new ClientNotInitializedError();
+    }
+
+    const result = await this.#client.fetchInboxUpdatesCount(inboxIds, true);
+
+    return toInboxUpdatesCountMap(result);
+  }
+
+  /**
+   * Fetches the latest inbox updates count for the client's inbox
+   *
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns The latest inbox updates count
+   * @throws {ClientNotInitializedError} if the client is not initialized
+   */
+  async fetchOwnInboxUpdatesCount(_refreshFromNetwork = true) {
+    if (!this.#client) {
+      throw new ClientNotInitializedError();
+    }
+
+    return this.#client.fetchOwnInboxUpdatesCount(true);
+  }
+
+  /**
    * Fetches the key package statuses from the network for the specified
    * installation IDs
    *
@@ -819,6 +872,59 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   ) {
     const backend = await resolveBackend(envOrBackend, gatewayHost);
     return fetchInboxStatesByInboxIds(backend, inboxIds);
+  }
+
+  /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   * without a client
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param backend - Optional `Backend` instance created with `createBackend()`
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   */
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    backendOrEnv?: Backend | XmtpEnv,
+    refreshFromNetwork?: boolean,
+  ): Promise<Map<string, number>>;
+  /**
+   * Fetches the latest inbox updates count for the specified inbox IDs
+   * without a client
+   *
+   * @param inboxIds - The inbox IDs to check
+   * @param env - The environment to use
+   * @param gatewayHost - Optional gateway host
+   * @param refreshFromNetwork - Whether to refresh from the network
+   * @returns Map of inbox IDs to their updates count
+   * @deprecated Pass a `Backend` instance created with `createBackend()` instead
+   * of `XmtpEnv` and `gatewayHost`.
+   */
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    env?: XmtpEnv,
+    gatewayHost?: string,
+    refreshFromNetwork?: boolean,
+  ): Promise<Map<string, number>>;
+  static async fetchLatestInboxUpdatesCount(
+    inboxIds: string[],
+    envOrBackend?: XmtpEnv | Backend,
+    gatewayHostOrRefresh?: string | boolean,
+    _refreshFromNetwork = true,
+  ) {
+    const gatewayHost =
+      typeof gatewayHostOrRefresh === "string"
+        ? gatewayHostOrRefresh
+        : undefined;
+    const backend = await resolveBackend(envOrBackend, gatewayHost);
+    const { client } = await createClient(createEphemeralIdentifier(), {
+      backend,
+      dbPath: null,
+      disableDeviceSync: true,
+    });
+    const result = await client.fetchInboxUpdatesCount(inboxIds, true);
+
+    return toInboxUpdatesCountMap(result);
   }
 
   /**

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -729,14 +729,10 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * Fetches the latest inbox updates count for the specified inbox IDs
    *
    * @param inboxIds - The inbox IDs to check
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    * @throws {ClientNotInitializedError} if the client is not initialized
    */
-  async fetchLatestInboxUpdatesCount(
-    inboxIds: string[],
-    _refreshFromNetwork = true,
-  ) {
+  async fetchLatestInboxUpdatesCount(inboxIds: string[]) {
     if (!this.#client) {
       throw new ClientNotInitializedError();
     }
@@ -749,11 +745,10 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   /**
    * Fetches the latest inbox updates count for the client's inbox
    *
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns The latest inbox updates count
    * @throws {ClientNotInitializedError} if the client is not initialized
    */
-  async fetchOwnInboxUpdatesCount(_refreshFromNetwork = true) {
+  async fetchOwnInboxUpdatesCount() {
     if (!this.#client) {
       throw new ClientNotInitializedError();
     }
@@ -880,13 +875,11 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    *
    * @param inboxIds - The inbox IDs to check
    * @param backend - Optional `Backend` instance created with `createBackend()`
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    */
   static async fetchLatestInboxUpdatesCount(
     inboxIds: string[],
     backendOrEnv?: Backend | XmtpEnv,
-    refreshFromNetwork?: boolean,
   ): Promise<Map<string, number>>;
   /**
    * Fetches the latest inbox updates count for the specified inbox IDs
@@ -895,7 +888,6 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
    * @param inboxIds - The inbox IDs to check
    * @param env - The environment to use
    * @param gatewayHost - Optional gateway host
-   * @param refreshFromNetwork - Whether to refresh from the network
    * @returns Map of inbox IDs to their updates count
    * @deprecated Pass a `Backend` instance created with `createBackend()` instead
    * of `XmtpEnv` and `gatewayHost`.
@@ -904,18 +896,12 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     inboxIds: string[],
     env?: XmtpEnv,
     gatewayHost?: string,
-    refreshFromNetwork?: boolean,
   ): Promise<Map<string, number>>;
   static async fetchLatestInboxUpdatesCount(
     inboxIds: string[],
     envOrBackend?: XmtpEnv | Backend,
-    gatewayHostOrRefresh?: string | boolean,
-    _refreshFromNetwork = true,
+    gatewayHost?: string,
   ) {
-    const gatewayHost =
-      typeof gatewayHostOrRefresh === "string"
-        ? gatewayHostOrRefresh
-        : undefined;
     const backend = await resolveBackend(envOrBackend, gatewayHost);
     const { client } = await createClient(createEphemeralIdentifier(), {
       backend,

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -903,6 +903,11 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
     gatewayHost?: string,
   ) {
     const backend = await resolveBackend(envOrBackend, gatewayHost);
+    // The node-bindings Client is a napi-rs class with no explicit close/free
+    // method. Release is non-deterministic: once this reference goes out of
+    // scope, JS GC will eventually invoke the Rust Drop impl and reclaim the
+    // underlying resources. If this becomes a bottleneck, switch to an
+    // explicit disposal API if/when the bindings expose one.
     const { client } = await createClient(createEphemeralIdentifier(), {
       backend,
       dbPath: null,

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -541,6 +541,43 @@ describe("Client", () => {
     ]);
   });
 
+  it("should get latest inbox updates count from inbox IDs without a client", async () => {
+    const { signer } = createSigner();
+    const client = await createRegisteredClient(signer);
+    const inboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
+      [client.inboxId],
+      "local",
+    );
+    expect(inboxUpdatesCounts.get(client.inboxId)).toBeTypeOf("number");
+
+    const freshInboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
+      [client.inboxId],
+      "local",
+      true,
+    );
+    expect(freshInboxUpdatesCounts.get(client.inboxId)).toBeTypeOf("number");
+  });
+
+  it("should get own inbox updates count from a client", async () => {
+    const { signer } = createSigner();
+    const client = await createRegisteredClient(signer);
+    const inboxUpdatesCounts = await client.fetchLatestInboxUpdatesCount([
+      client.inboxId,
+    ]);
+    const ownInboxUpdatesCount = await client.fetchOwnInboxUpdatesCount();
+    expect(inboxUpdatesCounts.get(client.inboxId)).toBe(ownInboxUpdatesCount);
+
+    const explicitFreshInboxUpdatesCounts =
+      await client.fetchLatestInboxUpdatesCount([client.inboxId], true);
+    expect(explicitFreshInboxUpdatesCounts.get(client.inboxId)).toBeTypeOf(
+      "number",
+    );
+
+    const explicitFreshOwnInboxUpdatesCount =
+      await client.fetchOwnInboxUpdatesCount(true);
+    expect(explicitFreshOwnInboxUpdatesCount).toBeTypeOf("number");
+  });
+
   it("should transfer an identifier to a new inbox", async () => {
     // original signer
     const { signer, identifier } = createSigner();

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -549,13 +549,6 @@ describe("Client", () => {
       "local",
     );
     expect(inboxUpdatesCounts.get(client.inboxId)).toBeTypeOf("number");
-
-    const freshInboxUpdatesCounts = await Client.fetchLatestInboxUpdatesCount(
-      [client.inboxId],
-      "local",
-      true,
-    );
-    expect(freshInboxUpdatesCounts.get(client.inboxId)).toBeTypeOf("number");
   });
 
   it("should get own inbox updates count from a client", async () => {
@@ -567,15 +560,8 @@ describe("Client", () => {
     const ownInboxUpdatesCount = await client.fetchOwnInboxUpdatesCount();
     expect(inboxUpdatesCounts.get(client.inboxId)).toBe(ownInboxUpdatesCount);
 
-    const explicitFreshInboxUpdatesCounts =
-      await client.fetchLatestInboxUpdatesCount([client.inboxId], true);
-    expect(explicitFreshInboxUpdatesCounts.get(client.inboxId)).toBeTypeOf(
-      "number",
-    );
-
-    const explicitFreshOwnInboxUpdatesCount =
-      await client.fetchOwnInboxUpdatesCount(true);
-    expect(explicitFreshOwnInboxUpdatesCount).toBeTypeOf("number");
+    expect(inboxUpdatesCounts.get(client.inboxId)).toBeTypeOf("number");
+    expect(ownInboxUpdatesCount).toBeTypeOf("number");
   });
 
   it("should transfer an identifier to a new inbox", async () => {


### PR DESCRIPTION
key-check.eth has used 81 identity log updates on prod:

<img width="1071" height="694" alt="image" src="https://github.com/user-attachments/assets/dbef0e2a-f759-417d-a50f-03cc13d6753c" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `fetchLatestInboxUpdatesCount` to browser SDK, Node SDK, and xmtp.chat
> - Adds `fetchLatestInboxUpdatesCount` and `fetchOwnInboxUpdatesCount` instance methods to both the browser and Node SDK `Client` classes, always requesting a network refresh.
> - Adds static `Client.fetchLatestInboxUpdatesCount` overloads to both SDKs, allowing callers to fetch counts without constructing a full client by using an ephemeral identifier internally.
> - Wires the new actions through the browser SDK web worker and `WorkerClient` via two new action types in [client.ts](https://github.com/xmtp/xmtp-js/pull/1784/files#diff-854d64289c974474e2397ab2ff2d0de3f89e6995cfbd2a5e35cd0facfaf9d986).
> - Updates the [InboxTools](https://github.com/xmtp/xmtp-js/pull/1784/files#diff-ffc713618933e71b66143557c3105753b5e740263209ebc763d7f4b5e22a6f7d) UI with a "Check updates count" button and a display section for the fetched count, clearing it on disconnect or when the inbox ID/environment changes.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #1784 opened
>
> - Replaced ephemeral address presence checks with `ephemeralAccountEnabled` boolean flag in `InboxTools` component UI conditions [4314db5]
> - Removed `refreshFromNetwork` parameter from `Client.fetchLatestInboxUpdatesCount`, `Client.fetchOwnInboxUpdatesCount`, and static `Client.fetchLatestInboxUpdatesCount` methods in both `browser-sdk` and `node-sdk` packages [13d075a]
> - Updated `WorkerClient.fetchLatestInboxUpdatesCount` and `WorkerClient.fetchOwnInboxUpdatesCount` in `browser-sdk` to remove `refreshFromNetwork` parameter, introducing incorrect argument passing to underlying client methods [13d075a]
> - Updated `ClientAction` union type in `browser-sdk` to remove `refreshFromNetwork` field from worker message schemas for actions `client.fetchLatestInboxUpdatesCount` and `client.fetchOwnInboxUpdatesCount` [13d075a]
> - Updated client worker message handler in `browser-sdk` to call `client.fetchLatestInboxUpdatesCount` and `client.fetchOwnInboxUpdatesCount` without `refreshFromNetwork` parameter [13d075a]
> - Removed test cases that explicitly passed `refreshFromNetwork` boolean parameter to `Client.fetchLatestInboxUpdatesCount` and `Client.fetchOwnInboxUpdatesCount` in both `browser-sdk` and `node-sdk` test files [13d075a]
> - Wrapped the `Client.fetchLatestInboxUpdatesCount` static method in the `browser-sdk` package in a try/finally block that calls `client.free()` in the finally clause to ensure the ephemeral WASM client is freed even when the fetch operation rejects [2c418a4]
> - Added an explanatory comment to the `Client.fetchLatestInboxUpdatesCount` static method in the `node-sdk` package documenting that the node-bindings Client lacks an explicit close or free method and will be reclaimed by garbage collection when out of scope [2c418a4]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9eeb03e. 7 files reviewed, 11 issues evaluated, 9 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 235](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/apps/xmtp.chat/src/components/InboxTools/InboxTools.tsx#L235): The condition `address || ephemeralAddress` at line 235 (and similarly at line 207) will always be truthy because `ephemeralAddress` from `useEphemeralSigner()` is always computed as a valid address string (the hook always generates or retrieves a private key). This means the `WalletConnect` component in the else branch (lines 244-248) will never be rendered, and the "Wallet connection required" text (lines 208-210) will never appear. The condition should likely use `ephemeralAccountEnabled` instead of `ephemeralAddress` to check whether the user has actually enabled ephemeral mode, matching the pattern used in the removed `useEffect` and in `handleRevokeInstallations` (line 109). <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>sdks/browser-sdk/src/Client.ts — 0 comments posted, 6 evaluated, 5 filtered</summary>
>
> - [line 761](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/browser-sdk/src/Client.ts#L761): The `_refreshFromNetwork` parameter in `fetchLatestInboxUpdatesCount` is documented as controlling whether to refresh from the network, but the code ignores it and always passes `refreshFromNetwork: true` to the worker action. This makes the parameter useless and the documented behavior incorrect. <b>[ Already posted ]</b>
> - [line 768](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/browser-sdk/src/Client.ts#L768): The `_refreshFromNetwork` parameter is completely ignored. The worker action is always called with `refreshFromNetwork: true` hardcoded, meaning callers who pass `false` to skip network refresh will still trigger a network refresh. The parameter should be used: `refreshFromNetwork: _refreshFromNetwork` instead of `refreshFromNetwork: true`. <b>[ Already posted ]</b>
> - [line 776](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/browser-sdk/src/Client.ts#L776): The `_refreshFromNetwork` parameter in `fetchOwnInboxUpdatesCount` is documented as controlling whether to refresh from the network, but the code ignores it and always passes `refreshFromNetwork: true` to the worker action. <b>[ Cross-file consolidated ]</b>
> - [line 789](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/browser-sdk/src/Client.ts#L789): The `_refreshFromNetwork` parameter is completely ignored. The worker action is always called with `refreshFromNetwork: true` hardcoded, meaning callers who pass `false` to skip network refresh will still trigger a network refresh. The parameter should be used: `refreshFromNetwork: _refreshFromNetwork` instead of `refreshFromNetwork: true`. <b>[ Out of scope ]</b>
> - [line 865](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/browser-sdk/src/Client.ts#L865): Potential resource leak in `static fetchLatestInboxUpdatesCount`: The client created via `createLowLevelClient()` at line 865 is never closed after use. Even though `dbPath: null` and `disableDeviceSync: true` are passed, the underlying WASM client may hold network connections or other resources that should be released. Consider adding cleanup after the `fetchLatestInboxUpdatesCount` call (e.g., wrapping in try/finally with client cleanup). <b>[ Already posted ]</b>
> </details>
>
> <details>
> <summary>sdks/node-sdk/src/Client.ts — 1 comment posted, 4 evaluated, 3 filtered</summary>
>
> - [line 744](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/node-sdk/src/Client.ts#L744): The `_refreshFromNetwork` parameter in `fetchLatestInboxUpdatesCount` (instance method) is documented to control whether to refresh from the network, but the implementation ignores it and always passes `true` to `this.#client.fetchInboxUpdatesCount()`. The parameter should be used: `await this.#client.fetchInboxUpdatesCount(inboxIds, _refreshFromNetwork)`. <b>[ Already posted ]</b>
> - [line 752](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/node-sdk/src/Client.ts#L752): The `_refreshFromNetwork` parameter is declared but completely ignored. The method always passes `true` to `this.#client.fetchInboxUpdatesCount()` regardless of what value the caller provides. If a caller passes `false` expecting to use cached data, their intent will be silently ignored. <b>[ Already posted ]</b>
> - [line 925](https://github.com/xmtp/xmtp-js/blob/9eeb03e533e65a0238792583fa1afd079726465e/sdks/node-sdk/src/Client.ts#L925): The `_refreshFromNetwork` parameter in the static `fetchLatestInboxUpdatesCount` method is documented to control whether to refresh from the network, but the implementation ignores it and always passes `true` to `client.fetchInboxUpdatesCount()`. The parameter should be used: `await client.fetchInboxUpdatesCount(inboxIds, _refreshFromNetwork)`. <b>[ Already posted ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->