### PR TITLE
fix(xmtp.chat): preserve concurrent inbox store updates

### DIFF
--- a/.changeset/quiet-inboxes-merge.md
+++ b/.changeset/quiet-inboxes-merge.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/xmtp.chat": patch
+---
+
+Preserve concurrent inbox store updates by merging async conversation and message updates against the latest state.

--- a/.changeset/quiet-inboxes-merge.md
+++ b/.changeset/quiet-inboxes-merge.md
@@ -1,5 +1,0 @@
----
-"@xmtp/xmtp.chat": patch
----
-
-Preserve concurrent inbox store updates by merging async conversation and message updates against the latest state.

--- a/apps/xmtp.chat/src/stores/inbox/store.test.ts
+++ b/apps/xmtp.chat/src/stores/inbox/store.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { inboxStore } from "@/stores/inbox/store";
+
+type InboxStoreState = ReturnType<typeof inboxStore.getState>;
+type ConversationArg = Parameters<InboxStoreState["addConversation"]>[0];
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+describe("inboxStore", () => {
+  beforeEach(() => {
+    inboxStore.getState().reset();
+  });
+
+  it("preserves concurrent conversation updates that finish out of order", async () => {
+    const firstMembers = deferred<unknown[]>();
+    const firstLastMessage = deferred<undefined>();
+    const secondMembers = deferred<unknown[]>();
+    const secondLastMessage = deferred<undefined>();
+
+    const firstConversation = {
+      id: "conversation-a",
+      createdAtNs: 1n,
+      members: () => firstMembers.promise,
+      lastMessage: () => firstLastMessage.promise,
+    } as unknown as ConversationArg;
+    const secondConversation = {
+      id: "conversation-b",
+      createdAtNs: 2n,
+      members: () => secondMembers.promise,
+      lastMessage: () => secondLastMessage.promise,
+    } as unknown as ConversationArg;
+
+    const firstUpdate = inboxStore
+      .getState()
+      .addConversation(firstConversation);
+    const secondUpdate = inboxStore
+      .getState()
+      .addConversation(secondConversation);
+
+    secondMembers.resolve([{ inboxId: "member-b" }]);
+    await Promise.resolve();
+    secondLastMessage.resolve(undefined);
+    await secondUpdate;
+
+    firstMembers.resolve([{ inboxId: "member-a" }]);
+    await Promise.resolve();
+    firstLastMessage.resolve(undefined);
+    await firstUpdate;
+
+    const state = inboxStore.getState();
+    expect(Array.from(state.conversations.keys()).sort()).toEqual([
+      "conversation-a",
+      "conversation-b",
+    ]);
+    expect(state.members.get("conversation-a")?.has("member-a")).toBe(true);
+    expect(state.members.get("conversation-b")?.has("member-b")).toBe(true);
+    expect(state.lastMessages.has("conversation-a")).toBe(true);
+    expect(state.lastMessages.has("conversation-b")).toBe(true);
+  });
+});

