### PR TITLE
fix: handle get_inbox_ids DM load errors

### DIFF
--- a/.changeset/clean-dms-search.md
+++ b/.changeset/clean-dms-search.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+fix: avoid reporting handled get_inbox_ids DM load errors

--- a/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
+++ b/apps/xmtp.chat/src/components/Conversation/LoadDM.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { LoadingMessage } from "@/components/LoadingMessage";
 import { useClient } from "@/contexts/XMTPContext";
+import { isGetInboxIdsRequestError } from "@/helpers/errors";
 import { isValidName, resolveNameQuery } from "@/helpers/names";
 import { isValidEthereumAddress } from "@/helpers/strings";
 import { useSettings } from "@/hooks/useSettings";
@@ -93,8 +94,10 @@ export const LoadDM: React.FC = () => {
 
         navigateToHome("Error loading DM, redirecting...");
 
-        // rethrow error for error modal
-        throw e;
+        if (!isGetInboxIdsRequestError(e)) {
+          // rethrow unhandled errors for error modal
+          throw e;
+        }
       }
     };
 

--- a/apps/xmtp.chat/src/helpers/errors.test.ts
+++ b/apps/xmtp.chat/src/helpers/errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isGetInboxIdsRequestError } from "./errors";
+
+describe("isGetInboxIdsRequestError", () => {
+  it("detects get_inbox_ids request errors", () => {
+    expect(
+      isGetInboxIdsRequestError(
+        new Error(
+          'api client error api client at endpoint "get_inbox_ids" has error error sending request',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores other errors", () => {
+    expect(isGetInboxIdsRequestError(new Error("Wrong chain id"))).toBe(false);
+    expect(isGetInboxIdsRequestError("get_inbox_ids")).toBe(false);
+  });
+});

--- a/apps/xmtp.chat/src/helpers/errors.ts
+++ b/apps/xmtp.chat/src/helpers/errors.ts
@@ -3,3 +3,14 @@ export class ClientNotFoundError extends Error {
     super(`XMTP client is required when ${context}`);
   }
 }
+
+export const isGetInboxIdsRequestError = (error: unknown) => {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.message.includes('endpoint "get_inbox_ids"') &&
+    error.message.includes("error sending request")
+  );
+};


### PR DESCRIPTION
## Summary
- avoid rethrowing handled get_inbox_ids request failures from the DM loader
- keep rethrowing unexpected DM loader errors for the error modal
- add a regression helper test for the get_inbox_ids error classifier

Closes xmtp/libxmtp#3987

## Testing
- yarn workspace @xmtp/xmtp.chat test apps/xmtp.chat/src/helpers/errors.test.ts *(fails locally: Couldn't find the node_modules state file - running an install might help)*
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `get_inbox_ids` DM load errors being rethrown to the error modal
> When loading a DM fails due to a `get_inbox_ids` request error, the error is now swallowed after redirecting to home instead of being rethrown to the error modal. A new `isGetInboxIdsRequestError` helper in [`helpers/errors.ts`](https://github.com/xmtp/xmtp-js/pull/1800/files#diff-ebe52af488caf00fd9b1643291ad73cab655bd2e8854cfbadf22c1e9ecb7c3e8) detects these errors by matching both `'endpoint "get_inbox_ids"'` and `'error sending request'` in the error message. All other errors in [`LoadDM.tsx`](https://github.com/xmtp/xmtp-js/pull/1800/files#diff-f999c8ef5e116330d863dbca66126681e618fa2e7c75744d86705106e220bc74) continue to be rethrown as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68f9dee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->