### PR TITLE
fix(agent-sdk): protect .env from overwrite

### DIFF
--- a/sdks/agent-sdk/src/bin/generateKeys.ts
+++ b/sdks/agent-sdk/src/bin/generateKeys.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { getRandomValues } from "node:crypto";
-import { writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { generatePrivateKey } from "viem/accounts";
 
@@ -16,10 +16,42 @@ const generateClientKeys = () => {
 /**
  * Generates client keys and saves them to a .env file in the project root.
  * This script creates the necessary environment variables for XMTP agent initialization.
+ *
+ * Safety: refuses to run if a .env file already exists, since this script
+ * previously overwrote XMTP_WALLET_KEY, XMTP_DB_ENCRYPTION_KEY, and any other
+ * unrelated variables in .env without warning. Pass --force to override.
  */
 function main() {
   try {
-    // Generate the client keys
+    if (!process.env.INIT_CWD) {
+      throw new Error(
+        `Cannot invoke script because "process.env.INIT_CWD" wasn't found.`,
+      );
+    }
+    const envFilePath = join(process.env.INIT_CWD, ".env");
+    const force = process.argv.includes("--force");
+
+    if (existsSync(envFilePath) && !force) {
+      console.error(
+        `❌ Refusing to overwrite existing file: ${envFilePath}\n` +
+          `   It may already contain XMTP_WALLET_KEY, XMTP_DB_ENCRYPTION_KEY,\n` +
+          `   or other variables that would be permanently lost.\n\n` +
+          `   Re-run with --force if you really want to regenerate credentials\n` +
+          `   and discard the current .env contents:\n\n` +
+          `       yarn gen:keys --force\n`,
+      );
+      process.exit(1);
+    }
+
+    if (existsSync(envFilePath) && force) {
+      console.warn(
+        `⚠️  --force passed: overwriting existing ${envFilePath}.\n` +
+          `   Any previous XMTP_WALLET_KEY, XMTP_DB_ENCRYPTION_KEY, or other\n` +
+          `   variables in this file will be permanently lost.`,
+      );
+    }
+
+    // Only generate new keys once we know it's safe (or explicitly forced) to write them.
     const keys = generateClientKeys();
 
     // Create the .env file content
@@ -27,13 +59,6 @@ function main() {
       Object.entries(keys)
         .map(([key, value]) => `${key}=${value}`)
         .join("\n") + "\n";
-
-    if (!process.env.INIT_CWD) {
-      throw new Error(
-        `Cannot invoke script because "process.env.INIT_CWD" wasn't found.`,
-      );
-    }
-    const envFilePath = join(process.env.INIT_CWD, ".env");
 
     writeFileSync(envFilePath, envContent, "utf8");
 


### PR DESCRIPTION
Fixed generateKeys to prevent accidental .env overwrites. Existing files are now protected by default, while --force explicitly allows regeneration with a warning.

Verified all three cases: new .env, protected existing .env, and explicit --force overwrite.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Protect `.env` from accidental overwrite in `generateKeys` script
> The `generateKeys` script in [generateKeys.ts](https://github.com/xmtp/xmtp-js/pull/1844/files#diff-86b5a6125ba1c710736d6492f009d05fd8690d9a11fb5e08716899115757eea0) previously overwrote any existing `.env` file unconditionally. It now checks for an existing `.env` before writing and exits with a non-zero status and an explanatory error if one is found. Pass `--force` to override this protection, which logs a warning about potential variable loss before proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84bc2c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->