### PR TITLE
test(content-type-text): add edge case unit tests for emojis, empty, and long strings

### DIFF
--- a/content-types/content-type-text/src/Text.test.ts
+++ b/content-types/content-type-text/src/Text.test.ts
@@ -43,4 +43,28 @@ describe("ContentTypeText", () => {
     };
     expect(() => codec.decode(ec)).toThrow("unrecognized encoding UTF-16");
   });
+
+  it("should correctly handle emojis and complex unicode characters", () => {
+    const codec = new TextCodec();
+    const complexText = "Hello XMTP! 🚀 Web3 Messaging 🔒- مرحبا - 👾";
+    const encoded = codec.encode(complexText);
+    const decoded = codec.decode(encoded);
+    expect(decoded).toBe(complexText);
+  });
+
+  it("should handle empty strings correctly", () => {
+    const codec = new TextCodec();
+    const emptyText = "";
+    const encoded = codec.encode(emptyText);
+    const decoded = codec.decode(encoded);
+    expect(decoded).toBe("");
+  });
+
+  it("should correctly encode and decode very long strings", () => {
+    const codec = new TextCodec();
+    const longText = "a".repeat(100000);
+    const encoded = codec.encode(longText);
+    const decoded = codec.decode(encoded);
+    expect(decoded).toBe(longText);
+  });
 });


### PR DESCRIPTION
## Description
This PR adds comprehensive edge-case unit tests for `ContentTypeText` codec in `@xmtp/content-type-text`.

## Changes Made
Added test cases covering:
- Complex Unicode characters and Emojis
- Empty string encoding/decoding
- Large payloads (100k+ character strings)

## Testing
- Ran `yarn test` inside `content-types/content-type-text`
- All 7 tests passed cleanly (duration ~250ms)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add edge case tests for `ContentTypeText` encode/decode
> Adds round-trip unit tests in [Text.test.ts](https://github.com/xmtp/xmtp-js/pull/1867/files#diff-5e061d2df2e22c581741bf9e243a9608d2a8c78e89a93b473f95f4186dbbc8bd) covering emojis and mixed-language Unicode, empty strings, and a 100,000-character long string. All tests assert that the decoded output matches the original input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e01f3b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->