### PR TITLE
fix(cli): add robust input validation for Ethereum address identifiers

### DIFF
--- a/packages/xmtp-cli/src/commands/client/change-recovery-identifier.ts
+++ b/packages/xmtp-cli/src/commands/client/change-recovery-identifier.ts
@@ -1,5 +1,6 @@
 import { Flags } from "@oclif/core";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { identifierKindMap } from "../../utils/enums.js";
 
 export default class ClientChangeRecoveryIdentifier extends BaseCommand {
@@ -55,9 +56,12 @@ The recovery identifier must be an Ethereum address.`;
     const { flags } = await this.parse(ClientChangeRecoveryIdentifier);
     const client = await this.initClient();
 
+    const identifierKind = identifierKindMap[flags.kind];
+    validateIdentifier(flags.identifier, identifierKind);
+
     // Build identifier before confirming so invalid input fails fast
     const identifier = {
-      identifierKind: identifierKindMap[flags.kind],
+      identifierKind,
       identifier: flags.identifier.toLowerCase(),
     };
 

--- a/packages/xmtp-cli/src/commands/client/inbox-id.ts
+++ b/packages/xmtp-cli/src/commands/client/inbox-id.ts
@@ -1,5 +1,6 @@
 import { Flags } from "@oclif/core";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { identifierKindMap } from "../../utils/enums.js";
 
 export default class ClientInboxId extends BaseCommand {
@@ -51,8 +52,11 @@ Returns null if the identifier has no associated inbox ID (not registered).`;
     const { flags } = await this.parse(ClientInboxId);
     const client = await this.initClient();
 
+    const identifierKind = identifierKindMap[flags.kind];
+    validateIdentifier(flags.identifier, identifierKind);
+
     const identifier = {
-      identifierKind: identifierKindMap[flags.kind],
+      identifierKind,
       identifier: flags.identifier.toLowerCase(),
     };
 

--- a/packages/xmtp-cli/src/commands/client/remove-account.ts
+++ b/packages/xmtp-cli/src/commands/client/remove-account.ts
@@ -1,5 +1,6 @@
 import { Flags } from "@oclif/core";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { identifierKindMap } from "../../utils/enums.js";
 
 export default class ClientRemoveAccount extends BaseCommand {
@@ -56,9 +57,12 @@ this client's inbox.`;
     const { flags } = await this.parse(ClientRemoveAccount);
     const client = await this.initClient();
 
+    const identifierKind = identifierKindMap[flags.kind];
+    validateIdentifier(flags.identifier, identifierKind);
+
     // Build identifier before confirming so invalid input fails fast
     const identifier = {
-      identifierKind: identifierKindMap[flags.kind],
+      identifierKind,
       identifier: flags.identifier.toLowerCase(),
     };
 

--- a/packages/xmtp-cli/src/commands/conversation/add-members.ts
+++ b/packages/xmtp-cli/src/commands/conversation/add-members.ts
@@ -1,6 +1,7 @@
 import { Args } from "@oclif/core";
 import { IdentifierKind } from "@xmtp/node-sdk";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { requireGroup } from "../../utils/conversation.js";
 
 export default class ConversationAddMembers extends BaseCommand {
@@ -63,10 +64,13 @@ Requires appropriate permissions to add members (based on group settings).`;
       this.error(`Conversation not found: ${args.id}`);
     }
 
-    const identifiers = addresses.map((address) => ({
-      identifier: address.toLowerCase(),
-      identifierKind: IdentifierKind.Ethereum,
-    }));
+    const identifiers = addresses.map((address) => {
+      validateIdentifier(address, IdentifierKind.Ethereum);
+      return {
+        identifier: address.toLowerCase(),
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
 
     const group = requireGroup(conversation);
     await group.addMembersByIdentifiers(identifiers);

--- a/packages/xmtp-cli/src/commands/conversation/remove-members.ts
+++ b/packages/xmtp-cli/src/commands/conversation/remove-members.ts
@@ -1,6 +1,7 @@
 import { Args } from "@oclif/core";
 import { IdentifierKind } from "@xmtp/node-sdk";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { requireGroup } from "../../utils/conversation.js";
 
 export default class ConversationRemoveMembers extends BaseCommand {
@@ -64,10 +65,13 @@ Requires appropriate permissions to remove members (based on group settings).`;
       this.error(`Conversation not found: ${args.id}`);
     }
 
-    const identifiers = addresses.map((address) => ({
-      identifier: address.toLowerCase(),
-      identifierKind: IdentifierKind.Ethereum,
-    }));
+    const identifiers = addresses.map((address) => {
+      validateIdentifier(address, IdentifierKind.Ethereum);
+      return {
+        identifier: address.toLowerCase(),
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
 
     const group = requireGroup(conversation);
     await group.removeMembersByIdentifiers(identifiers);

--- a/packages/xmtp-cli/src/commands/conversations/create-dm.ts
+++ b/packages/xmtp-cli/src/commands/conversations/create-dm.ts
@@ -1,5 +1,6 @@
 import { Args, Flags } from "@oclif/core";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 import { identifierKindMap } from "../../utils/enums.js";
 
 export default class ConversationsCreateDm extends BaseCommand {
@@ -50,9 +51,12 @@ Returns the DM's ID and details.`;
     const { args, flags } = await this.parse(ConversationsCreateDm);
     const client = await this.initClient();
 
+    const identifierKind = identifierKindMap[flags["identifier-kind"]];
+    validateIdentifier(args.identifier, identifierKind);
+
     const identifier = {
       identifier: args.identifier.toLowerCase(),
-      identifierKind: identifierKindMap[flags["identifier-kind"]],
+      identifierKind,
     };
 
     const dm = await client.conversations.createDmWithIdentifier(identifier);

--- a/packages/xmtp-cli/src/commands/conversations/create-group.ts
+++ b/packages/xmtp-cli/src/commands/conversations/create-group.ts
@@ -5,6 +5,7 @@ import {
   type CreateGroupOptions,
 } from "@xmtp/node-sdk";
 import { BaseCommand } from "../../baseCommand.js";
+import { validateIdentifier } from "../../utils/client.js";
 
 export default class ConversationsCreateGroup extends BaseCommand {
   static description = `Create a new group conversation.
@@ -88,10 +89,13 @@ Returns the new group's ID and details.`;
 
     const client = await this.initClient();
 
-    const identifierObjects = identifiers.map((id) => ({
-      identifier: id.toLowerCase(),
-      identifierKind: IdentifierKind.Ethereum,
-    }));
+    const identifierObjects = identifiers.map((id) => {
+      validateIdentifier(id, IdentifierKind.Ethereum);
+      return {
+        identifier: id.toLowerCase(),
+        identifierKind: IdentifierKind.Ethereum,
+      };
+    });
 
     const permissionsMap: Record<string, GroupPermissionsOptions> = {
       "all-members": GroupPermissionsOptions.Default,

--- a/packages/xmtp-cli/src/utils/client.ts
+++ b/packages/xmtp-cli/src/utils/client.ts
@@ -7,7 +7,7 @@ import {
   type NetworkOptions,
   type Signer,
 } from "@xmtp/node-sdk";
-import { isHex, toBytes } from "viem";
+import { isAddress, isHex, toBytes } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import type { XmtpConfig } from "./config.js";
 
@@ -64,6 +64,15 @@ export function hexToBytes(value: string): Uint8Array {
     throw new Error(`Invalid hex string: ${value}`);
   }
   return toBytes(hex);
+}
+
+export function validateIdentifier(
+  identifier: string,
+  kind: IdentifierKind,
+): void {
+  if (kind === IdentifierKind.Ethereum && !isAddress(identifier)) {
+    throw new Error(`Invalid Ethereum address: ${identifier}`);
+  }
 }
 
 export async function createClient(config: XmtpConfig): Promise<Client> {

--- a/packages/xmtp-cli/test/commands/conversations/create-dm.test.ts
+++ b/packages/xmtp-cli/test/commands/conversations/create-dm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createRegisteredIdentity,
+  createTestIdentity,
   parseJsonOutput,
   runWithIdentity,
 } from "../../helpers.js";
@@ -126,6 +127,22 @@ describe("conversations create-dm", () => {
     ]);
 
     expect(result.exitCode).not.toBe(0);
+  });
+
+  it("fails with an invalid ethereum address", async () => {
+    // Note: Use createTestIdentity so it validates fast locally and does not
+    // hit the docker network limit when running isolated testing
+    const sender = createTestIdentity();
+
+    const result = await runWithIdentity(sender, [
+      "conversations",
+      "create-dm",
+      "invalid-address",
+      "--json",
+    ]);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("Invalid Ethereum address");
   });
 
   it("both parties can see the DM", async () => {


### PR DESCRIPTION
Add `validateIdentifier` utility in the CLI using viem's `isAddress` to ensure Ethereum addresses are structurally sound before passing them to the SDK. This prevents the CLI from making unnecessary network calls or encountering confusing downstream C++ binding errors when given malformed input.

Applied validation symmetrically across the following commands:
- `client change-recovery-identifier`
- `client inbox-id`
- `client remove-account`
- `conversation add-members`
- `conversation remove-members`
- `conversations create-dm`
- `conversations create-group`

Includes an offline unit test for `create-dm` to verify the fast-failure path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ethereum address validation to CLI commands before execution
> - Adds a `validateIdentifier` utility in [`utils/client.ts`](https://github.com/xmtp/xmtp-js/pull/1814/files#diff-700b98e27b7393a6d519c860fbe599427cae63cb5625143369d561a8e70f7d55) that uses `viem`'s `isAddress` to throw on invalid Ethereum addresses.
> - Applies validation in 7 commands (`change-recovery-identifier`, `inbox-id`, `remove-account`, `add-members`, `remove-members`, `create-dm`, `create-group`) so invalid addresses are rejected before any network call or confirmation prompt.
> - Adds a test in the `create-dm` suite asserting the command fails with an `'Invalid Ethereum address'` message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 823b8f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->