### PR TITLE
feat(node-sdk): add Client.close() for clean shutdown

### DIFF
--- a/.changeset/curly-rivers-close.md
+++ b/.changeset/curly-rivers-close.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/node-sdk": minor
+---
+
+Added `Client.close()` for clean shutdown. It cancels in-flight workers and detached streams, then releases the database connection. The method is idempotent — await it before deleting the database file or dropping the client reference to avoid log noise from background tasks running against a closed database.

--- a/sdks/node-sdk/src/Client.ts
+++ b/sdks/node-sdk/src/Client.ts
@@ -297,6 +297,25 @@ export class Client<ContentTypes = ExtractCodecContentTypes> {
   }
 
   /**
+   * Cleanly shuts down the client: cancels in-flight workers and detached
+   * streams, then releases the database connection.
+   *
+   * This is idempotent — calling it more than once resolves without error.
+   * Await this before deleting the database file or dropping the client
+   * reference to avoid log noise from background tasks running against a
+   * closed database.
+   *
+   * @throws {ClientNotInitializedError} if the client is not initialized
+   * @returns Promise that resolves when the client has shut down
+   */
+  async close() {
+    if (!this.#client) {
+      throw new ClientNotInitializedError();
+    }
+    return this.#client.close();
+  }
+
+  /**
    * Adds a signature to a signature request using the client's signer (or the
    * provided signer)
    *

--- a/sdks/node-sdk/test/Client.test.ts
+++ b/sdks/node-sdk/test/Client.test.ts
@@ -499,6 +499,9 @@ describe("Client", () => {
     await expect(async () =>
       client.fetchInboxIdByIdentifier(createIdentifier(createUser())),
     ).rejects.toThrow(new ClientNotInitializedError());
+    await expect(async () => client.close()).rejects.toThrow(
+      new ClientNotInitializedError(),
+    );
     expect(() => client.signWithInstallationKey("gm1")).toThrow(
       new ClientNotInitializedError(),
     );
@@ -515,6 +518,14 @@ describe("Client", () => {
       new ClientNotInitializedError(),
     );
     expect(() => client.isRegistered).toThrow(new ClientNotInitializedError());
+  });
+
+  it("should close the client idempotently", async () => {
+    const { signer } = createSigner();
+    const client = await createClient(signer);
+    await client.close();
+    // a second call must resolve without throwing
+    await expect(client.close()).resolves.not.toThrow();
   });
 
   it("should get inbox states from inbox IDs without a client", async () => {


### PR DESCRIPTION
## Summary

Exposes `Client.close()` on the node-sdk, wrapping the `close()` method added to `@xmtp/node-bindings` in libxmtp [#3685](https://github.com/xmtp/libxmtp/pull/3685).

This is the SDK-layer half of the `Client.close()` rollout tracked in libxmtp issue [#3659](https://github.com/xmtp/libxmtp/issues/3659). The Rust bindings already ship `close()` (it's in the `@xmtp/node-bindings@1.11.0-nightly.20260522.3d3b1e2` already pinned on `main`), but the node-sdk `Client` class is a hand-written wrapper and did not forward it — so JS consumers (Convos/Herald) still couldn't reach it.

## Changes

- `Client.close()` — cancels in-flight workers and detached streams, then releases the database connection. Idempotent. Throws `ClientNotInitializedError` if the client was never initialized, consistent with the other `#client`-backed methods.
- Test: idempotency (`close()` twice resolves), plus a `ClientNotInitializedError` case in the existing "client is not initialized" test.
- Changeset: `minor` bump for `@xmtp/node-sdk`.

## Why

Consumers currently delete the SQLite file and drop JS references while background workers and stream callbacks keep firing against a closed DB, flooding logs. `await client.close()` gives them a clean shutdown before file deletion.

## Testing

- `yarn typecheck`, `yarn build` — clean
- `yarn test` — new idempotency test and the updated not-initialized test pass against the local XMTP backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Client.close()` for clean shutdown to node-sdk
> Adds a public async `close()` method to the `Client` class in [Client.ts](https://github.com/xmtp/xmtp-js/pull/1811/files#diff-d9b065e84339083d0f433b13652fdd58440125da85d29af761cf27029f6e2e60) that delegates to the underlying native client's close. The method throws `ClientNotInitializedError` if called before initialization and is idempotent — repeated calls resolve without error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa2e800.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->