### PR TITLE
fix: skip inactive group member refreshes

### DIFF
--- a/.changeset/quiet-groups-rest.md
+++ b/.changeset/quiet-groups-rest.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+fix: skip member refreshes for inactive groups

--- a/apps/xmtp.chat/src/stores/inbox/store.ts
+++ b/apps/xmtp.chat/src/stores/inbox/store.ts
@@ -292,13 +292,12 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
         // member updates
         if (conversation) {
           const isActive = await conversation.isActive();
-          // ensure group is active before syncing
           if (isActive) {
             await conversation.sync();
+            const members = await conversation.members();
+            const updatedMembers = new Map(members.map((m) => [m.inboxId, m]));
+            newMembers.set(message.conversationId, updatedMembers);
           }
-          const members = await conversation.members();
-          const updatedMembers = new Map(members.map((m) => [m.inboxId, m]));
-          newMembers.set(message.conversationId, updatedMembers);
         }
 
         // update metadata state
@@ -374,13 +373,14 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
           const conversation = state.conversations.get(message.conversationId);
           if (conversation) {
             const isActive = await conversation.isActive();
-            // ensure group is active before syncing
             if (isActive) {
               await conversation.sync();
+              const members = await conversation.members();
+              const updatedMembers = new Map(
+                members.map((m) => [m.inboxId, m]),
+              );
+              newMembers.set(message.conversationId, updatedMembers);
             }
-            const members = await conversation.members();
-            const updatedMembers = new Map(members.map((m) => [m.inboxId, m]));
-            newMembers.set(message.conversationId, updatedMembers);
           }
 
           // metadata updates


### PR DESCRIPTION
## Summary
- only refresh group members after group update messages when the group is active
- avoid calling members() on inactive groups in both single-message and batch-message store updates
- add a changeset for xmtp.chat

Closes xmtp/libxmtp#3983

## Testing
- yarn workspace @xmtp/xmtp.chat test *(fails locally: Couldn't find the node_modules state file - running an install might help)*
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip member refreshes for inactive groups on `GroupUpdated` messages
> In the `GroupUpdated` message handler in [store.ts](https://github.com/xmtp/xmtp-js/pull/1801/files#diff-572e773e875d19026abd898404b7ae68fa8a96aaf08601ef5294728d3cb9fce3), member retrieval and `newMembers.set()` are now gated behind the `isActive` check. Previously, members were fetched and the members map was updated unconditionally, even for inactive groups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db9a82f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->