### PR TITLE
Fix: Remove Windows-incompatible color prefix from turbo scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "lint": "yarn build && eslint .",
     "publish": "yarn build && changeset publish",
     "reset": "yarn clean && yarn && yarn build",
-    "test": "FORCE_COLOR=1 turbo run test",
+    "test": "turbo run test",
     "test:setup": "./dev/up",
     "test:teardown": "./dev/down",
-    "typecheck": "FORCE_COLOR=1 turbo run typecheck"
+    "typecheck": "turbo run typecheck"
   },
   "dependencies": {
     "@changesets/changelog-git": "^0.2.1",


### PR DESCRIPTION
This PR removes the POSIX-only `FORCE_COLOR=1` environment prefix to allow test and typecheck scripts to execute correctly on Windows.

**Changes:**
* Removed `FORCE_COLOR=1` from `test` and `typecheck` script definitions in `package.json`, retaining the core `turbo run` commands.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `FORCE_COLOR=1` prefix from `test` and `typecheck` turbo scripts
> `FORCE_COLOR=1` is not supported on Windows and caused the `test` and `typecheck` scripts in [package.json](https://github.com/xmtp/xmtp-js/pull/1857/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to fail on that platform. Both scripts now invoke `turbo run` directly without that prefix.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65f4d4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->