### PR TITLE
fix: parse decimal wallet send calls chain IDs

### DIFF
--- a/.changeset/purple-lizards-whisper.md
+++ b/.changeset/purple-lizards-whisper.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+fix: parse decimal wallet send calls chain IDs

--- a/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
+++ b/apps/xmtp.chat/src/components/Messages/WalletSendCallsContent.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { useChainId, useSendTransaction, useSwitchChain } from "wagmi";
 import { useConversationContext } from "@/contexts/ConversationContext";
 import { useClient } from "@/contexts/XMTPContext";
+import { parseWalletSendCallsChainId } from "@/helpers/walletSendCalls";
 import { useSettings } from "@/hooks/useSettings";
 
 export type WalletSendCallsContentProps = {
@@ -21,7 +22,7 @@ export const WalletSendCallsContent: React.FC<WalletSendCallsContentProps> = ({
   const { ephemeralAccountEnabled } = useSettings();
 
   const handleSubmit = useCallback(async () => {
-    const chainId = parseInt(content.chainId, 16);
+    const chainId = parseWalletSendCallsChainId(content.chainId);
     if (chainId !== wagmiChainId) {
       console.log(
         `Current Chain Id (${wagmiChainId}) doesn't match; switching to Chain Id ${chainId}.`,
@@ -55,7 +56,14 @@ export const WalletSendCallsContent: React.FC<WalletSendCallsContentProps> = ({
       }
       await conversation.sendTransactionReference(transactionReference);
     }
-  }, [content, sendTransactionAsync, client, conversationId]);
+  }, [
+    client,
+    content,
+    conversationId,
+    sendTransactionAsync,
+    switchChainAsync,
+    wagmiChainId,
+  ]);
 
   return (
     <Box flex="flex">

--- a/apps/xmtp.chat/src/helpers/walletSendCalls.test.ts
+++ b/apps/xmtp.chat/src/helpers/walletSendCalls.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { parseWalletSendCallsChainId } from "./walletSendCalls";
+
+describe("parseWalletSendCallsChainId", () => {
+  it("parses hex chain IDs", () => {
+    expect(parseWalletSendCallsChainId("0x2105")).toBe(8453);
+  });
+
+  it("parses decimal chain IDs", () => {
+    expect(parseWalletSendCallsChainId("8453")).toBe(8453);
+  });
+});

--- a/apps/xmtp.chat/src/helpers/walletSendCalls.ts
+++ b/apps/xmtp.chat/src/helpers/walletSendCalls.ts
@@ -1,0 +1,5 @@
+export const parseWalletSendCallsChainId = (chainId: string) => {
+  return chainId.toLowerCase().startsWith("0x")
+    ? parseInt(chainId, 16)
+    : parseInt(chainId, 10);
+};


### PR DESCRIPTION
## Summary
- parse wallet send calls chain IDs as hex only when they use the \

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chain ID parsing in `WalletSendCallsContent` to handle decimal and hex strings
> Adds a `parseWalletSendCallsChainId` helper in [walletSendCalls.ts](https://github.com/xmtp/xmtp-js/pull/1795/files#diff-6e78f484a7eb0d62bfd064157eb0eecddbde42def650b7b937cdc881181212fa) that parses chain IDs from either hex (`0x...`) or decimal string format. Previously, `WalletSendCallsContent` used `parseInt(chainId, 16)` unconditionally, causing incorrect chain IDs when the value was a decimal string. The `handleSubmit` callback dependency array is also updated to include `switchChainAsync` and `wagmiChainId`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a73cdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->