### PR TITLE
fix: detect remote static attachments in chat

### DIFF
--- a/.changeset/sour-jobs-share.md
+++ b/.changeset/sour-jobs-share.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+fix: detect remote static attachments in chat

--- a/apps/xmtp.chat/src/helpers/messages.test.ts
+++ b/apps/xmtp.chat/src/helpers/messages.test.ts
@@ -1,5 +1,6 @@
 import {
   contentTypeReaction,
+  contentTypeRemoteAttachment,
   contentTypeReply,
   contentTypeText,
   DeliveryStatus,
@@ -9,10 +10,11 @@ import {
   type DecodedMessage,
   type EnrichedReply,
   type Reaction,
+  type RemoteAttachment,
 } from "@xmtp/browser-sdk";
 import { type ContentTypeId } from "@xmtp/content-type-primitives";
 import { describe, expect, it } from "vitest";
-import { stringify } from "./messages";
+import { isActionable, isRemoteAttachment, stringify } from "./messages";
 
 const createDecodedMessage = <T>(
   content: T,
@@ -96,5 +98,27 @@ describe("stringify", () => {
       fallback,
     );
     expect(stringify(decodedMessage)).toBe(fallback);
+  });
+});
+
+describe("isRemoteAttachment", () => {
+  it("recognizes remote static attachment messages", async () => {
+    const content: RemoteAttachment = {
+      contentDigest: "digest",
+      contentLength: 42,
+      filename: "image.png",
+      nonce: new Uint8Array([1]),
+      salt: new Uint8Array([2]),
+      secret: new Uint8Array([3]),
+      scheme: "https://",
+      url: "https://example.com/image.png",
+    };
+    const decodedMessage = createDecodedMessage(
+      content,
+      await contentTypeRemoteAttachment(),
+    );
+
+    expect(isRemoteAttachment(decodedMessage)).toBe(true);
+    expect(isActionable(decodedMessage)).toBe(true);
   });
 });

--- a/apps/xmtp.chat/src/helpers/messages.ts
+++ b/apps/xmtp.chat/src/helpers/messages.ts
@@ -24,7 +24,7 @@ export const isText = (m: DecodedMessage): m is DecodedMessage<string> =>
 export const isRemoteAttachment = (
   m: DecodedMessage,
 ): m is DecodedMessage<RemoteAttachment> =>
-  m.contentType.typeId === "staticRemoteAttachment";
+  m.contentType.typeId === "remoteStaticAttachment";
 
 export const stringify = (message: DecodedMessage): string => {
   switch (true) {


### PR DESCRIPTION
## Summary
- fix xmtp.chat remote attachment detection to use the canonical \emoteStaticAttachment\ content type
- add regression coverage so remote static attachments remain actionable

Fixes xmtp/libxmtp#3986

## Testing
- git diff --check
- git diff --cached --check
- Not run: \yarn workspace @xmtp/xmtp.chat test apps/xmtp.chat/src/helpers/messages.test.ts\ because Yarn reports the checkout is missing its node_modules state file; prior \yarn install --immutable\ attempts in this checkout hung before creating \
ode_modules\.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isRemoteAttachment` to detect remote static attachments in chat
> Corrects a typo in [messages.ts](https://github.com/xmtp/xmtp-js/pull/1794/files#diff-e25bc61422cad463c89cbc7b322ca3fd772099192a81be1fd043d58452d70580) where the `contentType.typeId` was compared against `'staticRemoteAttachment'` instead of the correct value `'remoteStaticAttachment'`. Adds a test to verify that `isRemoteAttachment` and `isActionable` both return true for a properly constructed remote attachment message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized deb8517.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->