### PR TITLE
fix(cli): include all columns in table output

### DIFF
--- a/.changeset/quiet-tables-unite.md
+++ b/.changeset/quiet-tables-unite.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/cli": patch
+---
+
+Include columns that appear only in later rows when formatting CLI tables.

--- a/packages/xmtp-cli/src/utils/output.ts
+++ b/packages/xmtp-cli/src/utils/output.ts
@@ -100,7 +100,7 @@ function formatTable(rows: Record<string, unknown>[], prefix = ""): string {
     return "";
   }
 
-  const keys = Object.keys(rows[0]);
+  const keys = [...new Set(rows.flatMap((row) => Object.keys(row)))];
   const widths = keys.map((key) =>
     Math.max(key.length, ...rows.map((row) => stringifyValue(row[key]).length)),
   );

--- a/packages/xmtp-cli/test/utils/output.test.ts
+++ b/packages/xmtp-cli/test/utils/output.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatHuman } from "../../src/utils/output.js";
+
+describe("formatHuman", () => {
+  it("includes columns that only appear in later rows", () => {
+    const output = formatHuman([
+      {
+        id: "dm-1",
+        peerInboxId: "peer-1",
+      },
+      {
+        id: "group-1",
+        name: "Test Group",
+        description: "Group description",
+      },
+    ]);
+
+    expect(output).toContain("id");
+    expect(output).toContain("peerInboxId");
+    expect(output).toContain("name");
+    expect(output).toContain("description");
+    expect(output).toContain("Test Group");
+    expect(output).toContain("Group description");
+  });
+});


### PR DESCRIPTION
## Summary

Fix CLI table formatting so columns that only appear in later rows are still rendered.

`formatTable` previously derived its columns from `Object.keys(rows[0])`, which meant heterogeneous rows could silently lose fields depending on row order. This affects commands such as `conversations list`, where DMs and groups expose different fields.

The fix derives the ordered union of keys across all rows and adds a regression test covering a DM row followed by a group row.

## Testing

- Reproduced the bug on `main`: the new regression test failed because `name` was omitted from the rendered table.
- After the fix: `test/utils/output.test.ts` passes (1/1).
- `corepack yarn workspace @xmtp/cli typecheck` passes.
- `git diff --check` passes.
- The full CLI test suite was also run locally, but many existing integration/environment-dependent tests failed in this local setup; the targeted regression test passes.

Fixes #1860.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `formatTable` to include columns present only in later rows
> Changes `formatTable` in [output.ts](https://github.com/xmtp/xmtp-js/pull/1861/files#diff-bd35a37055d858a436975519c9fb368ad4361e77c1851140269c0f295bcec403) to compute the column set from the union of all row keys instead of using only the first row. Width calculation and rendering now iterate over the full key set, so columns appearing in later rows are no longer dropped. Adds a test in [output.test.ts](https://github.com/xmtp/xmtp-js/pull/1861/files#diff-78a944a979a01852c9e1455bd5de5943dfa6349a883e3da61132037ee663850e) covering this case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f1f3d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->