### PR TITLE
fix(release): base nightly SDK version on next planned version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const cp = require('child_process');
             const VERSION_RE = /^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$/;
 
             const sdk = process.env.SDK;
@@ -304,11 +305,46 @@ jobs:
               core.setFailed(`could not read ${pkgPath}: ${err.message}`);
               return;
             }
-            const sdkBase = (pkg.version || '').split('-')[0];
-            if (!sdkBase) {
+            const releasedBase = (pkg.version || '').split('-')[0];
+            if (!releasedBase) {
               core.setFailed(`could not read .version from ${pkgPath}`);
               return;
             }
+
+            // Prefer the next PLANNED version (from pending changesets) over the
+            // last released version, so nightlies preview the upcoming release
+            // instead of trailing it. `changeset status` reports the calculated
+            // newVersion without consuming changesets or mutating files.
+            //
+            // Caveats handled below:
+            //  - `--output` is resolved relative to the repo root; absolute paths
+            //    are ignored, so we use a repo-relative filename.
+            //  - The command prints monorepo dependency-consistency warnings to
+            //    stderr but still exits 0; a real failure (no changesets, etc.) is
+            //    treated as "nothing planned" and falls back to the released base.
+            //  - `releases[]` also contains phantom patch bumps for packages
+            //    touched only by `updateInternalDependencies` cascade
+            //    (changesets: []). Only a release with a non-empty `changesets`
+            //    array reflects a genuine pending change, so we require that.
+            const sdkPkgName = pkg.name;
+            let plannedBase = '';
+            const statusFile = 'cs-status.json';
+            try {
+              cp.execFileSync('yarn', ['changeset', 'status', `--output=${statusFile}`], { stdio: 'ignore' });
+              const status = JSON.parse(fs.readFileSync(statusFile, 'utf8'));
+              const release = (status.releases || []).find((r) => r.name === sdkPkgName);
+              if (release && Array.isArray(release.changesets) && release.changesets.length > 0 && release.newVersion) {
+                plannedBase = release.newVersion.split('-')[0];
+              }
+            } catch (err) {
+              core.info(`changeset status unavailable (${err.message}); using released base.`);
+            } finally {
+              try { fs.unlinkSync(statusFile); } catch {}
+            }
+
+            const sdkBase = plannedBase || releasedBase;
+            core.info(`${sdkPkgName} base: ${sdkBase} (planned=${plannedBase || '<none>'}, released=${releasedBase})`);
+
             const sdkVersion = `${sdkBase}-${bindings.slice(dash + 1)}`;
             if (!VERSION_RE.test(sdkVersion)) {
               core.setFailed(`computed sdk_version '${sdkVersion}' is malformed`);


### PR DESCRIPTION
## Problem

`auto-prerelease-publish` computes the nightly SDK base from the **released** `package.json` `.version`, so nightlies permanently trail the last GA release. With the pending `Client.close()` **minor** changeset (→ `6.1.0`) unreleased, nightlies still publish as `6.0.0-nightly.*`. Consumers can't preview the next version — effectively "ship stable X, then nightlies *of* X," the reverse of what a nightly is for.

## Fix

Read the next **planned** version from `changeset status --output` and use it as the base when a genuine pending changeset exists; fall back to the released version otherwise. Only the `Compute SDK version` step changes — trigger, matrix, test gates, and the `yarn version` / `npm publish --tag nightly` path are untouched.

### Base resolution

| matrix SDK | pending real changeset? | base source | base |
|---|---|---|---|
| node-sdk | yes (`Client.close` minor) | `changeset status` `newVersion` | 6.1.0 |
| node-sdk | no (post-GA) | `package.json` `.version` | released |
| node-sdk | only internal-dep cascade (`changesets: []`) | `package.json` `.version` | released |
| browser-sdk | no (absent from `releases[]`) | `package.json` `.version` | 7.0.0 |

### Why the `changesets.length > 0` guard

`changeset status` also reports **phantom patch bumps** for packages touched only by the `updateInternalDependencies` cascade (e.g. `@xmtp/cli`, `@xmtp/agent-sdk` show up with `changesets: []`). Only a release with a non-empty `changesets[]` reflects a genuine pending change, so we require that — otherwise an SDK's nightly base would falsely bump on a cascade.

### Caveats handled
- `--output` is repo-root-relative; absolute paths are ignored → use a relative filename.
- `changeset status` prints monorepo dep-consistency warnings to stderr but exits `0`; any real failure (no changesets, etc.) falls back to the released base — never fails the job.

## Verification (local, against the live `curly-rivers-close` changeset)

```
[node-sdk]    -> 6.1.0-nightly.20260530.065bd0d   (planned 6.1.0)
[browser-sdk] -> 7.0.0-nightly.20260530.065bd0d   (fallback, absent from releases)
status errors -> 6.0.0-nightly.20260530.065bd0d   (fallback to released)
```

YAML parses; compute logic dry-run asserts the above. End-to-end proof: the next Renovate bindings-bump merge should publish `@xmtp/node-sdk@6.1.0-nightly.<datetime>.<sha>` under the `nightly` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Base nightly SDK version on the next planned version when pending changesets exist
> When computing the nightly `sdk_version` in [release.yml](https://github.com/xmtp/xmtp-js/pull/1819/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34), the release workflow now runs `yarn changeset status` and parses its JSON output to detect a pending planned version for the SDK package. If a planned version with non-empty changesets is found, it is used as the base instead of the last released version. Falls back to the released base if the command fails or no planned version is found, and cleans up the temporary status file afterwards.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8dc683f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->