### PR TITLE
fix(cli): add robust error handling to formatTimestampNs for invalid inputs

### DIFF
--- a/.changeset/cli-format-timestamp-ns.md
+++ b/.changeset/cli-format-timestamp-ns.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/cli": patch
+---
+
+add robust error handling to formatTimestampNs for invalid inputs

--- a/packages/xmtp-cli/src/utils/output.ts
+++ b/packages/xmtp-cli/src/utils/output.ts
@@ -29,16 +29,31 @@ export function formatIdentifierKind(kind: IdentifierKind): string {
   }
 }
 
-export function formatTimestampNs(ns: bigint | string | undefined): string {
-  if (ns === undefined) {
+export function formatTimestampNs(
+  ns: bigint | string | number | null | undefined,
+): string {
+  if (ns === undefined || ns === null || ns === "") {
     return "Unknown";
   }
-  const ms = Number(BigInt(ns) / BigInt(1_000_000));
-  const date = new Date(ms);
-  return date
-    .toISOString()
-    .replace("T", " ")
-    .replace(/\.\d{3}Z$/, "");
+  try {
+    const ms =
+      typeof ns === "number"
+        ? ns
+        : Number(BigInt(ns) / BigInt(1_000_000));
+    if (Number.isNaN(ms)) {
+      return "Unknown";
+    }
+    const date = new Date(ms);
+    if (Number.isNaN(date.getTime())) {
+      return "Unknown";
+    }
+    return date
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d{3}Z$/, "");
+  } catch {
+    return "Unknown";
+  }
 }
 
 export function formatHuman(data: unknown, indent = 0): string {


### PR DESCRIPTION
## Summary

Enhances `formatTimestampNs` in `packages/xmtp-cli/src/utils/output.ts` to add type safety and robust error handling for `null`, empty string, invalid timestamp string, and numeric inputs.

## Problem

`formatTimestampNs` executed `BigInt(ns)` directly on the input argument without catching syntax or conversion errors. When invalid or decimal timestamp strings are passed, `BigInt` throws an unhandled `SyntaxError: Cannot convert ... to a BigInt`, causing `xmtp-cli` output formatting to crash.

## Fix

1. Guard against `null`, `undefined`, and empty string `""` inputs by immediately returning `"Unknown"`.
2. Add support for numeric millisecond inputs directly.
3. Wrap conversion in a `try...catch` block to handle invalid string conversions gracefully without crashing CLI rendering.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatTimestampNs` to handle invalid, null, and numeric inputs gracefully
> - Broadens the `formatTimestampNs` signature in [`output.ts`](https://github.com/xmtp/xmtp-js/pull/1841/files#diff-bd35a37055d858a436975519c9fb368ad4361e77c1851140269c0f295bcec403) to accept `bigint | string | number | null | undefined`.
> - Returns `"Unknown"` for null, undefined, empty string, NaN milliseconds, or invalid dates instead of throwing.
> - Numeric inputs are treated as milliseconds directly; bigint/string inputs continue to be treated as nanoseconds (divided by 1,000,000).
> - Behavioral Change: previously invalid inputs would throw; they now return `"Unknown"` silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 055b930.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->