### PR TITLE
docs: point SDK development to xmtp/libxmtp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-This is the official repository for XMTP client SDKs and content types for browsers and Node, written in TypeScript.
+> [!IMPORTANT]
+> **XMTP SDK development has moved.** The `agent-sdk`, `node-sdk`, and `browser-sdk` packages now live in [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp) under [`sdks/js/`](https://github.com/xmtp/libxmtp/tree/main/sdks/js) and are built and released from there. Please file SDK issues and open SDK pull requests at [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp/issues).
+>
+> This repository remains active and continues to host the `@xmtp/content-type-*` packages, the [xmtp.chat](https://xmtp.chat/) app, and `xmtp-cli`.
+
+This repository hosts XMTP content types, the [xmtp.chat](https://xmtp.chat/) web app, and `xmtp-cli`, written in TypeScript. The XMTP JavaScript/TypeScript SDKs now live in [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp).
 
 To learn more about the contents of this repository, see this README and the READMEs provided in each workspace directory.
 
@@ -19,9 +24,11 @@ XMTP offers SDKs for a variety of use cases. Whether you're building a chat app,
 
 ### SDKs
 
-- [`agent-sdk`](sdks/agent-sdk): XMTP agent SDK for Node
-- [`browser-sdk`](sdks/browser-sdk): XMTP client SDK for browsers
-- [`node-sdk`](sdks/node-sdk): XMTP client SDK for Node
+The XMTP SDKs have moved to [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp):
+
+- [`agent-sdk`](https://github.com/xmtp/libxmtp/tree/main/sdks/js/agent-sdk): XMTP agent SDK for Node
+- [`browser-sdk`](https://github.com/xmtp/libxmtp/tree/main/sdks/js/browser-sdk): XMTP client SDK for browsers
+- [`node-sdk`](https://github.com/xmtp/libxmtp/tree/main/sdks/js/node-sdk): XMTP client SDK for Node
 
 ### Content types
 


### PR DESCRIPTION
## Summary

XMTP SDK development has moved. The `agent-sdk`, `node-sdk`, and `browser-sdk` packages now live in [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp) under [`sdks/js/`](https://github.com/xmtp/libxmtp/tree/main/sdks/js) and are built and released from there.

This PR updates the top-level `README.md` so contributors are pointed to the right place:

- Adds a prominent note that SDK development (agent-sdk, node-sdk, browser-sdk) moved to `xmtp/libxmtp` under `sdks/js/`, and that SDK issues and pull requests should be filed at [`xmtp/libxmtp`](https://github.com/xmtp/libxmtp/issues).
- Updates the "SDKs" section links to point at their new homes in `xmtp/libxmtp`.
- Makes clear this repository **remains active** and continues to host the `@xmtp/content-type-*` packages, the [xmtp.chat](https://xmtp.chat/) app, and `xmtp-cli`.

No other content is changed; the apps, content-types, and contributing sections are preserved as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README to redirect SDK development to xmtp/libxmtp
> Adds an IMPORTANT notice at the top of [README.md](https://github.com/xmtp/xmtp-js/pull/1848/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) stating that XMTP SDK development has moved to `xmtp/libxmtp`, directing users to file issues and PRs there. Updates the SDKs section to replace local workspace links for `agent-sdk`, `browser-sdk`, and `node-sdk` with links pointing to their new locations in `xmtp/libxmtp`. Clarifies that this repo continues to host `@xmtp/content-type-*` packages, the `xmtp.chat` app, and `xmtp-cli`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfc2154.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->