### PR TITLE
test: restore global.fetch after mocking in AttachmentUtil tests

### DIFF
--- a/sdks/agent-sdk/src/util/AttachmentUtil.test.ts
+++ b/sdks/agent-sdk/src/util/AttachmentUtil.test.ts
@@ -17,13 +17,16 @@ import {
 describe("AttachmentUtil", () => {
   const testUrl = "https://localhost/test_file";
   let mockFetch: Mock;
-
+  let originalFetch: typeof global.fetch;
+  
   beforeEach(() => {
+    originalFetch = global.fetch;
     mockFetch = vi.fn();
     global.fetch = mockFetch;
   });
-
+  
   afterEach(() => {
+    global.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
Restore global.fetch after mocking in AttachmentUtil tests to avoid leaking global state between tests and improve test isolation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `global.fetch` after mocking in `AttachmentUtil` tests
> Saves the original `global.fetch` before replacing it with a `vi.fn()` mock in `beforeEach`, then restores it in `afterEach` before calling `vi.restoreAllMocks()`. Previously, `global.fetch` was left mocked after each test, which could leak state into other test suites.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 643ab6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->