### PR TITLE
bump to libxmtp nightly 05-15-2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,11 @@ sdks/js-sdk/bench/results
 # local database files
 **/*.db3*
 
+.direnv
+.direnv/**
+**/.direnv/**
+result
+result/**
+result-*
+result-*/**
+**/result-*/**

--- a/content-types/content-type-primitives/package.json
+++ b/content-types/content-type-primitives/package.json
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@xmtp/node-bindings": "1.10.0-dev.ae5ffba"
+    "@xmtp/node-bindings": "1.10.0-nightly.20260515.55ad124"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        { pkgs, ... }:
+        {
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              corepack
+            ];
+          };
+        };
+    };
+}

--- a/sdks/browser-sdk/package.json
+++ b/sdks/browser-sdk/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-primitives": "3.0.0",
-    "@xmtp/wasm-bindings": "1.10.0-dev.ae5ffba"
+    "@xmtp/wasm-bindings": "1.10.0-nightly.20260515.55ad124"
   },
   "devDependencies": {
     "@rollup/plugin-terser": "^0.4.4",

--- a/sdks/node-sdk/package.json
+++ b/sdks/node-sdk/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@xmtp/content-type-primitives": "3.0.0",
-    "@xmtp/node-bindings": "1.10.0-dev.ae5ffba"
+    "@xmtp/node-bindings": "1.10.0-nightly.20260515.55ad124"
   },
   "devDependencies": {
     "@rollup/plugin-json": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6414,7 +6414,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.0.18"
     "@web/rollup-plugin-copy": "npm:^0.5.1"
     "@xmtp/content-type-primitives": "npm:3.0.0"
-    "@xmtp/wasm-bindings": "npm:1.10.0-dev.ae5ffba"
+    "@xmtp/wasm-bindings": "npm:1.10.0-nightly.20260515.55ad124"
     playwright: "npm:^1.58.0"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.3.0"
@@ -6506,7 +6506,7 @@ __metadata:
     "@rollup/plugin-terser": "npm:^0.4.4"
     "@rollup/plugin-typescript": "npm:^12.3.0"
     "@types/node": "npm:^24.10.9"
-    "@xmtp/node-bindings": "npm:1.10.0-dev.ae5ffba"
+    "@xmtp/node-bindings": "npm:1.10.0-nightly.20260515.55ad124"
     rimraf: "npm:^6.1.2"
     rollup: "npm:^4.59.0"
     rollup-plugin-dts: "npm:^6.3.0"
@@ -6657,10 +6657,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@xmtp/node-bindings@npm:1.10.0-dev.ae5ffba":
-  version: 1.10.0-dev.ae5ffba
-  resolution: "@xmtp/node-bindings@npm:1.10.0-dev.ae5ffba"
-  checksum: 10/dc53b1673a3f26a0c06387a788084edcad3e5fedda9e903eddbd6ff701e753e55049033fb64ab0d2a609aef1f417d8f6c31684da4059d9e303c6013e20a844a2
+"@xmtp/node-bindings@npm:1.10.0-nightly.20260515.55ad124":
+  version: 1.10.0-nightly.20260515.55ad124
+  resolution: "@xmtp/node-bindings@npm:1.10.0-nightly.20260515.55ad124"
+  checksum: 10/cc6e7e561736391a3feeb4eb801a45416cd0cf1c0c71f728ab3476151a402c3e6134c94fe393a7b7bad67d4c9a20d89940524c9883a3d948aedf3067da0d1196
   languageName: node
   linkType: hard
 
@@ -6699,7 +6699,7 @@ __metadata:
     "@types/node": "npm:^24.10.9"
     "@vitest/coverage-v8": "npm:^4.0.18"
     "@xmtp/content-type-primitives": "npm:3.0.0"
-    "@xmtp/node-bindings": "npm:1.10.0-dev.ae5ffba"
+    "@xmtp/node-bindings": "npm:1.10.0-nightly.20260515.55ad124"
     fast-glob: "npm:^3.3.3"
     rimraf: "npm:^6.1.2"
     rollup: "npm:^4.59.0"
@@ -6740,10 +6740,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmtp/wasm-bindings@npm:1.10.0-dev.ae5ffba":
-  version: 1.10.0-dev.ae5ffba
-  resolution: "@xmtp/wasm-bindings@npm:1.10.0-dev.ae5ffba"
-  checksum: 10/3c42f835bd6357b5fca3c9d6972b152cea4300c91c8394e47e23d5ccbef7a71602d18e2e07cf30df64972f3001cc4defa286a06d14a1437be4c6f54d9d33fee4
+"@xmtp/wasm-bindings@npm:1.10.0-nightly.20260515.55ad124":
+  version: 1.10.0-nightly.20260515.55ad124
+  resolution: "@xmtp/wasm-bindings@npm:1.10.0-nightly.20260515.55ad124"
+  checksum: 10/5a0ba225ecf23cad02f72eec1d2f18f198102f850527d0d09f0d8b821a1201fc5f2bd0b09d03cb7139877109d8cf40482b62406b718c9eb48043760bf6016c03
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Bump libxmtp nightly bindings to 2026-05-15
Updates `@xmtp/node-bindings` and `@xmtp/wasm-bindings` from `1.10.0-dev.ae5ffba` to `1.10.0-nightly.20260515.55ad124` across the node SDK, browser SDK, and content-type-primitives packages. Also adds a Nix flake with a dev shell providing `corepack`, and updates `.gitignore` to exclude Nix/direnv artifacts.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fc0c5c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->