### PR TITLE
Automated node and wasm sdk releases

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,18 @@ jobs:
         run: yarn
       - name: Lint
         run: yarn lint
+
+  validate-renovate-config:
+    name: Validate Renovate config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ".node-version"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
+      - name: Validate renovate.json
+        run: npx --yes -p renovate renovate-config-validator renovate.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,204 @@ jobs:
       - name: Publish
         working-directory: ./sdks/${{ inputs.prerelease_sdk }}
         run: npm publish --tag ${{ inputs.prerelease_tag }}
+
+  auto-prerelease-bindings:
+    name: Auto Prerelease (Bindings) — detect
+    # NOTE: github.actor on push events is the user who merged the PR, not the
+    # commit author. We filter on head_commit.author.name so a human-merged
+    # Renovate PR still triggers publish. Confirmed against this repo's
+    # existing Dependabot squash-merges (which preserve bot authorship).
+    if: >
+      github.event_name == 'push' &&
+      github.event.head_commit.author.name == 'renovate[bot]' &&
+      contains(github.event.head_commit.message, 'xmtp bindings')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+      sdks: ${{ steps.detect.outputs.sdks }}
+      node_bindings: ${{ steps.detect.outputs.node_bindings }}
+      wasm_bindings: ${{ steps.detect.outputs.wasm_bindings }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Detect bindings bump
+        id: detect
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const cp = require('child_process');
+            const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$/;
+
+            const readDep = (rev, path, key) => {
+              try {
+                const json = rev === 'HEAD'
+                  ? fs.readFileSync(path, 'utf8')
+                  : cp.execFileSync('git', ['show', `${rev}:${path}`], { encoding: 'utf8' });
+                return JSON.parse(json).dependencies?.[key] ?? '';
+              } catch {
+                return '';
+              }
+            };
+
+            const diff = (path, key) => {
+              const before = readDep('HEAD^', path, key);
+              const after  = readDep('HEAD',  path, key);
+              if (before === after || !after) return '';
+              if (!VERSION_RE.test(after)) {
+                core.setFailed(`malformed version '${after}' for ${key} in ${path}`);
+                throw new Error('halt');
+              }
+              return after;
+            };
+
+            const nodeBindings = diff('sdks/node-sdk/package.json', '@xmtp/node-bindings');
+            if (nodeBindings) {
+              // primitives must also bump to the same version; missing or
+              // mismatched is an inconsistent partial bump.
+              const primitives = diff('content-types/content-type-primitives/package.json', '@xmtp/node-bindings');
+              if (primitives !== nodeBindings) {
+                core.setFailed(`node-bindings version mismatch: node-sdk=${nodeBindings}, primitives=${primitives || '<unchanged>'}`);
+                throw new Error('halt');
+              }
+            }
+            const wasmBindings = diff('sdks/browser-sdk/package.json', '@xmtp/wasm-bindings');
+
+            const sdks = [
+              ...(nodeBindings ? ['node-sdk'] : []),
+              ...(wasmBindings ? ['browser-sdk'] : []),
+            ];
+            core.setOutput('changed', sdks.length > 0 ? 'true' : 'false');
+            core.setOutput('node_bindings', nodeBindings);
+            core.setOutput('wasm_bindings', wasmBindings);
+            core.setOutput('sdks', JSON.stringify(sdks));
+      - name: Summary
+        run: |
+          {
+            echo "### Bindings detection"
+            echo "- changed: ${{ steps.detect.outputs.changed }}"
+            echo "- node_bindings: ${{ steps.detect.outputs.node_bindings }}"
+            echo "- wasm_bindings: ${{ steps.detect.outputs.wasm_bindings }}"
+            echo "- sdks: ${{ steps.detect.outputs.sdks }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  auto-prerelease-publish:
+    name: Auto Prerelease (Bindings) — publish ${{ matrix.sdk }}
+    needs: auto-prerelease-bindings
+    if: needs.auto-prerelease-bindings.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: ${{ fromJSON(needs.auto-prerelease-bindings.outputs.sdks) }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: ".node-version"
+          cache: "yarn"
+        env:
+          SKIP_YARN_COREPACK_CHECK: "1"
+      - name: Enable corepack
+        run: corepack enable
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+      - name: Install dependencies
+        run: yarn
+      - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
+        run: npm audit signatures
+
+      - name: Compute SDK version
+        id: version
+        uses: actions/github-script@v8
+        env:
+          SDK: ${{ matrix.sdk }}
+          NODE_BINDINGS: ${{ needs.auto-prerelease-bindings.outputs.node_bindings }}
+          WASM_BINDINGS: ${{ needs.auto-prerelease-bindings.outputs.wasm_bindings }}
+        with:
+          script: |
+            const fs = require('fs');
+            const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$/;
+
+            const sdk = process.env.SDK;
+            const bindings = sdk === 'node-sdk' ? process.env.NODE_BINDINGS : process.env.WASM_BINDINGS;
+            if (!bindings) {
+              core.info(`No bindings version for ${sdk}; skipping.`);
+              core.setOutput('sdk_version', '');
+              return;
+            }
+            const dash = bindings.indexOf('-');
+            if (dash < 0) {
+              core.info(`Bindings ${bindings} is stable; skipping publish.`);
+              core.setOutput('sdk_version', '');
+              return;
+            }
+
+            const pkgPath = `sdks/${sdk}/package.json`;
+            let pkg;
+            try {
+              pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+            } catch (err) {
+              core.setFailed(`could not read ${pkgPath}: ${err.message}`);
+              return;
+            }
+            const sdkBase = (pkg.version || '').split('-')[0];
+            if (!sdkBase) {
+              core.setFailed(`could not read .version from ${pkgPath}`);
+              return;
+            }
+            const sdkVersion = `${sdkBase}-${bindings.slice(dash + 1)}`;
+            if (!VERSION_RE.test(sdkVersion)) {
+              core.setFailed(`computed sdk_version '${sdkVersion}' is malformed`);
+              return;
+            }
+            core.setOutput('sdk_version', sdkVersion);
+
+      - if: steps.version.outputs.sdk_version != ''
+        run: yarn lint
+      - if: steps.version.outputs.sdk_version != ''
+        run: yarn typecheck
+      - if: steps.version.outputs.sdk_version != ''
+        run: ./dev/up
+      - if: steps.version.outputs.sdk_version != ''
+        run: sleep 5s
+      - if: steps.version.outputs.sdk_version != ''
+        working-directory: ./sdks/${{ matrix.sdk }}
+        run: yarn test
+      - if: steps.version.outputs.sdk_version != ''
+        working-directory: ./sdks/${{ matrix.sdk }}
+        run: yarn version ${{ steps.version.outputs.sdk_version }}
+      - if: steps.version.outputs.sdk_version != ''
+        working-directory: ./sdks/${{ matrix.sdk }}
+        run: yarn build
+      - if: steps.version.outputs.sdk_version != ''
+        working-directory: ./sdks/${{ matrix.sdk }}
+        # Auth is inherited from the workflow environment (OIDC via
+        # id-token: write, matching the existing prerelease job's pattern).
+        # If npm auth needs an explicit token in the future, set
+        # NODE_AUTH_TOKEN here and add registry-url to setup-node above.
+        run: npm publish --tag dev
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Nightly Publish (${{ matrix.sdk }})"
+            if [[ -z "${{ steps.version.outputs.sdk_version }}" ]]; then
+              echo "- **Skipped**: bindings version was stable, not a nightly"
+            else
+              echo "- **SDK**: @xmtp/${{ matrix.sdk }}"
+              echo "- **Version**: ${{ steps.version.outputs.sdk_version }}"
+              echo "- **Tag**: dev"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["npm"],
+  "dependencyDashboard": true,
+  "labels": ["dependencies", "bindings", "renovate"],
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 1,
+  "packageRules": [
+    {
+      "matchPackageNames": ["@xmtp/node-bindings", "@xmtp/wasm-bindings"],
+      "groupName": "xmtp bindings",
+      "groupSlug": "xmtp-bindings",
+      "commitMessageTopic": "xmtp bindings",
+      "followTag": "dev",
+      "respectLatest": false,
+      "automerge": false,
+      "rangeStrategy": "pin"
+    },
+    {
+      "matchPackageNames": [
+        "*",
+        "!@xmtp/node-bindings",
+        "!@xmtp/wasm-bindings"
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Automate prerelease npm publishes for node and wasm SDKs on Renovate updates
- Adds [renovate.json](https://github.com/xmtp/xmtp-js/pull/1803/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57) to configure Renovate to track only `@xmtp/node-bindings` and `@xmtp/wasm-bindings` (grouped as 'xmtp bindings') following the `dev` npm tag.
- Adds an `auto-prerelease-bindings` job in [release.yml](https://github.com/xmtp/xmtp-js/pull/1803/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) that detects version changes to those bindings on Renovate pushes by diffing `HEAD` vs `HEAD^` in the relevant `package.json` files.
- Adds an `auto-prerelease-publish` job that computes a matching SDK prerelease version from the bindings' prerelease suffix, runs lint/typecheck/tests/build, then publishes affected SDKs to npm under the `dev` tag.
- Adds a `validate-renovate-config` job in [lint.yml](https://github.com/xmtp/xmtp-js/pull/1803/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2) that validates `renovate.json` on every PR.
- Risk: inconsistent bindings versions across `node-sdk` and `primitives`, or malformed version strings, will fail the release job with no publish.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6144cbd.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->