### PR TITLE
fix: use wallet address as DM title fallback

### DIFF
--- a/apps/xmtp.chat/src/stores/inbox/store.test.ts
+++ b/apps/xmtp.chat/src/stores/inbox/store.test.ts
@@ -1,0 +1,41 @@
+import type { GroupMember } from "@xmtp/browser-sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import { getDmConversationName } from "@/stores/inbox/store";
+import { profilesStore } from "@/stores/profiles";
+
+const createMember = (address: string): GroupMember =>
+  ({
+    accountIdentifiers: [
+      {
+        identifier: address,
+        identifierKind: "Ethereum",
+      },
+    ],
+    inboxId: "peer-inbox-id",
+  }) as unknown as GroupMember;
+
+describe("getDmConversationName", () => {
+  afterEach(() => {
+    profilesStore.getState().reset();
+  });
+
+  it("uses the member wallet address when no display name is available", () => {
+    const address = "0x1234567890123456789012345678901234567890";
+
+    expect(getDmConversationName(createMember(address))).toBe(address);
+  });
+
+  it("uses the profile display name when one is available", () => {
+    const address = "0x1234567890123456789012345678901234567890";
+    profilesStore.getState().addProfile({
+      address,
+      avatar: null,
+      description: null,
+      displayName: "vitalik.eth",
+      identity: "vitalik.eth",
+      platform: "ens",
+    });
+
+    expect(getDmConversationName(createMember(address))).toBe("vitalik.eth");
+  });
+});

--- a/apps/xmtp.chat/src/stores/inbox/store.ts
+++ b/apps/xmtp.chat/src/stores/inbox/store.ts
@@ -18,12 +18,18 @@ import {
   sortConversations,
   sortMessages,
 } from "@/stores/inbox/utils";
-import { profilesStore } from "@/stores/profiles";
+import { combineProfiles, profilesStore } from "@/stores/profiles";
 
 export type ConversationMetadata = {
   name?: string;
   description?: string;
   imageUrl?: string;
+};
+
+export const getDmConversationName = (member: GroupMember) => {
+  const address = getMemberAddress(member);
+  const profiles = profilesStore.getState().getProfiles(address);
+  return combineProfiles(address, profiles).displayName ?? address;
 };
 
 // alias types for clarity
@@ -122,16 +128,9 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
           (m) => m.inboxId !== conversation.addedByInboxId,
         );
         if (member) {
-          const profiles = profilesStore
-            .getState()
-            .getProfiles(getMemberAddress(member));
-          let displayName = member.inboxId;
-          if (profiles.length > 0) {
-            displayName = profiles[0].displayName ?? displayName;
-          }
           // update metadata state
           newMetadata.set(conversation.id, {
-            name: displayName,
+            name: getDmConversationName(member),
           });
         }
       }
@@ -214,16 +213,9 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
             (m) => m.inboxId !== conversation.addedByInboxId,
           );
           if (member) {
-            const profiles = profilesStore
-              .getState()
-              .getProfiles(getMemberAddress(member));
-            let displayName = member.inboxId;
-            if (profiles.length > 0) {
-              displayName = profiles[0].displayName ?? displayName;
-            }
             // update metadata state
             newMetadata.set(conversation.id, {
-              name: displayName,
+              name: getDmConversationName(member),
             });
           }
         }


### PR DESCRIPTION
## Summary
- use the peer wallet address as the fallback title for DM conversations
- keep resolved profile display names when they are available
- add coverage for the DM title fallback behavior

Fixes #1596

## Testing
- git diff --cached --check
- Not run: xmtp.chat tests/typecheck because \yarn install --immutable\ and \yarn install --immutable --mode=skip-build\ both hung before creating \
ode_modules\ or emitting Yarn progress output.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use wallet address as DM conversation name fallback instead of inbox ID
> - Adds `getDmConversationName` in [store.ts](https://github.com/xmtp/xmtp-js/pull/1793/files#diff-572e773e875d19026abd898404b7ae68fa8a96aaf08601ef5294728d3cb9fce3) that resolves a DM member's display name by checking their combined profile's `displayName`, falling back to their wallet address.
> - Updates `inboxStore` to call `getDmConversationName` in both DM metadata-setting paths, replacing inline logic that previously fell back to `member.inboxId`.
> - Behavioral Change: DM conversation names now show the wallet address (e.g. `0x...`) instead of the inbox ID when no profile display name is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c217fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->