### PR TITLE
fix(docs): fix broken links (404) in agent-sdk README.md

### DIFF
--- a/sdks/agent-sdk/README.md
+++ b/sdks/agent-sdk/README.md
@@ -89,7 +89,7 @@ Subscribe only to what you need using Node’s `EventEmitter` interface. Events 
 - `attachment` – an incoming [remote attachment message](https://docs.xmtp.org/agents/content-types/attachments#how-remote-attachments-work)
 - `group-update` – an incoming [group update](https://docs.xmtp.org/agents/content-types/group-updates#listen-for-group-updates) (like name change, member update, etc.)
 - `inline-attachment` – an incoming inline attachment (small files sent directly in the message)
-- `intent` – an incoming [intent message](https://docs.xmtp.org/agents/content-types/intents) (user's response to an actions message)
+- `intent` – an incoming [intent message](https://docs.xmtp.org/chat-apps/content-types/intents) (user's response to an actions message)
 - `leave-request` – an incoming leave request from a member wanting to leave a group
 - `markdown` – an incoming [markdown-formatted](https://docs.xmtp.org/agents/content-types/markdown) text message
 - `message` – all messages that are not having a [custom content type](https://docs.xmtp.org/agents/content-types/content-types#custom-content-types)
@@ -466,8 +466,8 @@ console.log(agent.libxmtpVersion);
 
 ## Debugging
 
-- [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
-- [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
+- [Debug an agent](https://docs.xmtp.org/agents/deploy/debug-agents)
+- [Further debugging info](https://docs.xmtp.org/chat-apps/debug/debug-your-app)
 
 ## Contributing / Feedback
 


### PR DESCRIPTION
## Problem
`sdks/agent-sdk/README.md` contains three broken links that return 404:
- `https://docs.xmtp.org/agents/content-types/intents`
- `https://docs.xmtp.org/agents/debug-agents`
- `https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app` (redirects to 404)

## Root Cause
The docs site was restructured and these pages moved to new URLs, but `sdks/agent-sdk/README.md` was not updated to reflect the changes.

## Fix
**`sdks/agent-sdk/README.md`**
```diff
- `intent` – an incoming [intent message](https://docs.xmtp.org/agents/content-types/intents)
+ `intent` – an incoming [intent message](https://docs.xmtp.org/chat-apps/content-types/intents)
```
```diff
- [Debug an agent](https://docs.xmtp.org/agents/debug-agents)
+ [Debug an agent](https://docs.xmtp.org/agents/deploy/debug-agents)
```
```diff
- [Further debugging info](https://docs.xmtp.org/inboxes/debug-your-app#debug-your-inbox-app)
+ [Further debugging info](https://docs.xmtp.org/chat-apps/debug/debug-your-app)
```

## Verification
Confirmed all three target URLs resolve correctly:
- https://docs.xmtp.org/chat-apps/content-types/intents ✅
- https://docs.xmtp.org/agents/deploy/debug-agents ✅
- https://docs.xmtp.org/chat-apps/debug/debug-your-app ✅

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix broken documentation links in agent-sdk README
> Updates three broken links in [README.md](https://github.com/xmtp/xmtp-js/pull/1829/files#diff-b4177824a8cf0723ed03a0df2e89239a5ec37971e3bd130c1a2ac3719ffc2d6a) that were returning 404s: the `intent` message type link, the 'Debug an agent' link, and the 'Further debugging info' link now all point to their correct URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e33df41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->