### PR TITLE
fix(node-sdk): invoke onEnd callback when stream ends

### DIFF
--- a/.changeset/fix-node-sdk-stream-onend.md
+++ b/.changeset/fix-node-sdk-stream-onend.md
@@ -1,0 +1,5 @@
+﻿---
+"@xmtp/node-sdk": patch
+---
+
+Fixed `createStream` in `@xmtp/node-sdk` to properly destructure and invoke the `onEnd` callback when the stream is ended.

--- a/sdks/node-sdk/src/utils/streams.ts
+++ b/sdks/node-sdk/src/utils/streams.ts
@@ -90,6 +90,7 @@ export const createStream = async <T = unknown, V = T>(
   options?: StreamOptions<T, V>,
 ) => {
   const {
+    onEnd,
     onError,
     onFail,
     onRestart,
@@ -167,6 +168,7 @@ export const createStream = async <T = unknown, V = T>(
       // when the async stream is done, end the stream
       asyncStream.onDone = () => {
         streamCloser.end();
+        onEnd?.();
       };
       // stream restarted, call the onRestart callback
       onRestart?.();
@@ -198,6 +200,7 @@ export const createStream = async <T = unknown, V = T>(
     // when the async stream is done, end the stream
     asyncStream.onDone = () => {
       streamCloser.end();
+      onEnd?.();
     };
   } catch (error) {
     onError?.(error as Error);

--- a/sdks/node-sdk/test/streams.test.ts
+++ b/sdks/node-sdk/test/streams.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { StreamFailedError } from "@/utils/errors";
-import { createStream } from "@/utils/streams";
+import {
+  createStream,
+  type StreamCallback,
+  type StreamFunction,
+} from "@/utils/streams";
 
 describe("createStream", () => {
   it("should forward StreamFailedError to onError", async () => {
@@ -34,5 +38,101 @@ describe("createStream", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     expect(onErrorSpy).toHaveBeenCalledWith(expect.any(StreamFailedError));
+  });
+
+  it("should call onEnd and streamCloser.end when stream ends", async () => {
+    const onEndSpy = vi.fn();
+    const closerEndSpy = vi.fn();
+
+    const mockStreamFunction: StreamFunction<number> = vi.fn(
+      async (callback: StreamCallback<number>) => {
+        callback(null, 1);
+        return Promise.resolve({
+          end: closerEndSpy,
+          endAndWait: vi.fn().mockResolvedValue(undefined),
+          isClosed: vi.fn().mockReturnValue(false),
+          waitForReady: vi.fn().mockResolvedValue(undefined),
+        });
+      },
+    );
+
+    const stream = await createStream(mockStreamFunction, undefined, {
+      onEnd: onEndSpy,
+    });
+
+    await stream.end();
+
+    expect(closerEndSpy).toHaveBeenCalledTimes(1);
+    expect(onEndSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should emit values and invoke onValue callback", async () => {
+    const values: number[] = [];
+    const onValueSpy = vi.fn<(value: number) => void>();
+
+    const mockStreamFunction: StreamFunction<number> = vi.fn(
+      async (callback: StreamCallback<number>) => {
+        callback(null, 1);
+        callback(null, 2);
+        return Promise.resolve({
+          end: vi.fn(),
+          endAndWait: vi.fn().mockResolvedValue(undefined),
+          isClosed: vi.fn().mockReturnValue(false),
+          waitForReady: vi.fn().mockResolvedValue(undefined),
+        });
+      },
+    );
+
+    const stream = await createStream(mockStreamFunction, undefined, {
+      onValue: onValueSpy,
+    });
+
+    setTimeout(() => {
+      void stream.end();
+    }, 50);
+
+    for await (const value of stream) {
+      values.push(value);
+    }
+
+    expect(values).toEqual([1, 2]);
+    expect(onValueSpy).toHaveBeenCalledTimes(2);
+    expect(onValueSpy).toHaveBeenCalledWith(1);
+    expect(onValueSpy).toHaveBeenCalledWith(2);
+  });
+
+  it("should call onEnd and streamCloser.end after successful retry", async () => {
+    const onEndSpy = vi.fn();
+    const closerEndSpy = vi.fn();
+    let callCount = 0;
+
+    const mockStreamFunction: StreamFunction<number> = vi.fn(
+      async (callback: StreamCallback<number>) => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error("Initial failure");
+        }
+        callback(null, 42);
+        return Promise.resolve({
+          end: closerEndSpy,
+          endAndWait: vi.fn().mockResolvedValue(undefined),
+          isClosed: vi.fn().mockReturnValue(false),
+          waitForReady: vi.fn().mockResolvedValue(undefined),
+        });
+      },
+    );
+
+    const stream = await createStream(mockStreamFunction, undefined, {
+      onEnd: onEndSpy,
+      retryOnFail: true,
+      retryDelay: 10,
+      retryAttempts: 3,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await stream.end();
+
+    expect(closerEndSpy).toHaveBeenCalledTimes(1);
+    expect(onEndSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

In \@xmtp/node-sdk\, the \StreamOptions\ type includes an \onEnd?: () => void\ callback (matching \@xmtp/browser-sdk\). However, in \sdks/node-sdk/src/utils/streams.ts\, \onEnd\ was omitted from options destructuring and was never called in the \syncStream.onDone\ handlers (both on initial stream creation and during reconnection retries). Consequently, any caller supplying an \onEnd\ callback found that the callback was silently ignored.

## Solution

- Destructured \onEnd\ from \options\ in \createStream\.
- Added \onEnd?.()\ calls inside \syncStream.onDone\ in both the initial stream setup and the retry reconnect path.
- Added comprehensive unit tests in \sdks/node-sdk/test/streams.test.ts\ asserting that \onEnd\ is called on \stream.end()\ and after retry recovery.
- Added changeset file for \@xmtp/node-sdk\.

Closes #1862

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Invoke `onEnd` callback in `createStream` when stream ends
> Destructures `onEnd` from options and calls `onEnd?.()` inside both `asyncStream.onDone` handlers (initial and retry-restart paths) in [streams.ts](https://github.com/xmtp/xmtp-js/pull/1863/files#diff-db8795b836415e580ae1633ad924353f59cdb62e280b17e27bea583b15118188), immediately after `streamCloser.end()`. Adds tests covering `onEnd` on stream end, value emission, and `onEnd` after retry.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e82e802.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->