### PR TITLE
fix: decode legacy reactions with non-object JSON content

### DIFF
--- a/.changeset/olive-comics-press.md
+++ b/.changeset/olive-comics-press.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-reaction": patch
+---
+
+Fix decoding of legacy reactions whose content is a valid JSON literal

--- a/content-types/content-type-reaction/src/Reaction.test.ts
+++ b/content-types/content-type-reaction/src/Reaction.test.ts
@@ -87,6 +87,26 @@ describe("ReactionContentType", () => {
     expect(legacy.schema).toBe("shortcode");
   });
 
+  it("decodes legacy reactions with numeric content", () => {
+    const codec = new ReactionCodec();
+
+    const legacyEncoded: EncodedContent<LegacyReactionParameters> = {
+      type: ContentTypeReaction,
+      parameters: {
+        action: "added",
+        reference: "abc123",
+        schema: "shortcode",
+        encoding: "UTF-8",
+      },
+      content: new TextEncoder().encode("5"),
+    };
+
+    const legacy = codec.decode(legacyEncoded);
+    expect(legacy.action).toBe("added");
+    expect(legacy.reference).toBe("abc123");
+    expect(legacy.schema).toBe("shortcode");
+    expect(legacy.content).toBe("5");
+  });
   it("can send a reaction", async () => {
     const signer1 = createSigner();
     const client1 = await Client.create(signer1, {

--- a/content-types/content-type-reaction/src/Reaction.ts
+++ b/content-types/content-type-reaction/src/Reaction.ts
@@ -73,9 +73,12 @@ export class ReactionCodec implements ContentCodec<
 
     // First try to decode it in the canonical form.
     try {
-      const reaction = JSON.parse(decodedContent) as Reaction;
-      const { action, reference, referenceInboxId, schema, content } = reaction;
-      return { action, reference, referenceInboxId, schema, content };
+      const parsed: unknown = JSON.parse(decodedContent);
+      if (typeof parsed === "object" && parsed !== null) {
+        const { action, reference, referenceInboxId, schema, content } =
+          parsed as Reaction;
+        return { action, reference, referenceInboxId, schema, content };
+      }
     } catch {
       // ignore, fall through to legacy decoding
     }


### PR DESCRIPTION
## Problem

`ReactionCodec.decode` breaks when a legacy reaction's content is valid JSON but not an object, such as `5`, `true`, or `null`. It incorrectly treats the parsed value as the new format, so `action`, `reference`, and `schema` become `undefined` instead of being read from `parameters`.

## Cause

`JSON.parse` can return primitives as well as objects, and destructuring a primitive like a number does not throw an error. Because of this, the `try` block succeeds even though the parsed value is not a valid reaction object.

## Fix

I added a check to make sure the parsed value is a non-null object before treating it as the new format. The `parsed !== null` check is necessary because `typeof null` is also `"object"`. I also moved the `as Reaction` cast so it is only applied after this check.

## Testing

I added a regression test covering numeric legacy content. It failed before the change and passes after it, while the existing package tests continue to pass.

I noticed this while reading the codec rather than from a bug in a real application.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ReactionCodec.decode` to handle legacy reactions with non-object JSON content
> When decoding a reaction, the canonical JSON parsing branch previously treated any valid JSON parse result as a `Reaction` object, including primitives like numbers or strings. The fix adds a `typeof`/object check so that non-object JSON values (e.g. `'5'`) fall through to the legacy decoding path, which reads `action`, `reference`, and `schema` from parameters instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce9dd45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->