### PR TITLE
fix(agent-sdk): do not evict on LimitedMap updates at capacity

### DIFF
--- a/sdks/agent-sdk/src/util/LimitedMap.test.ts
+++ b/sdks/agent-sdk/src/util/LimitedMap.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { LimitedMap } from "./LimitedMap";
+
+describe("LimitedMap", () => {
+  it("does not evict another entry when updating an existing key at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("b", 4);
+
+    expect(map.get("a")).toBe(1);
+    expect(map.get("b")).toBe(4);
+  });
+
+  it("evicts the oldest key when inserting a new key at capacity", () => {
+    const map = new LimitedMap<string, number>(2);
+    map.set("a", 1);
+    map.set("b", 2);
+    map.set("c", 3);
+
+    expect(map.get("a")).toBeUndefined();
+    expect(map.get("b")).toBe(2);
+    expect(map.get("c")).toBe(3);
+  });
+});

--- a/sdks/agent-sdk/src/util/LimitedMap.ts
+++ b/sdks/agent-sdk/src/util/LimitedMap.ts
@@ -7,7 +7,9 @@ export class LimitedMap<K, V> {
   }
 
   set(key: K, value: V) {
-    if (this.#map.size >= this.#limit) {
+    // Only evict when inserting a *new* key would exceed the limit.
+    // Updating an existing key must not drop a different cached entry.
+    if (!this.#map.has(key) && this.#map.size >= this.#limit) {
       const it = this.#map.keys().next();
       if (!it.done) {
         this.#map.delete(it.value);


### PR DESCRIPTION
## Summary

`LimitedMap.set` evicted another entry whenever `size >= limit`, including updates to an existing key. That dropped still-valid cache entries. Only evict when inserting a *new* key would exceed the limit.

## Testing

- Capacity 2: update existing key keeps the sibling entry
- Capacity 2: inserting a new key still evicts the oldest entry
- Added `sdks/agent-sdk/src/util/LimitedMap.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LimitedMap.set` to skip eviction when updating an existing key at capacity
> Previously, calling `set` on a key that already exists in a full `LimitedMap` would evict the oldest entry, shrinking the map unnecessarily. The fix adds a presence check before eviction so that only genuinely new keys trigger removal of the oldest entry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 596084e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->