### PR TITLE
fix: ignore runtime.sendMessage errors in chat

### DIFF
--- a/.changeset/quiet-windows-smile.md
+++ b/.changeset/quiet-windows-smile.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+fix: ignore runtime.sendMessage browser extension errors

--- a/apps/xmtp.chat/src/helpers/sentry.test.ts
+++ b/apps/xmtp.chat/src/helpers/sentry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { shouldIgnoreError } from "./sentry";
+
+describe("shouldIgnoreError", () => {
+  it("ignores runtime.sendMessage errors", () => {
+    expect(
+      shouldIgnoreError(
+        new Error(
+          "Error in invocation of runtime.sendMessage: No matching signature.",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores runtime.sendMessage strings", () => {
+    expect(
+      shouldIgnoreError("Error in invocation of runtime.sendMessage"),
+    ).toBe(true);
+  });
+
+  it("does not ignore unrelated errors", () => {
+    expect(shouldIgnoreError(new Error("Unable to connect"))).toBe(false);
+  });
+});

--- a/apps/xmtp.chat/src/helpers/sentry.ts
+++ b/apps/xmtp.chat/src/helpers/sentry.ts
@@ -1,0 +1,21 @@
+const IGNORED_ERROR_MESSAGES = ["runtime.sendMessage"];
+
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return undefined;
+};
+
+export const shouldIgnoreError = (error: unknown) => {
+  const message = getErrorMessage(error);
+  if (!message) {
+    return false;
+  }
+  return IGNORED_ERROR_MESSAGES.some((ignoredMessage) =>
+    message.includes(ignoredMessage),
+  );
+};

--- a/apps/xmtp.chat/src/main.tsx
+++ b/apps/xmtp.chat/src/main.tsx
@@ -37,6 +37,7 @@ import {
 import { App } from "@/components/App/App";
 import { XMTPProvider } from "@/contexts/XMTPContext";
 import { queryClient } from "@/helpers/queries";
+import { shouldIgnoreError } from "@/helpers/sentry";
 
 Sentry.init({
   dsn: "https://ba2f58ad2e3d5fd09cd8aa36038b950f@o4504757119680512.ingest.us.sentry.io/4510308912005120",
@@ -47,6 +48,17 @@ Sentry.init({
   replaysSessionSampleRate: 0,
   sendDefaultPii: false,
   tracesSampleRate: 0,
+  beforeSend: (event, hint) => {
+    if (
+      shouldIgnoreError(hint.originalException) ||
+      event.exception?.values?.some((exception) =>
+        shouldIgnoreError(exception.value),
+      )
+    ) {
+      return null;
+    }
+    return event;
+  },
 });
 
 export const config = createConfig({


### PR DESCRIPTION
## Summary
- filter known browser extension runtime.sendMessage errors before Sentry reports them
- add focused coverage for Error and string forms of the ignored error
- add a patch changeset for @xmtp/xmtp.chat

Fixes xmtp/libxmtp#3994

## Testing
- git diff --check
- git diff --cached --check
- Not run: \yarn workspace @xmtp/xmtp.chat test apps/xmtp.chat/src/helpers/sentry.test.ts\ because Yarn reports the checkout is missing its node_modules state file; prior \yarn install --immutable\ attempts in this checkout hung before creating \
ode_modules\.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore `runtime.sendMessage` browser extension errors in Sentry
> Adds a `beforeSend` callback to `Sentry.init` in [main.tsx](https://github.com/xmtp/xmtp-js/pull/1799/files#diff-11f60809f1f0b15283feb4fc7277cd6813fd3b810b9b9e8c92da6f2a1ab0b4bf) that drops events where the exception message contains `runtime.sendMessage`. The check is handled by a new `shouldIgnoreError` helper in [sentry.ts](https://github.com/xmtp/xmtp-js/pull/1799/files#diff-294ef16a2fc93a2225f509e48d148137b5b04b89971f7eb3635ba75ab48d9e42) that normalizes unknown errors (Error objects or strings) before matching against an ignored-messages list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a244fd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->