### PR TITLE
fix(remote-attachment): validate parsed HTTPS protocol

### DIFF
--- a/.changeset/tidy-mice-attach.md
+++ b/.changeset/tidy-mice-attach.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/content-type-remote-attachment": patch
+---
+
+Validate remote attachment URLs using their parsed HTTPS protocol.

--- a/content-types/content-type-remote-attachment/src/RemoteAttachment.ts
+++ b/content-types/content-type-remote-attachment/src/RemoteAttachment.ts
@@ -144,7 +144,14 @@ export class RemoteAttachmentCodec implements ContentCodec<
   }
 
   encode(content: RemoteAttachment) {
-    if (!content.url.startsWith("https")) {
+    let protocol: string;
+    try {
+      protocol = new URL(content.url).protocol;
+    } catch {
+      throw new Error("scheme must be https");
+    }
+
+    if (protocol !== "https:") {
       throw new Error("scheme must be https");
     }
 

--- a/content-types/content-type-remote-attachment/src/RemoteAttachmentUrl.test.ts
+++ b/content-types/content-type-remote-attachment/src/RemoteAttachmentUrl.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "vitest";
+import {
+  RemoteAttachmentCodec,
+  type RemoteAttachment,
+} from "./RemoteAttachment";
+
+const createRemoteAttachment = (url: string): RemoteAttachment => ({
+  url,
+  contentDigest: "00".repeat(32),
+  salt: new Uint8Array(32),
+  nonce: new Uint8Array(12),
+  secret: new Uint8Array(32),
+  scheme: "https",
+  contentLength: 0,
+  filename: "test.txt",
+});
+
+test.each([
+  "http://attachments.example/test.txt",
+  "httpsnot://attachments.example/test.txt",
+  "httpswhatever",
+  "https://",
+])("rejects a URL without a valid HTTPS protocol: %s", (url) => {
+  const codec = new RemoteAttachmentCodec();
+
+  expect(() => codec.encode(createRemoteAttachment(url))).toThrow(
+    "scheme must be https",
+  );
+});
+
+test.each([
+  "https://attachments.example/test.txt",
+  "HTTPS://attachments.example/test.txt",
+])("accepts a valid HTTPS URL: %s", (url) => {
+  const codec = new RemoteAttachmentCodec();
+
+  expect(() => codec.encode(createRemoteAttachment(url))).not.toThrow();
+});


### PR DESCRIPTION
Closes #1865

## Summary

- parse remote attachment URLs before checking their protocol
- require the normalized protocol to be exactly `https:`
- preserve the existing `scheme must be https` error
- add offline coverage for valid, case-insensitive, non-HTTPS, custom-scheme, and malformed URLs

## Why

The previous `startsWith("https")` check treated a string prefix as a URL scheme. It accepted values such as `httpsnot://...` and `httpswhatever`, while rejecting the valid case-insensitive form `HTTPS://...`.

This change only affects encode-time URL validation. Attachment loading, encryption, decryption, and digest verification are unchanged.

## Testing

- `yarn workspace @xmtp/content-type-remote-attachment test src/RemoteAttachmentUrl.test.ts` (6 tests)
- `yarn workspace @xmtp/content-type-remote-attachment typecheck`
- `yarn workspace @xmtp/content-type-remote-attachment build`
- ESLint on the changed TypeScript files
- Prettier check on all changed files
- `git diff --check`

The full remote-attachment integration suite was not run locally because it requires the repository's Docker-backed XMTP test environment and Docker is not installed on this machine. The new regression file is intentionally network-independent.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate parsed HTTPS protocol in `RemoteAttachmentCodec.encode`
> Replaces the `startsWith("https")` prefix check on `content.url` with `new URL()` parsing and an exact `https:` protocol match. The codec now rejects strings that merely start with `https` but are not valid HTTPS URLs (e.g. `httpsnot://`, `httpswhatever`, or `https://` with no host), while accepting valid HTTPS URLs regardless of scheme case. Risk: `encode` now throws `scheme must be https` for any URL that fails to parse or whose protocol is not exactly `https:`; callers passing previously accepted malformed strings will see errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02c2635.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->