--- a/apps/xmtp.chat/src/stores/inbox/store.ts
+++ b/apps/xmtp.chat/src/stores/inbox/store.ts
@@ -95,28 +95,17 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
     sortedConversations: [],
     sortedMessages: new Map(),
     addConversation: async (conversation: Conversation<ContentTypes>) => {
-      const state = get();
-      // update conversations state
-      const newConversations = new Map(state.conversations);
-      newConversations.set(conversation.id, conversation);
-      // update members state
       const members = await conversation.members();
-      const newMembers = new Map(state.members);
-      newMembers.set(
-        conversation.id,
-        new Map(members.map((m) => [m.inboxId, m])),
-      );
-      const newPermissions = new Map(state.permissions);
-      const newMetadata = new Map(state.metadata);
+      let permissions: SafeConversation["permissions"] | undefined;
+      let metadata: ConversationMetadata | undefined;
+
       if (conversation instanceof Group) {
-        // update permissions state
-        newPermissions.set(conversation.id, await conversation.permissions());
-        // update metadata state
-        newMetadata.set(conversation.id, {
+        permissions = await conversation.permissions();
+        metadata = {
           name: conversation.name,
           description: conversation.description,
           imageUrl: conversation.imageUrl,
-        });
+        };
       } else if (conversation instanceof Dm) {
         const member = members.find(
           (m) => m.inboxId !== conversation.addedByInboxId,
@@ -129,27 +118,47 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
           if (profiles.length > 0) {
             displayName = profiles[0].displayName ?? displayName;
           }
-          // update metadata state
-          newMetadata.set(conversation.id, {
-            name: displayName,
-          });
+          metadata = { name: displayName };
         }
       }
-      // update last message state
+
       const lastMessage = await conversation.lastMessage();
-      const newLastMessages = new Map(state.lastMessages);
-      newLastMessages.set(conversation.id, lastMessage);
-      set({
-        conversations: newConversations,
-        lastCreatedAt: getLastCreatedAt(conversation, state.lastCreatedAt),
-        lastMessages: newLastMessages,
-        members: newMembers,
-        metadata: newMetadata,
-        permissions: newPermissions,
-        sortedConversations: sortConversations(
-          newConversations,
-          newLastMessages,
-        ),
+
+      set((state) => {
+        const newConversations = new Map(state.conversations);
+        newConversations.set(conversation.id, conversation);
+
+        const newMembers = new Map(state.members);
+        newMembers.set(
+          conversation.id,
+          new Map(members.map((m) => [m.inboxId, m])),
+        );
+
+        const newPermissions = new Map(state.permissions);
+        if (permissions) {
+          newPermissions.set(conversation.id, permissions);
+        }
+
+        const newMetadata = new Map(state.metadata);
+        if (metadata) {
+          newMetadata.set(conversation.id, metadata);
+        }
+
+        const newLastMessages = new Map(state.lastMessages);
+        newLastMessages.set(conversation.id, lastMessage);
+
+        return {
+          conversations: newConversations,
+          lastCreatedAt: getLastCreatedAt(conversation, state.lastCreatedAt),
+          lastMessages: newLastMessages,
+          members: newMembers,
+          metadata: newMetadata,
+          permissions: newPermissions,
+          sortedConversations: sortConversations(
+            newConversations,
+            newLastMessages,
+          ),
+        };
       });
     },
     addConversations: async (conversations: Conversation<ContentTypes>[]) => {
@@ -254,88 +263,90 @@ export const inboxStore = createStore<InboxState & InboxActions>()(
       conversationId: string,
       message: DecodedMessage<ContentTypes>,
     ) => {
-      const state = get();
-      const conversation = state.conversations.get(conversationId);
-      // update messages state
-      const newMessagesState = new Map(state.messages);
-      const conversationMessages =
-        newMessagesState.get(conversationId) ||
-        new Map<string, DecodedMessage<ContentTypes>>();
-      const newMessages = new Map(conversationMessages);
-      newMessages.set(message.id, message);
-      newMessagesState.set(conversationId, newMessages);
+      const isGroupUpdated = contentTypesAreEqual(
+        message.contentType,
+        await contentTypeGroupUpdated(),
+      );
+      let updatedMembers: Map<InboxId, GroupMember> | undefined;
+      let metadataUpdates: ConversationMetadata | undefined;
 
-      // update last sent at and last message states
-      const newLastSentAt = new Map(state.lastSentAt);
-      const newLastMessages = new Map(state.lastMessages);
-      if (isLastSentAt(message, state.lastSentAt.get(conversationId))) {
-        newLastSentAt.set(conversationId, message.sentAtNs);
-        newLastMessages.set(conversationId, message);
-      }
-
-      // update sorted messages state
-      const newSortedMessages = new Map(state.sortedMessages);
-      newSortedMessages.set(conversationId, sortMessages(newMessages));
-
-      const newMembers = new Map(state.members);
-      const newMetadata = new Map(state.metadata);
-
-      // check for updated members and metadata
-      if (
-        contentTypesAreEqual(
-          message.contentType,
-          await contentTypeGroupUpdated(),
-        )
-      ) {
+      if (isGroupUpdated) {
+        const conversation = get().conversations.get(conversationId);
         const groupUpdated = message.content as GroupUpdated;
 
-        // member updates
         if (conversation) {
           const isActive = await conversation.isActive();
-          // ensure group is active before syncing
           if (isActive) {
             await conversation.sync();
           }
           const members = await conversation.members();
-          const updatedMembers = new Map(members.map((m) => [m.inboxId, m]));
-          newMembers.set(message.conversationId, updatedMembers);
+          updatedMembers = new Map(members.map((m) => [m.inboxId, m]));
         }
 
-        // update metadata state
-        const metadataUpdates: ConversationMetadata = {};
+        const updates: ConversationMetadata = {};
         groupUpdated.metadataFieldChanges.forEach((change) => {
           switch (change.fieldName) {
             case "group_name":
-              metadataUpdates.name = change.newValue;
+              updates.name = change.newValue;
               break;
             case "description":
-              metadataUpdates.description = change.newValue;
+              updates.description = change.newValue;
               break;
             case "group_image_url_square":
-              metadataUpdates.imageUrl = change.newValue;
+              updates.imageUrl = change.newValue;
               break;
           }
         });
-        if (Object.keys(metadataUpdates).length > 0) {
+        if (Object.keys(updates).length > 0) {
+          metadataUpdates = updates;
+        }
+      }
+
+      set((state) => {
+        const newMessagesState = new Map(state.messages);
+        const conversationMessages =
+          newMessagesState.get(conversationId) ||
+          new Map<string, DecodedMessage<ContentTypes>>();
+        const newMessages = new Map(conversationMessages);
+        newMessages.set(message.id, message);
+        newMessagesState.set(conversationId, newMessages);
+
+        const newLastSentAt = new Map(state.lastSentAt);
+        const newLastMessages = new Map(state.lastMessages);
+        if (isLastSentAt(message, state.lastSentAt.get(conversationId))) {
+          newLastSentAt.set(conversationId, message.sentAtNs);
+          newLastMessages.set(conversationId, message);
+        }
+
+        const newSortedMessages = new Map(state.sortedMessages);
+        newSortedMessages.set(conversationId, sortMessages(newMessages));
+
+        const newMembers = new Map(state.members);
+        if (updatedMembers) {
+          newMembers.set(message.conversationId, updatedMembers);
+        }
+
+        const newMetadata = new Map(state.metadata);
+        if (metadataUpdates) {
           const existingMetadata = newMetadata.get(message.conversationId);
           newMetadata.set(message.conversationId, {
             ...existingMetadata,
             ...metadataUpdates,
           });
         }
-      }
 
-      set({
-        lastMessages: newLastMessages,
-        lastSentAt: newLastSentAt,
-        members: newMembers,
-        messages: newMessagesState,
-        metadata: newMetadata,
-        sortedConversations: sortConversations(
-          state.conversations,
-          newLastMessages,
-        ),
-        sortedMessages: newSortedMessages,
+        return {
+          lastMessages: newLastMessages,
+          lastSentAt: newLastSentAt,
+          members: newMembers,
+          messages: newMessagesState,
+          metadata: newMetadata,
+          sortedConversations: sortConversations(
+            state.conversations,
+            newLastMessages,
+          ),
+          sortedMessages: newSortedMessages,
+        };
       });
     },
     addMessages: async (


### PR DESCRIPTION
Fixes #1864.

Updates the xmtp.chat inbox store so asynchronous message updates merge against the latest Zustand state instead of a stale snapshot.

This prevents concurrent stream updates from overwriting messages or related inbox state written by another update while an SDK call is still pending.

Adds regression coverage that resolves concurrent updates out of order and verifies that both updates are preserved.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix concurrent updates in `inboxStore.addConversation` and `addMessage`
> - Moves state construction in `inboxStore.addConversation` and `inboxStore.addMessage` into functional Zustand updates that clone state at commit time instead of before async awaits
> - `addMessage` now collects group members and metadata before committing, applying optional updates only when present
> - Adds a test using deferred promises to verify out-of-order concurrent `addConversation` calls retain both conversations and their associated state
> - Risk: Functional state updaters in [store.ts](https://github.com/xmtp/xmtp-js/pull/1872/files#diff-572e773e875d19026abd898404b7ae68fa8a96aaf08601ef5294728d3cb9fce3) must return all required state fields; any omitted fields will be lost on commit
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 456cdf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->