### PR TITLE
fix(renovate): use nightly dist-tag instead of dev for xmtp bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,7 +339,7 @@ jobs:
         # id-token: write, matching the existing prerelease job's pattern).
         # If npm auth needs an explicit token in the future, set
         # NODE_AUTH_TOKEN here and add registry-url to setup-node above.
-        run: npm publish --tag dev
+        run: npm publish --tag nightly
 
       - name: Summary
         if: always()
@@ -351,6 +351,6 @@ jobs:
             else
               echo "- **SDK**: @xmtp/${{ matrix.sdk }}"
               echo "- **Version**: ${{ steps.version.outputs.sdk_version }}"
-              echo "- **Tag**: dev"
+              echo "- **Tag**: nightly"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "groupName": "xmtp bindings",
       "groupSlug": "xmtp-bindings",
       "commitMessageTopic": "xmtp bindings",
-      "followTag": "dev",
+      "followTag": "nightly",
       "respectLatest": false,
       "automerge": false,
       "rangeStrategy": "pin"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Switch xmtp bindings npm dist-tag from `dev` to `nightly`
Updates both the publish step in [release.yml](.github/workflows/release.yml) and [renovate.json](renovate.json) to use the `nightly` dist-tag instead of `dev`. This aligns the published tag with the tag Renovate tracks for xmtp binding dependencies.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f51636.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->